### PR TITLE
feat(cli): add doctor integrations for first-class host status

### DIFF
--- a/docs/en/docs/how-to/install-and-run.md
+++ b/docs/en/docs/how-to/install-and-run.md
@@ -25,6 +25,14 @@ powercontext setup dsh --source oceanbase/powercontext --ref <ref>
 powercontext setup pi --source oceanbase/powercontext --ref <ref>
 ```
 
+Per-host commands remain the explicit path. To install more than one first-class host in one run, pass `--host`
+repeatedly, or omit `--host` on a TTY to choose from the catalog. `powercontext setup` with no subcommand still
+prints help:
+
+```bash
+powercontext setup select --host codex --host dsh --source oceanbase/powercontext --ref <ref>
+```
+
 For host-specific options, see [Configure Codex](configure-codex.md) and
 [Configure DeepSeek Harness](configure-dsh.md).
 

--- a/docs/en/docs/how-to/install-and-run.md
+++ b/docs/en/docs/how-to/install-and-run.md
@@ -25,13 +25,18 @@ powercontext setup dsh --source oceanbase/powercontext --ref <ref>
 powercontext setup pi --source oceanbase/powercontext --ref <ref>
 ```
 
-Per-host commands remain the explicit path. To install more than one first-class host in one run, pass `--host`
-repeatedly, or omit `--host` on a TTY to choose from the catalog. `powercontext setup` with no subcommand still
-prints help:
+Per-host commands remain the explicit path. The first-class catalog contains `codex`, `claude-code`, `dsh`,
+`openclaw`, `opencode`, `pi`, and `hermes`. To install more than one in one run, pass `--host` repeatedly, or omit
+`--host` on a TTY to choose from the catalog. `powercontext setup` with no subcommand still prints help:
 
 ```bash
 powercontext setup select --host codex --host dsh --source oceanbase/powercontext --ref <ref>
 ```
+
+Without `--server-url`, Claude Code and OpenClaw keep their `http://127.0.0.1:8000` defaults. An explicit
+`--server-url` overrides both selected hosts. OpenClaw's `--scope-mode` defaults to `agent`. Selected Codex, DSH,
+OpenCode, Pi, and Hermes integrations pass their existing post-install diagnostics before they are reported as
+installed. After installing Hermes, run `hermes memory setup` and select PowerContext before starting Hermes.
 
 For host-specific options, see [Configure Codex](configure-codex.md) and
 [Configure DeepSeek Harness](configure-dsh.md).

--- a/docs/en/docs/how-to/install-and-run.md
+++ b/docs/en/docs/how-to/install-and-run.md
@@ -61,6 +61,7 @@ disable the Dashboard explicitly.
 
 ```bash
 powercontext doctor
+powercontext doctor integrations
 powercontext doctor codex
 powercontext doctor dsh
 powercontext doctor pi
@@ -71,6 +72,7 @@ powercontext capabilities
 `doctor` checks the installed package, Server liveness, and Server readiness without requiring an integration. Server
 readiness covers the database and each configured inference provider. Runtime or database failures return
 `not_ready`; an inference failure returns `degraded` without removing database-backed operations from traffic.
+`doctor integrations` is an optional read-only overview of every first-class host; a missing CLI does not fail that command.
 `doctor codex`, `doctor dsh`, and `doctor pi` separately check their optional host CLI and PowerContext integration. The content commands exercise the
 public HTTP SDK path. `ready` and `capabilities` show the readiness and enabled capabilities of the running service. For complete status definitions and
 recovery steps, see [Troubleshoot](troubleshoot.md).

--- a/docs/en/docs/how-to/install-and-run.md
+++ b/docs/en/docs/how-to/install-and-run.md
@@ -99,9 +99,14 @@ powercontext capabilities
 
 ```bash
 powercontext doctor
+powercontext doctor integrations
 powercontext doctor codex
+powercontext doctor claude-code
 powercontext doctor dsh
+powercontext doctor openclaw
+powercontext doctor opencode
 powercontext doctor pi
+powercontext doctor hermes
 powercontext ready
 powercontext capabilities
 ```
@@ -109,9 +114,11 @@ powercontext capabilities
 `doctor` checks the installed package, Server liveness, and Server readiness without requiring an integration. Server
 readiness covers the database and each configured inference provider. Runtime or database failures return
 `not_ready`; an inference failure returns `degraded` without removing database-backed operations from traffic.
-`doctor codex`, `doctor dsh`, and `doctor pi` separately check their optional host CLI and PowerContext integration. The content commands exercise the
-public HTTP SDK path. `ready` and `capabilities` show the readiness and enabled capabilities of the running service. For complete status definitions and
-recovery steps, see [Troubleshoot](troubleshoot.md).
+`doctor integrations` is an optional read-only overview of every first-class host; a missing CLI does not fail that
+command. The individual `doctor <host>` commands check one optional host CLI and all of its PowerContext integration
+items. The content commands exercise the public HTTP SDK path. `ready` and `capabilities` show the readiness and
+enabled capabilities of the running service. For complete status definitions and recovery steps, see
+[Troubleshoot](troubleshoot.md).
 
 ## Update or replace an installation
 

--- a/docs/en/docs/how-to/troubleshoot.md
+++ b/docs/en/docs/how-to/troubleshoot.md
@@ -48,7 +48,9 @@ command -v pi
 
 Add the uv tool bin directory to `PATH` if needed. `powercontext setup codex`, `powercontext setup claude-code`,
 `powercontext setup dsh`, and `powercontext setup pi` report an error rather than attempting installation when the host
-CLI is unavailable.
+CLI is unavailable. `powercontext setup select` installs only the hosts you choose. A selected host that is missing
+still fails that row and does not block the other selected hosts. An unselected host is skipped even if its CLI is on
+`PATH`.
 
 ## The plugin is missing or stale
 

--- a/docs/en/docs/how-to/troubleshoot.md
+++ b/docs/en/docs/how-to/troubleshoot.md
@@ -16,11 +16,16 @@ The command checks the package, Server liveness, and Server readiness. It exits 
 the top-level result and every check include `ok` and `status`. Check optional host integrations separately:
 
 ```bash
+powercontext doctor integrations
 powercontext doctor codex
 powercontext doctor claude-code
 powercontext doctor dsh
 powercontext doctor pi
 ```
+
+`doctor integrations` prints every first-class host. A host whose CLI is not on PATH is `missing` and does not fail
+the command. A present host that is broken still exits 1. Single-host commands such as `doctor codex` stay fail-closed
+when that CLI is missing.
 
 ## Installation cannot read the Git URL
 

--- a/docs/en/docs/how-to/troubleshoot.md
+++ b/docs/en/docs/how-to/troubleshoot.md
@@ -16,11 +16,19 @@ The command checks the package, Server liveness, and Server readiness. It exits 
 the top-level result and every check include `ok` and `status`. Check optional host integrations separately:
 
 ```bash
+powercontext doctor integrations
 powercontext doctor codex
 powercontext doctor claude-code
 powercontext doctor dsh
+powercontext doctor openclaw
+powercontext doctor opencode
 powercontext doctor pi
+powercontext doctor hermes
 ```
+
+`doctor integrations` prints every first-class host. A host whose CLI is not on PATH is `missing` and does not fail
+the command. A present host that is broken still exits 1. Single-host commands such as `doctor codex` stay fail-closed
+when that CLI is missing.
 
 ## Installation cannot read the Git URL
 

--- a/docs/en/docs/how-to/troubleshoot.md
+++ b/docs/en/docs/how-to/troubleshoot.md
@@ -33,7 +33,7 @@ git ls-remote https://github.com/oceanbase/powercontext.git HEAD
 If this fails, configure the credential helper or SSH key used by Git, then rerun `uv tool install`. `uv` uses Git's
 credential configuration; PowerContext does not accept or store repository credentials.
 
-## `powercontext`, `codex`, `claude`, `dsh`, or `pi` is not found
+## A PowerContext or host CLI is not found
 
 Run:
 
@@ -43,14 +43,17 @@ command -v powercontext
 command -v codex
 command -v claude
 command -v dsh
+command -v openclaw
+command -v opencode
 command -v pi
+command -v hermes
 ```
 
 Add the uv tool bin directory to `PATH` if needed. `powercontext setup codex`, `powercontext setup claude-code`,
-`powercontext setup dsh`, and `powercontext setup pi` report an error rather than attempting installation when the host
-CLI is unavailable. `powercontext setup select` installs only the hosts you choose. A selected host that is missing
-still fails that row and does not block the other selected hosts. An unselected host is skipped even if its CLI is on
-`PATH`.
+`powercontext setup dsh`, `powercontext setup openclaw`, `powercontext setup opencode`, `powercontext setup pi`, and
+`powercontext setup hermes` report an error rather than attempting installation when the host CLI is unavailable.
+`powercontext setup select` installs only the hosts you choose. A selected host that is missing still fails that row
+and does not block the other selected hosts. An unselected host is skipped even if its CLI is on `PATH`.
 
 ## The plugin is missing or stale
 

--- a/docs/en/docs/reference/interfaces.md
+++ b/docs/en/docs/reference/interfaces.md
@@ -83,6 +83,7 @@ boundary flushing fail open; explicit durable writes require interactive confirm
 powercontext setup codex
 powercontext setup dsh
 powercontext setup pi
+powercontext setup select
 powercontext doctor
 powercontext doctor codex
 powercontext doctor dsh

--- a/docs/en/docs/reference/interfaces.md
+++ b/docs/en/docs/reference/interfaces.md
@@ -126,9 +126,11 @@ powercontext setup pi
 powercontext setup hermes
 powercontext setup select
 powercontext doctor
+powercontext doctor integrations
 powercontext doctor codex
 powercontext doctor claude-code
 powercontext doctor dsh
+powercontext doctor openclaw
 powercontext doctor opencode
 powercontext doctor pi
 powercontext doctor hermes
@@ -151,10 +153,11 @@ powercontext external-skill import --scope-id project:example --fingerprint SHA2
 All content commands call the configured Server. The optional `server` role adds `powercontext server run`; it does
 not create a second content profile inside the CLI.
 
-`powercontext doctor` checks the package and Server without requiring an integration. `powercontext doctor codex`
-checks the Codex CLI and PowerContext plugin explicitly. `powercontext doctor dsh` checks the DeepSeek Harness CLI
-and that dump-config lists the plugin id `powercontext-dsh`. `powercontext doctor pi` checks the Pi executable and
-that Pi lists the PowerContext package.
+`powercontext doctor` checks the package and Server without requiring an integration. `powercontext doctor integrations`
+prints a read-only matrix for every first-class host; a missing CLI is `missing` and does not fail the command.
+Each `powercontext doctor <host>` command still fails when that host CLI is missing. The matrix preserves every
+host-specific integration check, including OpenCode's separate `plugin` and `skill` results. DSH checks that
+`dump-config` lists `powercontext-dsh`; Pi checks that the CLI lists the PowerContext package.
 
 The `candidate` command group exposes the human Review Inbox. See [Review Candidates](../how-to/review-candidates.md)
 for the ordered workflow to list, inspect, revise, approve, or reject Candidates.

--- a/docs/en/docs/reference/interfaces.md
+++ b/docs/en/docs/reference/interfaces.md
@@ -85,6 +85,7 @@ powercontext setup dsh
 powercontext setup pi
 powercontext setup select
 powercontext doctor
+powercontext doctor integrations
 powercontext doctor codex
 powercontext doctor dsh
 powercontext doctor pi
@@ -116,10 +117,11 @@ powercontext external-skill import --scope-id project:example --fingerprint SHA2
 All content commands call the configured Server. The optional `server` role adds `powercontext server run`; it does
 not create a second content profile inside the CLI.
 
-`powercontext doctor` checks the package and Server without requiring an integration. `powercontext doctor codex`
-checks the Codex CLI and PowerContext plugin explicitly. `powercontext doctor dsh` checks the DeepSeek Harness CLI
-and that dump-config lists the plugin id `powercontext-dsh`. `powercontext doctor pi` checks the Pi executable and
-that Pi lists the PowerContext package.
+`powercontext doctor` checks the package and Server without requiring an integration. `powercontext doctor integrations`
+prints a read-only matrix for every first-class host; a missing CLI is `missing` and does not fail the command.
+`powercontext doctor codex` checks the Codex CLI and PowerContext plugin explicitly and still fails when that CLI is
+missing. `powercontext doctor dsh` checks the DeepSeek Harness CLI and that dump-config lists the plugin id
+`powercontext-dsh`. `powercontext doctor pi` checks the Pi executable and that Pi lists the PowerContext package.
 
 Generation and revision commands accept repeatable `--source-ref TYPE/ID` and
 `--artifact-ref FAMILY/ID@REVISION` options instead of serialized request files. `--target FAMILY/ID@REVISION`

--- a/docs/en/docs/reference/interfaces.md
+++ b/docs/en/docs/reference/interfaces.md
@@ -118,13 +118,20 @@ boundary flushing fail open; explicit durable writes require interactive confirm
 
 ```text
 powercontext setup codex
+powercontext setup claude-code
 powercontext setup dsh
+powercontext setup openclaw
+powercontext setup opencode
 powercontext setup pi
+powercontext setup hermes
 powercontext setup select
 powercontext doctor
 powercontext doctor codex
+powercontext doctor claude-code
 powercontext doctor dsh
+powercontext doctor opencode
 powercontext doctor pi
+powercontext doctor hermes
 powercontext server run
 powercontext ready
 powercontext capabilities

--- a/docs/en/docs/reference/interfaces.md
+++ b/docs/en/docs/reference/interfaces.md
@@ -120,6 +120,7 @@ boundary flushing fail open; explicit durable writes require interactive confirm
 powercontext setup codex
 powercontext setup dsh
 powercontext setup pi
+powercontext setup select
 powercontext doctor
 powercontext doctor codex
 powercontext doctor dsh

--- a/docs/zh/docs/how-to/install-and-run.md
+++ b/docs/zh/docs/how-to/install-and-run.md
@@ -24,6 +24,13 @@ powercontext setup dsh --source oceanbase/powercontext --ref <ref>
 powercontext setup pi --source oceanbase/powercontext --ref <ref>
 ```
 
+单宿主命令仍是显式路径。若要一次安装多个一级宿主，可重复传入 `--host`；在 TTY 上省略 `--host` 则从目录中选择。
+不带子命令的 `powercontext setup` 仍然只打印帮助：
+
+```bash
+powercontext setup select --host codex --host dsh --source oceanbase/powercontext --ref <ref>
+```
+
 宿主专有选项见[配置 Codex](configure-codex.md)和[配置 DeepSeek Harness](configure-dsh.md)。
 
 ## 运行本地 Server

--- a/docs/zh/docs/how-to/install-and-run.md
+++ b/docs/zh/docs/how-to/install-and-run.md
@@ -95,17 +95,24 @@ powercontext capabilities
 
 ```bash
 powercontext doctor
+powercontext doctor integrations
 powercontext doctor codex
+powercontext doctor claude-code
 powercontext doctor dsh
+powercontext doctor openclaw
+powercontext doctor opencode
 powercontext doctor pi
+powercontext doctor hermes
 powercontext ready
 powercontext capabilities
 ```
 
 `doctor` 检查已安装的包、Server 存活状态和 Server 就绪状态，不要求安装集成。Server 就绪检查涵盖数据库和
 每个已配置的推理服务。Runtime 或数据库故障返回 `not_ready`；推理服务故障返回 `degraded`，不会使数据库
-操作退出流量。`doctor codex`、`doctor dsh` 和 `doctor pi` 分别检查对应的可选宿主 CLI 与 PowerContext 集成。内容命令会经过公开 HTTP SDK
-路径。`ready` 和 `capabilities` 用于查看运行中服务的就绪状态和已启用能力。完整的状态解释和恢复步骤见[排查问题](troubleshoot.md)。
+操作退出流量。`doctor integrations` 是可选的一级宿主只读总览，缺失 CLI 不会让该命令失败。
+各个 `doctor <host>` 命令分别检查一个可选宿主 CLI 及其全部 PowerContext 集成项。内容命令会经过公开 HTTP SDK
+路径。`ready` 和 `capabilities` 用于查看运行中服务的就绪状态和已启用能力。完整的状态解释和恢复步骤见
+[排查问题](troubleshoot.md)。
 
 ## 更新或替换安装
 

--- a/docs/zh/docs/how-to/install-and-run.md
+++ b/docs/zh/docs/how-to/install-and-run.md
@@ -57,6 +57,7 @@ powercontext server run
 
 ```bash
 powercontext doctor
+powercontext doctor integrations
 powercontext doctor codex
 powercontext doctor dsh
 powercontext doctor pi
@@ -66,7 +67,8 @@ powercontext capabilities
 
 `doctor` 检查已安装的包、Server 存活状态和 Server 就绪状态，不要求安装集成。Server 就绪检查涵盖数据库和
 每个已配置的推理服务。Runtime 或数据库故障返回 `not_ready`；推理服务故障返回 `degraded`，不会使数据库
-操作退出流量。`doctor codex`、`doctor dsh` 和 `doctor pi` 分别检查对应的可选宿主 CLI 与 PowerContext 集成。内容命令会经过公开 HTTP SDK
+操作退出流量。`doctor integrations` 是可选的一级宿主只读总览，缺失 CLI 不会让该命令失败。
+`doctor codex`、`doctor dsh` 和 `doctor pi` 分别检查对应的可选宿主 CLI 与 PowerContext 集成。内容命令会经过公开 HTTP SDK
 路径。`ready` 和 `capabilities` 用于查看运行中服务的就绪状态和已启用能力。完整的状态解释和恢复步骤见[排查问题](troubleshoot.md)。
 
 ## 更新或替换安装

--- a/docs/zh/docs/how-to/install-and-run.md
+++ b/docs/zh/docs/how-to/install-and-run.md
@@ -24,12 +24,18 @@ powercontext setup dsh --source oceanbase/powercontext --ref <ref>
 powercontext setup pi --source oceanbase/powercontext --ref <ref>
 ```
 
-单宿主命令仍是显式路径。若要一次安装多个一级宿主，可重复传入 `--host`；在 TTY 上省略 `--host` 则从目录中选择。
-不带子命令的 `powercontext setup` 仍然只打印帮助：
+单宿主命令仍是显式路径。一级宿主目录包含 `codex`、`claude-code`、`dsh`、`openclaw`、`opencode`、`pi`
+和 `hermes`。若要一次安装多个宿主，可重复传入 `--host`；在 TTY 上省略 `--host` 则从目录中选择。不带子命令的
+`powercontext setup` 仍然只打印帮助：
 
 ```bash
 powercontext setup select --host codex --host dsh --source oceanbase/powercontext --ref <ref>
 ```
+
+未传入 `--server-url` 时，Claude Code 和 OpenClaw 保留 `http://127.0.0.1:8000` 默认值；显式传入该选项时会覆盖
+两个被选中宿主的地址。OpenClaw 的 `--scope-mode` 默认值为 `agent`。Codex、DSH、OpenCode、Pi 和 Hermes 只有在
+通过现有安装后诊断后才会报告为 installed。安装 Hermes 后，还需运行 `hermes memory setup` 并选择 PowerContext，
+然后再启动 Hermes。
 
 宿主专有选项见[配置 Codex](configure-codex.md)和[配置 DeepSeek Harness](configure-dsh.md)。
 

--- a/docs/zh/docs/how-to/troubleshoot.md
+++ b/docs/zh/docs/how-to/troubleshoot.md
@@ -48,6 +48,8 @@ command -v pi
 
 必要时把 uv tool bin 目录加入 `PATH`。宿主 CLI 不可用时，`powercontext setup codex`、
 `powercontext setup claude-code`、`powercontext setup dsh` 和 `powercontext setup pi` 都会报告错误，而不会尝试安装。
+`powercontext setup select` 只安装你选中的宿主。某个选中宿主未安装时，该行失败，但不会阻塞其余选中项；未选中的
+宿主即使已在 `PATH` 上也不会安装。
 
 ## 插件缺失或版本不一致
 

--- a/docs/zh/docs/how-to/troubleshoot.md
+++ b/docs/zh/docs/how-to/troubleshoot.md
@@ -16,11 +16,15 @@ powercontext doctor
 `ok` 与 `status`。可单独检查可选的宿主集成：
 
 ```bash
+powercontext doctor integrations
 powercontext doctor codex
 powercontext doctor claude-code
 powercontext doctor dsh
 powercontext doctor pi
 ```
+
+`doctor integrations` 会打印全部一级宿主。CLI 不在 PATH 上时该行是 `missing`，不会让整条命令失败；已安装但异常的
+宿主仍会以状态码 1 退出。单宿主命令（如 `doctor codex`）在该 CLI 缺失时仍然失败。
 
 ## 安装时无法读取 Git 地址
 

--- a/docs/zh/docs/how-to/troubleshoot.md
+++ b/docs/zh/docs/how-to/troubleshoot.md
@@ -33,7 +33,7 @@ git ls-remote https://github.com/oceanbase/powercontext.git HEAD
 如果失败，请配置 Git 使用的 credential helper 或 SSH key，再重新运行 `uv tool install`。`uv` 使用 Git
 凭据配置；PowerContext 不接收或保存仓库凭据。
 
-## 找不到 `powercontext`、`codex`、`claude`、`dsh` 或 `pi`
+## 找不到 PowerContext 或宿主 CLI
 
 执行：
 
@@ -43,13 +43,17 @@ command -v powercontext
 command -v codex
 command -v claude
 command -v dsh
+command -v openclaw
+command -v opencode
 command -v pi
+command -v hermes
 ```
 
 必要时把 uv tool bin 目录加入 `PATH`。宿主 CLI 不可用时，`powercontext setup codex`、
-`powercontext setup claude-code`、`powercontext setup dsh` 和 `powercontext setup pi` 都会报告错误，而不会尝试安装。
-`powercontext setup select` 只安装你选中的宿主。某个选中宿主未安装时，该行失败，但不会阻塞其余选中项；未选中的
-宿主即使已在 `PATH` 上也不会安装。
+`powercontext setup claude-code`、`powercontext setup dsh`、`powercontext setup openclaw`、
+`powercontext setup opencode`、`powercontext setup pi` 和 `powercontext setup hermes` 都会报告错误，而不会尝试安装。
+`powercontext setup select` 只安装你选中的宿主。某个选中宿主未安装时，该行失败，但不会阻塞其余选中项；
+未选中的宿主即使已在 `PATH` 上也不会安装。
 
 ## 插件缺失或版本不一致
 

--- a/docs/zh/docs/how-to/troubleshoot.md
+++ b/docs/zh/docs/how-to/troubleshoot.md
@@ -16,11 +16,18 @@ powercontext doctor
 `ok` 与 `status`。可单独检查可选的宿主集成：
 
 ```bash
+powercontext doctor integrations
 powercontext doctor codex
 powercontext doctor claude-code
 powercontext doctor dsh
+powercontext doctor openclaw
+powercontext doctor opencode
 powercontext doctor pi
+powercontext doctor hermes
 ```
+
+`doctor integrations` 会打印全部一级宿主。CLI 不在 PATH 上时该行是 `missing`，不会让整条命令失败；已安装但异常的
+宿主仍会以状态码 1 退出。单宿主命令（如 `doctor codex`）在该 CLI 缺失时仍然失败。
 
 ## 安装时无法读取 Git 地址
 

--- a/docs/zh/docs/reference/interfaces.md
+++ b/docs/zh/docs/reference/interfaces.md
@@ -74,6 +74,7 @@ Pi transcript。召回、采集和边界 flush 都会正常降级；显式持久
 powercontext setup codex
 powercontext setup dsh
 powercontext setup pi
+powercontext setup select
 powercontext doctor
 powercontext doctor codex
 powercontext doctor dsh

--- a/docs/zh/docs/reference/interfaces.md
+++ b/docs/zh/docs/reference/interfaces.md
@@ -76,6 +76,7 @@ powercontext setup dsh
 powercontext setup pi
 powercontext setup select
 powercontext doctor
+powercontext doctor integrations
 powercontext doctor codex
 powercontext doctor dsh
 powercontext doctor pi
@@ -107,8 +108,9 @@ powercontext external-skill import --scope-id project:example --fingerprint SHA2
 所有内容命令都调用已配置的 Server。可选的 `server` role 会增加 `powercontext server run`，但不会在 CLI
 中创建第二套内容 profile。
 
-`powercontext doctor` 检查安装包和 Server，不要求任何集成；`powercontext doctor codex` 显式检查 Codex CLI
-和 PowerContext 插件；`powercontext doctor dsh` 检查 DeepSeek Harness CLI，以及 dump-config 是否列出插件 id
+`powercontext doctor` 检查安装包和 Server，不要求任何集成。`powercontext doctor integrations` 打印全部一级宿主的只读矩阵；
+CLI 不在 PATH 上时该行是 `missing`，不会让整条命令失败。`powercontext doctor codex` 显式检查 Codex CLI
+和 PowerContext 插件，该 CLI 缺失时仍失败。`powercontext doctor dsh` 检查 DeepSeek Harness CLI，以及 dump-config 是否列出插件 id
 `powercontext-dsh`；`powercontext doctor pi` 检查 Pi 可执行文件，以及 Pi 是否列出了 PowerContext package。
 
 Generation 和 revision 命令通过可重复的 `--source-ref TYPE/ID` 与

--- a/docs/zh/docs/reference/interfaces.md
+++ b/docs/zh/docs/reference/interfaces.md
@@ -106,6 +106,7 @@ Pi transcript。召回、采集和边界 flush 都会正常降级；显式持久
 powercontext setup codex
 powercontext setup dsh
 powercontext setup pi
+powercontext setup select
 powercontext doctor
 powercontext doctor codex
 powercontext doctor dsh

--- a/docs/zh/docs/reference/interfaces.md
+++ b/docs/zh/docs/reference/interfaces.md
@@ -104,13 +104,20 @@ Pi transcript。召回、采集和边界 flush 都会正常降级；显式持久
 
 ```text
 powercontext setup codex
+powercontext setup claude-code
 powercontext setup dsh
+powercontext setup openclaw
+powercontext setup opencode
 powercontext setup pi
+powercontext setup hermes
 powercontext setup select
 powercontext doctor
 powercontext doctor codex
+powercontext doctor claude-code
 powercontext doctor dsh
+powercontext doctor opencode
 powercontext doctor pi
+powercontext doctor hermes
 powercontext server run
 powercontext ready
 powercontext capabilities

--- a/docs/zh/docs/reference/interfaces.md
+++ b/docs/zh/docs/reference/interfaces.md
@@ -112,9 +112,11 @@ powercontext setup pi
 powercontext setup hermes
 powercontext setup select
 powercontext doctor
+powercontext doctor integrations
 powercontext doctor codex
 powercontext doctor claude-code
 powercontext doctor dsh
+powercontext doctor openclaw
 powercontext doctor opencode
 powercontext doctor pi
 powercontext doctor hermes
@@ -137,9 +139,10 @@ powercontext external-skill import --scope-id project:example --fingerprint SHA2
 所有内容命令都调用已配置的 Server。可选的 `server` role 会增加 `powercontext server run`，但不会在 CLI
 中创建第二套内容 profile。
 
-`powercontext doctor` 检查安装包和 Server，不要求任何集成；`powercontext doctor codex` 显式检查 Codex CLI
-和 PowerContext 插件；`powercontext doctor dsh` 检查 DeepSeek Harness CLI，以及 dump-config 是否列出插件 id
-`powercontext-dsh`；`powercontext doctor pi` 检查 Pi 可执行文件，以及 Pi 是否列出了 PowerContext package。
+`powercontext doctor` 检查安装包和 Server，不要求任何集成。`powercontext doctor integrations` 打印全部一级宿主的只读矩阵；
+CLI 不在 PATH 上时该行是 `missing`，不会让整条命令失败。各个 `powercontext doctor <host>` 命令在对应 CLI
+缺失时仍会失败。矩阵保留每个宿主专有的全部集成检查，包括 OpenCode 独立的 `plugin` 与 `skill` 结果。
+DSH 检查 `dump-config` 是否列出 `powercontext-dsh`；Pi 检查 CLI 是否列出 PowerContext package。
 
 `candidate` 命令组提供面向人工的 Review Inbox。列出、检查、修订、批准和拒绝的操作步骤见
 [审核 Candidate](../how-to/review-candidates.md)。

--- a/src/powercontext/cli/hosts.py
+++ b/src/powercontext/cli/hosts.py
@@ -1,0 +1,259 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""First-class host catalog and opt-in multi-host setup orchestration."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import typer
+
+
+@dataclass(frozen=True, slots=True)
+class HostSpec:
+    """One first-class setup target. PATH is not used to build this catalog."""
+
+    name: str
+    label: str
+
+
+FIRST_CLASS_HOSTS: tuple[HostSpec, ...] = (
+    HostSpec("codex", "Codex"),
+    HostSpec("claude-code", "Claude Code"),
+    HostSpec("dsh", "DeepSeek Harness"),
+    HostSpec("pi", "Pi"),
+    HostSpec("hermes", "Hermes"),
+)
+HOST_NAMES: tuple[str, ...] = tuple(host.name for host in FIRST_CLASS_HOSTS)
+_HOST_INDEX: dict[str, str] = {str(index): host.name for index, host in enumerate(FIRST_CLASS_HOSTS, start=1)}
+
+
+class SetupSelectError(RuntimeError):
+    """Invalid setup select usage or host selection."""
+
+    @classmethod
+    def json_requires_host(cls) -> SetupSelectError:
+        return cls("setup select --json requires --host.")
+
+    @classmethod
+    def tty_requires_host(cls) -> SetupSelectError:
+        return cls("setup select requires --host when stdin is not a TTY.")
+
+    @classmethod
+    def unknown_host(cls, token: str) -> SetupSelectError:
+        return cls(f"unknown host: {token}. Choose from: {', '.join(HOST_NAMES)}.")
+
+
+@dataclass(frozen=True, slots=True)
+class HostSetupRow:
+    """One catalog row in a setup select report."""
+
+    host: str
+    status: str
+    error: str | None = None
+
+    def as_json(self) -> dict[str, str]:
+        payload = {"host": self.host, "status": self.status}
+        if self.error is not None:
+            payload["error"] = self.error
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class SetupSelectReport:
+    """Per-host matrix for one setup select run."""
+
+    hosts: tuple[HostSetupRow, ...]
+
+    @property
+    def has_failure(self) -> bool:
+        return any(row.status == "failed" for row in self.hosts)
+
+    @property
+    def has_installed(self) -> bool:
+        return any(row.status == "installed" for row in self.hosts)
+
+
+def stdin_is_tty() -> bool:
+    """Return True when the current stdin can prompt for a host selection."""
+
+    return sys.stdin.isatty()
+
+
+def parse_host_selection(text: str) -> tuple[str, ...] | None:
+    """Parse a comma-separated catalog selection. Empty input cancels."""
+
+    stripped = text.strip()
+    if not stripped:
+        return None
+    selected: set[str] = set()
+    for token in (part.strip() for part in stripped.split(",")):
+        if not token:
+            continue
+        selected.add(_resolve_host_token(token))
+    return tuple(host.name for host in FIRST_CLASS_HOSTS if host.name in selected)
+
+
+def normalize_requested_hosts(hosts: Sequence[str]) -> tuple[str, ...]:
+    """Validate --host values, drop duplicates, and keep catalog order."""
+
+    selected = {_resolve_host_token(name) for name in hosts}
+    return tuple(host.name for host in FIRST_CLASS_HOSTS if host.name in selected)
+
+
+def run_setup_select(
+    *,
+    hosts: Sequence[str] | None,
+    source: str,
+    ref: str,
+    server_url: str,
+    capture_prompts: bool,
+    json_output: bool,
+) -> None:
+    """Resolve a selection, install those hosts, and print the matrix."""
+
+    try:
+        selected = resolve_selected_hosts(requested=hosts, json_output=json_output)
+    except SetupSelectError as error:
+        typer.echo(str(error), err=True)
+        raise typer.Exit(code=1) from error
+    if selected is None:
+        return
+    report = setup_selected_hosts(
+        selected=selected,
+        source=source,
+        ref=ref,
+        server_url=server_url,
+        capture_prompts=capture_prompts,
+    )
+    write_setup_select_report(report, json_output=json_output)
+    if report.has_failure:
+        raise typer.Exit(code=1)
+
+
+def resolve_selected_hosts(*, requested: Sequence[str] | None, json_output: bool) -> tuple[str, ...] | None:
+    """Return catalog names to install, or None when the user cancels."""
+
+    if requested:
+        return normalize_requested_hosts(requested)
+    if json_output:
+        raise SetupSelectError.json_requires_host()
+    if not stdin_is_tty():
+        raise SetupSelectError.tty_requires_host()
+    _write_host_catalog()
+    return parse_host_selection(sys.stdin.readline())
+
+
+def setup_selected_hosts(
+    *,
+    selected: Sequence[str],
+    source: str,
+    ref: str,
+    server_url: str,
+    capture_prompts: bool,
+) -> SetupSelectReport:
+    """Install selected hosts and isolate failures from sibling hosts."""
+
+    from powercontext.cli.system import SetupError
+
+    selected_names = set(selected)
+    rows: list[HostSetupRow] = []
+    for host in FIRST_CLASS_HOSTS:
+        if host.name not in selected_names:
+            rows.append(HostSetupRow(host=host.name, status="skipped"))
+            continue
+        try:
+            install_host(
+                host.name,
+                source=source,
+                ref=ref,
+                server_url=server_url,
+                capture_prompts=capture_prompts,
+            )
+        except SetupError as error:
+            rows.append(HostSetupRow(host=host.name, status="failed", error=str(error)))
+            continue
+        rows.append(HostSetupRow(host=host.name, status="installed"))
+    return SetupSelectReport(hosts=tuple(rows))
+
+
+def install_host(
+    name: str,
+    *,
+    source: str,
+    ref: str,
+    server_url: str,
+    capture_prompts: bool,
+) -> object:
+    """Call the existing installer for one first-class host."""
+
+    if name == "codex":
+        from powercontext.cli.system import install_codex_plugin
+
+        return install_codex_plugin(source=source, ref=ref)
+    if name == "claude-code":
+        from powercontext.cli.system import install_claude_code_plugin
+
+        return install_claude_code_plugin(
+            source=source,
+            ref=ref,
+            server_url=server_url,
+            capture_prompts=capture_prompts,
+        )
+    if name == "dsh":
+        from powercontext.cli.dsh import install_dsh_plugin
+
+        return install_dsh_plugin(source=source, ref=ref)
+    if name == "pi":
+        from powercontext.cli.pi import install_pi_plugin
+
+        return install_pi_plugin(source=source, ref=ref)
+    if name == "hermes":
+        from powercontext.cli.hermes import install_hermes_plugin
+
+        return install_hermes_plugin(source=source, ref=ref)
+    raise SetupSelectError.unknown_host(name)
+
+
+def write_setup_select_report(report: SetupSelectReport, *, json_output: bool) -> None:
+    """Write the per-host matrix as JSON or human text."""
+
+    if json_output:
+        typer.echo(json.dumps({"hosts": [row.as_json() for row in report.hosts]}, indent=2))
+        return
+    for row in report.hosts:
+        if row.status == "failed" and row.error is not None:
+            typer.echo(f"{row.host}: failed - {row.error}")
+            continue
+        typer.echo(f"{row.host}: {row.status}")
+    if report.has_installed:
+        typer.echo("Next: run `powercontext server run`, then start a new host session.")
+
+
+def _resolve_host_token(token: str) -> str:
+    name = _HOST_INDEX.get(token, token)
+    if name not in HOST_NAMES:
+        raise SetupSelectError.unknown_host(token)
+    return name
+
+
+def _write_host_catalog() -> None:
+    typer.echo("Official first-class integrations:")
+    for index, host in enumerate(FIRST_CLASS_HOSTS, start=1):
+        typer.echo(f"  {index}) {host.label} ({host.name})")
+    typer.echo("Select hosts by number or name (comma-separated), or press Enter to cancel:")

--- a/src/powercontext/cli/hosts.py
+++ b/src/powercontext/cli/hosts.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""First-class host catalog and opt-in multi-host setup orchestration."""
+"""First-class host catalog, opt-in multi-host setup, and read-only integration diagnostics."""
 
 from __future__ import annotations
 
@@ -20,8 +20,12 @@ import json
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import typer
+
+if TYPE_CHECKING:
+    from powercontext.cli.system import Diagnostic
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,6 +45,8 @@ FIRST_CLASS_HOSTS: tuple[HostSpec, ...] = (
 )
 HOST_NAMES: tuple[str, ...] = tuple(host.name for host in FIRST_CLASS_HOSTS)
 _HOST_INDEX: dict[str, str] = {str(index): host.name for index, host in enumerate(FIRST_CLASS_HOSTS, start=1)}
+_INTEGRATION_KEYS = frozenset({"plugin", "package"})
+_PATH_MISSING = "is not installed or is not on PATH"
 
 
 class SetupSelectError(RuntimeError):
@@ -87,6 +93,55 @@ class SetupSelectReport:
     @property
     def has_installed(self) -> bool:
         return any(row.status == "installed" for row in self.hosts)
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrationRow:
+    """One first-class host in a doctor integrations report."""
+
+    host: str
+    presence: str
+    cli_key: str
+    cli: Diagnostic
+    integration_key: str
+    integration: Diagnostic
+
+    @property
+    def failed(self) -> bool:
+        return self.presence == "present" and not (self.cli.ok and self.integration.ok)
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "presence": self.presence,
+            self.cli_key: self.cli.as_json(),
+            self.integration_key: self.integration.as_json(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrationReport:
+    """Read-only matrix of first-class host CLI and integration status."""
+
+    hosts: tuple[IntegrationRow, ...]
+
+    @property
+    def has_present_failure(self) -> bool:
+        return any(row.failed for row in self.hosts)
+
+    @property
+    def ok(self) -> bool:
+        return not self.has_present_failure
+
+    @property
+    def status(self) -> str:
+        return "failed" if self.has_present_failure else "ok"
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "status": self.status,
+            "hosts": {row.host: row.as_json() for row in self.hosts},
+        }
 
 
 def stdin_is_tty() -> bool:
@@ -257,3 +312,94 @@ def _write_host_catalog() -> None:
     for index, host in enumerate(FIRST_CLASS_HOSTS, start=1):
         typer.echo(f"  {index}) {host.label} ({host.name})")
     typer.echo("Select hosts by number or name (comma-separated), or press Enter to cancel:")
+
+
+def diagnose_host(name: str) -> dict[str, Diagnostic]:
+    """Lazily collect diagnostics for one first-class host."""
+
+    if name == "codex":
+        from powercontext.cli.system import run_codex_diagnostics
+
+        return run_codex_diagnostics()
+    if name == "claude-code":
+        from powercontext.cli.system import run_claude_code_diagnostics
+
+        return run_claude_code_diagnostics()
+    if name == "dsh":
+        from powercontext.cli.dsh import run_dsh_diagnostics
+
+        return run_dsh_diagnostics()
+    if name == "pi":
+        from powercontext.cli.pi import run_pi_diagnostics
+
+        return run_pi_diagnostics()
+    if name == "hermes":
+        from powercontext.cli.hermes import run_hermes_diagnostics
+
+        return run_hermes_diagnostics()
+    raise SetupSelectError.unknown_host(name)
+
+
+def split_host_diagnostics(
+    diagnostics: dict[str, Diagnostic],
+) -> tuple[str, Diagnostic, str, Diagnostic]:
+    """Split one host probe into the CLI check and the plugin/package check."""
+
+    integration_key = next(key for key in diagnostics if key in _INTEGRATION_KEYS)
+    cli_key = next(key for key in diagnostics if key not in _INTEGRATION_KEYS)
+    return cli_key, diagnostics[cli_key], integration_key, diagnostics[integration_key]
+
+
+def classify_host_presence(cli: Diagnostic, integration: Diagnostic) -> str:
+    """Mark a host missing only when PATH lookup failed and the integration was skipped."""
+
+    if _PATH_MISSING in cli.detail and integration.status.value == "skipped":
+        return "missing"
+    return "present"
+
+
+def build_integration_row(name: str, diagnostics: dict[str, Diagnostic]) -> IntegrationRow:
+    """Classify one host diagnostic pair without deciding the command exit code."""
+
+    cli_key, cli, integration_key, integration = split_host_diagnostics(diagnostics)
+    return IntegrationRow(
+        host=name,
+        presence=classify_host_presence(cli, integration),
+        cli_key=cli_key,
+        cli=cli,
+        integration_key=integration_key,
+        integration=integration,
+    )
+
+
+def collect_integration_diagnostics() -> IntegrationReport:
+    """Walk the shared catalog and collect a row for every first-class host."""
+
+    return IntegrationReport(
+        hosts=tuple(build_integration_row(host.name, diagnose_host(host.name)) for host in FIRST_CLASS_HOSTS)
+    )
+
+
+def format_integration_row(row: IntegrationRow) -> str:
+    return (
+        f"{row.host}: {row.presence} - cli={row.cli.status.value} {row.integration_key}={row.integration.status.value}"
+    )
+
+
+def write_integration_report(report: IntegrationReport, *, json_output: bool) -> None:
+    """Write the host matrix as JSON or one human line per host."""
+
+    if json_output:
+        typer.echo(json.dumps(report.as_json(), indent=2))
+        return
+    for row in report.hosts:
+        typer.echo(format_integration_row(row))
+
+
+def run_doctor_integrations(*, json_output: bool) -> None:
+    """Print the first-class host matrix and fail only when a present host is broken."""
+
+    report = collect_integration_diagnostics()
+    write_integration_report(report, json_output=json_output)
+    if report.has_present_failure:
+        raise typer.Exit(code=1)

--- a/src/powercontext/cli/hosts.py
+++ b/src/powercontext/cli/hosts.py
@@ -36,6 +36,8 @@ FIRST_CLASS_HOSTS: tuple[HostSpec, ...] = (
     HostSpec("codex", "Codex"),
     HostSpec("claude-code", "Claude Code"),
     HostSpec("dsh", "DeepSeek Harness"),
+    HostSpec("openclaw", "OpenClaw"),
+    HostSpec("opencode", "OpenCode"),
     HostSpec("pi", "Pi"),
     HostSpec("hermes", "Hermes"),
 )
@@ -88,6 +90,11 @@ class SetupSelectReport:
     def has_installed(self) -> bool:
         return any(row.status == "installed" for row in self.hosts)
 
+    def is_installed(self, host: str) -> bool:
+        """Return whether one host completed installation and verification."""
+
+        return any(row.host == host and row.status == "installed" for row in self.hosts)
+
 
 def stdin_is_tty() -> bool:
     """Return True when the current stdin can prompt for a host selection."""
@@ -121,7 +128,8 @@ def run_setup_select(
     hosts: Sequence[str] | None,
     source: str,
     ref: str,
-    server_url: str,
+    server_url: str | None,
+    scope_mode: str,
     capture_prompts: bool,
     json_output: bool,
 ) -> None:
@@ -139,6 +147,7 @@ def run_setup_select(
         source=source,
         ref=ref,
         server_url=server_url,
+        scope_mode=scope_mode,
         capture_prompts=capture_prompts,
     )
     write_setup_select_report(report, json_output=json_output)
@@ -164,7 +173,8 @@ def setup_selected_hosts(
     selected: Sequence[str],
     source: str,
     ref: str,
-    server_url: str,
+    server_url: str | None,
+    scope_mode: str,
     capture_prompts: bool,
 ) -> SetupSelectReport:
     """Install selected hosts and isolate failures from sibling hosts."""
@@ -183,8 +193,10 @@ def setup_selected_hosts(
                 source=source,
                 ref=ref,
                 server_url=server_url,
+                scope_mode=scope_mode,
                 capture_prompts=capture_prompts,
             )
+            verify_host(host.name)
         except SetupError as error:
             rows.append(HostSetupRow(host=host.name, status="failed", error=str(error)))
             continue
@@ -197,7 +209,8 @@ def install_host(
     *,
     source: str,
     ref: str,
-    server_url: str,
+    server_url: str | None,
+    scope_mode: str,
     capture_prompts: bool,
 ) -> object:
     """Call the existing installer for one first-class host."""
@@ -207,18 +220,32 @@ def install_host(
 
         return install_codex_plugin(source=source, ref=ref)
     if name == "claude-code":
-        from powercontext.cli.system import install_claude_code_plugin
+        from powercontext.cli.system import DEFAULT_CLAUDE_CODE_SERVER_URL, install_claude_code_plugin
 
         return install_claude_code_plugin(
             source=source,
             ref=ref,
-            server_url=server_url,
+            server_url=server_url if server_url is not None else DEFAULT_CLAUDE_CODE_SERVER_URL,
             capture_prompts=capture_prompts,
         )
     if name == "dsh":
         from powercontext.cli.dsh import install_dsh_plugin
 
         return install_dsh_plugin(source=source, ref=ref)
+    if name == "openclaw":
+        from powercontext.cli.openclaw import install_openclaw_plugin
+        from powercontext.cli.system import DEFAULT_OPENCLAW_SERVER_URL
+
+        return install_openclaw_plugin(
+            source=source,
+            ref=ref,
+            server_url=server_url if server_url is not None else DEFAULT_OPENCLAW_SERVER_URL,
+            scope_mode=scope_mode,
+        )
+    if name == "opencode":
+        from powercontext.cli.opencode import install_opencode_plugin
+
+        return install_opencode_plugin(source=source, ref=ref)
     if name == "pi":
         from powercontext.cli.pi import install_pi_plugin
 
@@ -228,6 +255,41 @@ def install_host(
 
         return install_hermes_plugin(source=source, ref=ref)
     raise SetupSelectError.unknown_host(name)
+
+
+def verify_host(name: str) -> None:
+    """Run the post-install diagnostics used by the matching single-host setup command."""
+
+    from powercontext.cli.system import SetupError
+
+    if name == "codex":
+        from powercontext.cli.system import run_codex_diagnostics
+
+        diagnostics = run_codex_diagnostics()
+    elif name == "dsh":
+        from powercontext.cli.dsh import run_dsh_diagnostics
+
+        diagnostics = run_dsh_diagnostics()
+    elif name == "pi":
+        from powercontext.cli.pi import run_pi_diagnostics
+
+        diagnostics = run_pi_diagnostics()
+    elif name == "hermes":
+        from powercontext.cli.hermes import run_hermes_diagnostics
+
+        diagnostics = run_hermes_diagnostics()
+    elif name == "opencode":
+        from powercontext.cli.opencode import run_opencode_diagnostics
+
+        diagnostics = run_opencode_diagnostics()
+    elif name in {"claude-code", "openclaw"}:
+        return
+    else:
+        raise SetupSelectError.unknown_host(name)
+
+    failures = [f"{check}: {diagnostic.detail}" for check, diagnostic in diagnostics.items() if not diagnostic.ok]
+    if failures:
+        raise SetupError.post_install_verification(failures)
 
 
 def write_setup_select_report(report: SetupSelectReport, *, json_output: bool) -> None:
@@ -243,6 +305,8 @@ def write_setup_select_report(report: SetupSelectReport, *, json_output: bool) -
         typer.echo(f"{row.host}: {row.status}")
     if report.has_installed:
         typer.echo("Next: run `powercontext server run`, then start a new host session.")
+    if report.is_installed("hermes"):
+        typer.echo("Hermes: run `hermes memory setup` and select PowerContext before starting Hermes.")
 
 
 def _resolve_host_token(token: str) -> str:

--- a/src/powercontext/cli/hosts.py
+++ b/src/powercontext/cli/hosts.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""First-class host catalog and opt-in multi-host setup orchestration."""
+"""First-class host catalog, opt-in multi-host setup, and read-only integration diagnostics."""
 
 from __future__ import annotations
 
@@ -20,8 +20,12 @@ import json
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import typer
+
+if TYPE_CHECKING:
+    from powercontext.cli.system import Diagnostic
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,6 +47,8 @@ FIRST_CLASS_HOSTS: tuple[HostSpec, ...] = (
 )
 HOST_NAMES: tuple[str, ...] = tuple(host.name for host in FIRST_CLASS_HOSTS)
 _HOST_INDEX: dict[str, str] = {str(index): host.name for index, host in enumerate(FIRST_CLASS_HOSTS, start=1)}
+_INTEGRATION_KEYS = frozenset({"plugin", "package", "skill"})
+_PATH_MISSING = "is not installed or is not on PATH"
 
 
 class SetupSelectError(RuntimeError):
@@ -94,6 +100,57 @@ class SetupSelectReport:
         """Return whether one host completed installation and verification."""
 
         return any(row.host == host and row.status == "installed" for row in self.hosts)
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrationRow:
+    """One first-class host in a doctor integrations report."""
+
+    host: str
+    presence: str
+    cli_key: str
+    cli: Diagnostic
+    integrations: tuple[tuple[str, Diagnostic], ...]
+
+    @property
+    def failed(self) -> bool:
+        return self.presence == "present" and not (
+            self.cli.ok and all(diagnostic.ok for _, diagnostic in self.integrations)
+        )
+
+    def as_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "presence": self.presence,
+            self.cli_key: self.cli.as_json(),
+        }
+        payload.update({key: diagnostic.as_json() for key, diagnostic in self.integrations})
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrationReport:
+    """Read-only matrix of first-class host CLI and integration status."""
+
+    hosts: tuple[IntegrationRow, ...]
+
+    @property
+    def has_present_failure(self) -> bool:
+        return any(row.failed for row in self.hosts)
+
+    @property
+    def ok(self) -> bool:
+        return not self.has_present_failure
+
+    @property
+    def status(self) -> str:
+        return "failed" if self.has_present_failure else "ok"
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "status": self.status,
+            "hosts": {row.host: row.as_json() for row in self.hosts},
+        }
 
 
 def stdin_is_tty() -> bool:
@@ -321,3 +378,100 @@ def _write_host_catalog() -> None:
     for index, host in enumerate(FIRST_CLASS_HOSTS, start=1):
         typer.echo(f"  {index}) {host.label} ({host.name})")
     typer.echo("Select hosts by number or name (comma-separated), or press Enter to cancel:")
+
+
+def diagnose_host(name: str) -> dict[str, Diagnostic]:
+    """Lazily collect diagnostics for one first-class host."""
+
+    if name == "codex":
+        from powercontext.cli.system import run_codex_diagnostics
+
+        return run_codex_diagnostics()
+    if name == "claude-code":
+        from powercontext.cli.system import run_claude_code_diagnostics
+
+        return run_claude_code_diagnostics()
+    if name == "dsh":
+        from powercontext.cli.dsh import run_dsh_diagnostics
+
+        return run_dsh_diagnostics()
+    if name == "openclaw":
+        from powercontext.cli.openclaw import run_openclaw_diagnostics
+
+        return run_openclaw_diagnostics()
+    if name == "opencode":
+        from powercontext.cli.opencode import run_opencode_diagnostics
+
+        return run_opencode_diagnostics()
+    if name == "pi":
+        from powercontext.cli.pi import run_pi_diagnostics
+
+        return run_pi_diagnostics()
+    if name == "hermes":
+        from powercontext.cli.hermes import run_hermes_diagnostics
+
+        return run_hermes_diagnostics()
+    raise SetupSelectError.unknown_host(name)
+
+
+def split_host_diagnostics(
+    diagnostics: dict[str, Diagnostic],
+) -> tuple[str, Diagnostic, tuple[tuple[str, Diagnostic], ...]]:
+    """Split one host probe into its CLI check and integration checks."""
+
+    cli_key = next(key for key in diagnostics if key not in _INTEGRATION_KEYS)
+    integrations = tuple((key, diagnostic) for key, diagnostic in diagnostics.items() if key in _INTEGRATION_KEYS)
+    return cli_key, diagnostics[cli_key], integrations
+
+
+def classify_host_presence(cli: Diagnostic, integrations: tuple[tuple[str, Diagnostic], ...]) -> str:
+    """Mark a host missing only when PATH lookup failed and the integration was skipped."""
+
+    if _PATH_MISSING in cli.detail and all(diagnostic.status.value == "skipped" for _, diagnostic in integrations):
+        return "missing"
+    return "present"
+
+
+def build_integration_row(name: str, diagnostics: dict[str, Diagnostic]) -> IntegrationRow:
+    """Classify one host diagnostic pair without deciding the command exit code."""
+
+    cli_key, cli, integrations = split_host_diagnostics(diagnostics)
+    return IntegrationRow(
+        host=name,
+        presence=classify_host_presence(cli, integrations),
+        cli_key=cli_key,
+        cli=cli,
+        integrations=integrations,
+    )
+
+
+def collect_integration_diagnostics() -> IntegrationReport:
+    """Walk the shared catalog and collect a row for every first-class host."""
+
+    return IntegrationReport(
+        hosts=tuple(build_integration_row(host.name, diagnose_host(host.name)) for host in FIRST_CLASS_HOSTS)
+    )
+
+
+def format_integration_row(row: IntegrationRow) -> str:
+    integrations = " ".join(f"{key}={diagnostic.status.value}" for key, diagnostic in row.integrations)
+    return f"{row.host}: {row.presence} - cli={row.cli.status.value} {integrations}"
+
+
+def write_integration_report(report: IntegrationReport, *, json_output: bool) -> None:
+    """Write the host matrix as JSON or one human line per host."""
+
+    if json_output:
+        typer.echo(json.dumps(report.as_json(), indent=2))
+        return
+    for row in report.hosts:
+        typer.echo(format_integration_row(row))
+
+
+def run_doctor_integrations(*, json_output: bool) -> None:
+    """Print the first-class host matrix and fail only when a present host is broken."""
+
+    report = collect_integration_diagnostics()
+    write_integration_report(report, json_output=json_output)
+    if report.has_present_failure:
+        raise typer.Exit(code=1)

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -449,6 +449,47 @@ def setup_hermes(
     typer.echo("Next: run `hermes memory setup`, select PowerContext, then start Hermes.")
 
 
+@setup_app.command("select")
+def setup_select(
+    host: Annotated[
+        list[str] | None,
+        typer.Option(help="First-class host to install. Repeatable. Required with --json or a non-TTY."),
+    ] = None,
+    source: Annotated[
+        str,
+        typer.Option(help="Git source or local path passed to each selected installer."),
+    ] = DEFAULT_MARKETPLACE_SOURCE,
+    ref: Annotated[
+        str,
+        typer.Option(help="Git ref used for a remote source."),
+    ] = DEFAULT_MARKETPLACE_REF,
+    server_url: Annotated[
+        str,
+        typer.Option(help="PowerContext Server base URL configured for Claude Code."),
+    ] = "http://127.0.0.1:8000",
+    capture_prompts: Annotated[
+        bool,
+        typer.Option(help="Capture Claude Code user prompts as ordinary Source evidence."),
+    ] = True,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Write the result as JSON."),
+    ] = False,
+) -> None:
+    """Install selected first-class host plugins without scanning PATH."""
+
+    from powercontext.cli.hosts import run_setup_select
+
+    run_setup_select(
+        hosts=host,
+        source=source,
+        ref=ref,
+        server_url=server_url,
+        capture_prompts=capture_prompts,
+        json_output=json_output,
+    )
+
+
 @doctor_app.callback()
 def doctor(
     context: typer.Context,

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -40,6 +40,9 @@ from powercontext.paths import powercontext_data_dir
 HELP_OPTION_NAMES = ("-h", "--help")
 DEFAULT_MARKETPLACE_SOURCE = "oceanbase/powercontext"
 DEFAULT_MARKETPLACE_REF = "master"
+DEFAULT_CLAUDE_CODE_SERVER_URL = "http://127.0.0.1:8000"
+DEFAULT_OPENCLAW_SERVER_URL = "http://127.0.0.1:8000"
+DEFAULT_OPENCLAW_SCOPE_MODE = "agent"
 PLUGIN_NAME = "powercontext"
 CLAUDE_MARKETPLACE_NAME = "powercontext"
 _GITHUB_REPOSITORY = re.compile(r"^[^/\s]+/[^/\s]+$")
@@ -281,6 +284,10 @@ class SetupError(RuntimeError):
         return cls(f"Integration CLI did not return {name}")
 
     @classmethod
+    def post_install_verification(cls, failures: list[str]) -> SetupError:
+        return cls(f"post-install verification failed: {'; '.join(failures)}")
+
+    @classmethod
     def claude_plugin_not_enabled(cls) -> SetupError:
         return cls("Claude Code did not report an enabled PowerContext plugin after installation.")
 
@@ -428,7 +435,7 @@ def setup_claude_code(
     server_url: Annotated[
         str,
         typer.Option(help="PowerContext Server base URL configured for the plugin."),
-    ] = "http://127.0.0.1:8000",
+    ] = DEFAULT_CLAUDE_CODE_SERVER_URL,
     capture_prompts: Annotated[
         bool,
         typer.Option(help="Capture Claude Code user prompts as ordinary Source evidence."),
@@ -514,11 +521,11 @@ def setup_openclaw(
     server_url: Annotated[
         str,
         typer.Option(help="PowerContext Server base URL configured for the plugin."),
-    ] = "http://127.0.0.1:8000",
+    ] = DEFAULT_OPENCLAW_SERVER_URL,
     scope_mode: Annotated[
         str,
         typer.Option("--scope-mode", help="Memory scope mode: agent or project."),
-    ] = "agent",
+    ] = DEFAULT_OPENCLAW_SCOPE_MODE,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -685,9 +692,13 @@ def setup_select(
         typer.Option(help="Git ref used for a remote source."),
     ] = DEFAULT_MARKETPLACE_REF,
     server_url: Annotated[
+        str | None,
+        typer.Option(help="PowerContext Server base URL override for Claude Code and OpenClaw."),
+    ] = None,
+    scope_mode: Annotated[
         str,
-        typer.Option(help="PowerContext Server base URL configured for Claude Code."),
-    ] = "http://127.0.0.1:8000",
+        typer.Option("--scope-mode", help="OpenClaw memory scope mode: agent or project."),
+    ] = DEFAULT_OPENCLAW_SCOPE_MODE,
     capture_prompts: Annotated[
         bool,
         typer.Option(help="Capture Claude Code user prompts as ordinary Source evidence."),
@@ -706,6 +717,7 @@ def setup_select(
         source=source,
         ref=ref,
         server_url=server_url,
+        scope_mode=scope_mode,
         capture_prompts=capture_prompts,
         json_output=json_output,
     )

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -919,6 +919,20 @@ def doctor_openclaw(
         raise typer.Exit(code=1)
 
 
+@doctor_app.command("integrations")
+def doctor_integrations(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Write the result as JSON."),
+    ] = False,
+) -> None:
+    """Report first-class host CLI and integration status without failing on missing CLIs."""
+
+    from powercontext.cli.hosts import run_doctor_integrations
+
+    run_doctor_integrations(json_output=json_output)
+
+
 def install_codex_plugin(*, source: str, ref: str) -> CodexSetupResult:
     """Install the plugin from one local or Git marketplace source."""
 

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -594,6 +594,20 @@ def doctor_hermes(
         raise typer.Exit(code=1)
 
 
+@doctor_app.command("integrations")
+def doctor_integrations(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Write the result as JSON."),
+    ] = False,
+) -> None:
+    """Report first-class host CLI and integration status without failing on missing CLIs."""
+
+    from powercontext.cli.hosts import run_doctor_integrations
+
+    run_doctor_integrations(json_output=json_output)
+
+
 def install_codex_plugin(*, source: str, ref: str) -> CodexSetupResult:
     """Install the plugin from one local or Git marketplace source."""
 

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -670,6 +670,47 @@ def setup_hermes(
     typer.echo("Next: run `hermes memory setup`, select PowerContext, then start Hermes.")
 
 
+@setup_app.command("select")
+def setup_select(
+    host: Annotated[
+        list[str] | None,
+        typer.Option(help="First-class host to install. Repeatable. Required with --json or a non-TTY."),
+    ] = None,
+    source: Annotated[
+        str,
+        typer.Option(help="Git source or local path passed to each selected installer."),
+    ] = DEFAULT_MARKETPLACE_SOURCE,
+    ref: Annotated[
+        str,
+        typer.Option(help="Git ref used for a remote source."),
+    ] = DEFAULT_MARKETPLACE_REF,
+    server_url: Annotated[
+        str,
+        typer.Option(help="PowerContext Server base URL configured for Claude Code."),
+    ] = "http://127.0.0.1:8000",
+    capture_prompts: Annotated[
+        bool,
+        typer.Option(help="Capture Claude Code user prompts as ordinary Source evidence."),
+    ] = True,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Write the result as JSON."),
+    ] = False,
+) -> None:
+    """Install selected first-class host plugins without scanning PATH."""
+
+    from powercontext.cli.hosts import run_setup_select
+
+    run_setup_select(
+        hosts=host,
+        source=source,
+        ref=ref,
+        server_url=server_url,
+        capture_prompts=capture_prompts,
+        json_output=json_output,
+    )
+
+
 @setup_app.command("workbuddy")
 def setup_workbuddy(
     source: Annotated[

--- a/tests/test_doctor_integrations.py
+++ b/tests/test_doctor_integrations.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock
+
+from typer.testing import CliRunner
+
+import powercontext.cli.dsh as dsh_cli
+import powercontext.cli.hermes as hermes_cli
+import powercontext.cli.openclaw as openclaw_cli
+import powercontext.cli.opencode as opencode_cli
+import powercontext.cli.pi as pi_cli
+import powercontext.cli.system as system_cli
+from powercontext.cli.app import create_cli
+from powercontext.cli.system import Diagnostic, DiagnosticStatus, doctor_app
+
+FIRST_CLASS_HOSTS = ("codex", "claude-code", "dsh", "openclaw", "opencode", "pi", "hermes")
+CLI_KEYS = {
+    "codex": "codex",
+    "claude-code": "claude_code",
+    "dsh": "dsh",
+    "openclaw": "openclaw",
+    "opencode": "opencode",
+    "pi": "pi",
+    "hermes": "hermes",
+}
+INTEGRATION_KEYS = {
+    "codex": ("plugin",),
+    "claude-code": ("plugin",),
+    "dsh": ("plugin",),
+    "openclaw": ("plugin",),
+    "opencode": ("plugin", "skill"),
+    "pi": ("package",),
+    "hermes": ("plugin",),
+}
+PATH_MISSING = {
+    "codex": "Codex CLI is not installed or is not on PATH",
+    "claude-code": "Claude Code CLI is not installed or is not on PATH",
+    "dsh": "DeepSeek Harness CLI is not installed or is not on PATH",
+    "openclaw": "OpenClaw CLI is not installed or is not on PATH",
+    "opencode": "OpenCode CLI is not installed or is not on PATH",
+    "pi": "Pi CLI is not installed or is not on PATH",
+    "hermes": "Hermes CLI is not installed or is not on PATH",
+}
+
+
+def _cli():
+    return create_cli([doctor_app])
+
+
+def _invoke(arguments: list[str]):
+    return CliRunner().invoke(_cli(), arguments)
+
+
+def _missing(host: str) -> dict[str, Diagnostic]:
+    diagnostics = {
+        CLI_KEYS[host]: Diagnostic(status=DiagnosticStatus.FAILED, detail=PATH_MISSING[host]),
+    }
+    diagnostics.update({
+        key: Diagnostic(
+            status=DiagnosticStatus.SKIPPED,
+            detail="not checked because the host CLI is unavailable",
+        )
+        for key in INTEGRATION_KEYS[host]
+    })
+    return diagnostics
+
+
+def _ok_codex() -> dict[str, Diagnostic]:
+    return {
+        "codex": Diagnostic(status=DiagnosticStatus.OK, detail="/usr/bin/codex"),
+        "plugin": Diagnostic(status=DiagnosticStatus.OK, detail="powercontext@powercontext enabled=True"),
+    }
+
+
+def _failed_plugin_codex() -> dict[str, Diagnostic]:
+    return {
+        "codex": Diagnostic(status=DiagnosticStatus.OK, detail="/usr/bin/codex"),
+        "plugin": Diagnostic(status=DiagnosticStatus.FAILED, detail="PowerContext plugin is not installed"),
+    }
+
+
+def _list_failed_codex() -> dict[str, Diagnostic]:
+    return {
+        "codex": Diagnostic(status=DiagnosticStatus.FAILED, detail="codex plugin list failed: timeout"),
+        "plugin": Diagnostic(status=DiagnosticStatus.SKIPPED, detail="plugin list is unavailable"),
+    }
+
+
+def _failed_skill_opencode() -> dict[str, Diagnostic]:
+    return {
+        "opencode": Diagnostic(status=DiagnosticStatus.OK, detail="/usr/bin/opencode (1.18.21)"),
+        "plugin": Diagnostic(status=DiagnosticStatus.OK, detail="powercontext is configured and active"),
+        "skill": Diagnostic(status=DiagnosticStatus.FAILED, detail="PowerContext OpenCode Skill is not installed"),
+    }
+
+
+def _patch_diagnostics(monkeypatch, **replacements: Mock) -> dict[str, Mock]:
+    probes = {host: Mock(name=f"run_{host}_diagnostics", return_value=_missing(host)) for host in FIRST_CLASS_HOSTS}
+    probes.update(replacements)
+    monkeypatch.setattr(system_cli, "run_codex_diagnostics", probes["codex"])
+    monkeypatch.setattr(system_cli, "run_claude_code_diagnostics", probes["claude-code"])
+    monkeypatch.setattr(dsh_cli, "run_dsh_diagnostics", probes["dsh"])
+    monkeypatch.setattr(openclaw_cli, "run_openclaw_diagnostics", probes["openclaw"])
+    monkeypatch.setattr(opencode_cli, "run_opencode_diagnostics", probes["opencode"])
+    monkeypatch.setattr(pi_cli, "run_pi_diagnostics", probes["pi"])
+    monkeypatch.setattr(hermes_cli, "run_hermes_diagnostics", probes["hermes"])
+    return probes
+
+
+def test_doctor_integrations_json_includes_every_first_class_host(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch)
+
+    result = _invoke(["doctor", "integrations", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert list(payload["hosts"]) == list(FIRST_CLASS_HOSTS)
+    for host in FIRST_CLASS_HOSTS:
+        assert payload["hosts"][host]["presence"] == "missing"
+        assert CLI_KEYS[host] in payload["hosts"][host]
+        for integration_key in INTEGRATION_KEYS[host]:
+            assert integration_key in payload["hosts"][host]
+
+
+def test_doctor_integrations_treats_missing_clis_as_success(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch, codex=Mock(return_value=_ok_codex()))
+
+    result = _invoke(["doctor", "integrations", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["status"] == "ok"
+    assert payload["hosts"]["codex"]["presence"] == "present"
+    assert payload["hosts"]["codex"]["plugin"]["ok"] is True
+    assert payload["hosts"]["pi"]["presence"] == "missing"
+    assert payload["hosts"]["pi"]["package"]["status"] == "skipped"
+
+
+def test_doctor_integrations_prints_a_human_matrix(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch, codex=Mock(return_value=_ok_codex()))
+
+    result = _invoke(["doctor", "integrations"])
+
+    assert result.exit_code == 0
+    assert "codex: present - cli=ok plugin=ok" in result.output
+    assert "claude-code: missing - cli=failed plugin=skipped" in result.output
+    assert "opencode: missing - cli=failed plugin=skipped skill=skipped" in result.output
+    assert "pi: missing - cli=failed package=skipped" in result.output
+
+
+def test_doctor_integrations_fails_when_a_present_plugin_is_broken(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch, codex=Mock(return_value=_failed_plugin_codex()))
+
+    result = _invoke(["doctor", "integrations", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    assert payload["status"] == "failed"
+    assert payload["hosts"]["codex"]["presence"] == "present"
+    assert payload["hosts"]["codex"]["plugin"]["status"] == "failed"
+    assert payload["hosts"]["dsh"]["presence"] == "missing"
+
+
+def test_doctor_integrations_fails_when_a_present_cli_cannot_list_plugins(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch, codex=Mock(return_value=_list_failed_codex()))
+
+    result = _invoke(["doctor", "integrations", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["hosts"]["codex"]["presence"] == "present"
+    assert payload["hosts"]["codex"]["codex"]["status"] == "failed"
+    assert payload["hosts"]["codex"]["plugin"]["status"] == "skipped"
+    assert "is not installed or is not on PATH" not in payload["hosts"]["codex"]["codex"]["detail"]
+
+
+def test_doctor_integrations_fails_when_a_present_opencode_skill_is_broken(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch, opencode=Mock(return_value=_failed_skill_opencode()))
+
+    result = _invoke(["doctor", "integrations", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["hosts"]["opencode"]["presence"] == "present"
+    assert payload["hosts"]["opencode"]["plugin"]["status"] == "ok"
+    assert payload["hosts"]["opencode"]["skill"]["status"] == "failed"
+
+
+def test_doctor_integrations_succeeds_when_every_host_is_missing(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch)
+
+    result = _invoke(["doctor", "integrations"])
+
+    assert result.exit_code == 0
+    assert "codex: missing - cli=failed plugin=skipped" in result.output
+    assert "hermes: missing - cli=failed plugin=skipped" in result.output
+
+
+def test_default_doctor_does_not_scan_first_class_hosts(monkeypatch) -> None:
+    probes = _patch_diagnostics(
+        monkeypatch,
+        **{
+            host: Mock(side_effect=AssertionError(f"default doctor must not inspect {host}"))
+            for host in FIRST_CLASS_HOSTS
+        },
+    )
+    monkeypatch.setattr(
+        system_cli,
+        "run_diagnostics",
+        lambda **_kwargs: {
+            "package": Diagnostic(status=DiagnosticStatus.OK, detail="powercontext 0.0.1"),
+            "server_liveness": Diagnostic(status=DiagnosticStatus.OK, detail="http://127.0.0.1:8000 status=ok"),
+            "server_readiness": Diagnostic(status=DiagnosticStatus.OK, detail="http://127.0.0.1:8000 status=ready"),
+        },
+    )
+
+    result = _invoke(["doctor", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert list(payload["checks"]) == ["package", "server_liveness", "server_readiness"]
+    for probe in probes.values():
+        probe.assert_not_called()
+
+
+def test_doctor_codex_still_fails_when_the_cli_is_missing(monkeypatch) -> None:
+    monkeypatch.setattr(system_cli, "which", lambda _name: None)
+
+    result = _invoke(["doctor", "codex"])
+
+    assert result.exit_code == 1
+    assert "Codex CLI is not installed or is not on PATH" in result.output

--- a/tests/test_doctor_integrations.py
+++ b/tests/test_doctor_integrations.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock
+
+from typer.testing import CliRunner
+
+import powercontext.cli.dsh as dsh_cli
+import powercontext.cli.hermes as hermes_cli
+import powercontext.cli.pi as pi_cli
+import powercontext.cli.system as system_cli
+from powercontext.cli.app import create_cli
+from powercontext.cli.system import Diagnostic, DiagnosticStatus, doctor_app
+
+FIRST_CLASS_HOSTS = ("codex", "claude-code", "dsh", "pi", "hermes")
+CLI_KEYS = {
+    "codex": "codex",
+    "claude-code": "claude_code",
+    "dsh": "dsh",
+    "pi": "pi",
+    "hermes": "hermes",
+}
+INTEGRATION_KEYS = {
+    "codex": "plugin",
+    "claude-code": "plugin",
+    "dsh": "plugin",
+    "pi": "package",
+    "hermes": "plugin",
+}
+PATH_MISSING = {
+    "codex": "Codex CLI is not installed or is not on PATH",
+    "claude-code": "Claude Code CLI is not installed or is not on PATH",
+    "dsh": "DeepSeek Harness CLI is not installed or is not on PATH",
+    "pi": "Pi CLI is not installed or is not on PATH",
+    "hermes": "Hermes CLI is not installed or is not on PATH",
+}
+
+
+def _cli():
+    return create_cli([doctor_app])
+
+
+def _invoke(arguments: list[str]):
+    return CliRunner().invoke(_cli(), arguments)
+
+
+def _missing(host: str) -> dict[str, Diagnostic]:
+    return {
+        CLI_KEYS[host]: Diagnostic(status=DiagnosticStatus.FAILED, detail=PATH_MISSING[host]),
+        INTEGRATION_KEYS[host]: Diagnostic(
+            status=DiagnosticStatus.SKIPPED,
+            detail="not checked because the host CLI is unavailable",
+        ),
+    }
+
+
+def _ok_codex() -> dict[str, Diagnostic]:
+    return {
+        "codex": Diagnostic(status=DiagnosticStatus.OK, detail="/usr/bin/codex"),
+        "plugin": Diagnostic(status=DiagnosticStatus.OK, detail="powercontext@powercontext enabled=True"),
+    }
+
+
+def _failed_plugin_codex() -> dict[str, Diagnostic]:
+    return {
+        "codex": Diagnostic(status=DiagnosticStatus.OK, detail="/usr/bin/codex"),
+        "plugin": Diagnostic(status=DiagnosticStatus.FAILED, detail="PowerContext plugin is not installed"),
+    }
+
+
+def _list_failed_codex() -> dict[str, Diagnostic]:
+    return {
+        "codex": Diagnostic(status=DiagnosticStatus.FAILED, detail="codex plugin list failed: timeout"),
+        "plugin": Diagnostic(status=DiagnosticStatus.SKIPPED, detail="plugin list is unavailable"),
+    }
+
+
+def _patch_diagnostics(monkeypatch, **replacements: Mock) -> dict[str, Mock]:
+    probes = {host: Mock(name=f"run_{host}_diagnostics", return_value=_missing(host)) for host in FIRST_CLASS_HOSTS}
+    probes.update(replacements)
+    monkeypatch.setattr(system_cli, "run_codex_diagnostics", probes["codex"])
+    monkeypatch.setattr(system_cli, "run_claude_code_diagnostics", probes["claude-code"])
+    monkeypatch.setattr(dsh_cli, "run_dsh_diagnostics", probes["dsh"])
+    monkeypatch.setattr(pi_cli, "run_pi_diagnostics", probes["pi"])
+    monkeypatch.setattr(hermes_cli, "run_hermes_diagnostics", probes["hermes"])
+    return probes
+
+
+def test_doctor_integrations_json_includes_every_first_class_host(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch)
+
+    result = _invoke(["doctor", "integrations", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert list(payload["hosts"]) == list(FIRST_CLASS_HOSTS)
+    for host in FIRST_CLASS_HOSTS:
+        assert payload["hosts"][host]["presence"] == "missing"
+        assert CLI_KEYS[host] in payload["hosts"][host]
+        assert INTEGRATION_KEYS[host] in payload["hosts"][host]
+
+
+def test_doctor_integrations_treats_missing_clis_as_success(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch, codex=Mock(return_value=_ok_codex()))
+
+    result = _invoke(["doctor", "integrations", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["status"] == "ok"
+    assert payload["hosts"]["codex"]["presence"] == "present"
+    assert payload["hosts"]["codex"]["plugin"]["ok"] is True
+    assert payload["hosts"]["pi"]["presence"] == "missing"
+    assert payload["hosts"]["pi"]["package"]["status"] == "skipped"
+
+
+def test_doctor_integrations_prints_a_human_matrix(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch, codex=Mock(return_value=_ok_codex()))
+
+    result = _invoke(["doctor", "integrations"])
+
+    assert result.exit_code == 0
+    assert "codex: present - cli=ok plugin=ok" in result.output
+    assert "claude-code: missing - cli=failed plugin=skipped" in result.output
+    assert "pi: missing - cli=failed package=skipped" in result.output
+
+
+def test_doctor_integrations_fails_when_a_present_plugin_is_broken(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch, codex=Mock(return_value=_failed_plugin_codex()))
+
+    result = _invoke(["doctor", "integrations", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    assert payload["status"] == "failed"
+    assert payload["hosts"]["codex"]["presence"] == "present"
+    assert payload["hosts"]["codex"]["plugin"]["status"] == "failed"
+    assert payload["hosts"]["dsh"]["presence"] == "missing"
+
+
+def test_doctor_integrations_fails_when_a_present_cli_cannot_list_plugins(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch, codex=Mock(return_value=_list_failed_codex()))
+
+    result = _invoke(["doctor", "integrations", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["hosts"]["codex"]["presence"] == "present"
+    assert payload["hosts"]["codex"]["codex"]["status"] == "failed"
+    assert payload["hosts"]["codex"]["plugin"]["status"] == "skipped"
+    assert "is not installed or is not on PATH" not in payload["hosts"]["codex"]["codex"]["detail"]
+
+
+def test_doctor_integrations_succeeds_when_every_host_is_missing(monkeypatch) -> None:
+    _patch_diagnostics(monkeypatch)
+
+    result = _invoke(["doctor", "integrations"])
+
+    assert result.exit_code == 0
+    assert "codex: missing - cli=failed plugin=skipped" in result.output
+    assert "hermes: missing - cli=failed plugin=skipped" in result.output
+
+
+def test_default_doctor_does_not_scan_first_class_hosts(monkeypatch) -> None:
+    probes = _patch_diagnostics(
+        monkeypatch,
+        **{
+            host: Mock(side_effect=AssertionError(f"default doctor must not inspect {host}"))
+            for host in FIRST_CLASS_HOSTS
+        },
+    )
+    monkeypatch.setattr(
+        system_cli,
+        "run_diagnostics",
+        lambda **_kwargs: {
+            "package": Diagnostic(status=DiagnosticStatus.OK, detail="powercontext 0.0.1"),
+            "server_liveness": Diagnostic(status=DiagnosticStatus.OK, detail="http://127.0.0.1:8000 status=ok"),
+            "server_readiness": Diagnostic(status=DiagnosticStatus.OK, detail="http://127.0.0.1:8000 status=ready"),
+        },
+    )
+
+    result = _invoke(["doctor", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert list(payload["checks"]) == ["package", "server_liveness", "server_readiness"]
+    for probe in probes.values():
+        probe.assert_not_called()
+
+
+def test_doctor_codex_still_fails_when_the_cli_is_missing(monkeypatch) -> None:
+    monkeypatch.setattr(system_cli, "which", lambda _name: None)
+
+    result = _invoke(["doctor", "codex"])
+
+    assert result.exit_code == 1
+    assert "Codex CLI is not installed or is not on PATH" in result.output

--- a/tests/test_setup_select.py
+++ b/tests/test_setup_select.py
@@ -239,20 +239,18 @@ def test_setup_select_json_writes_the_matrix_without_a_prompt(monkeypatch) -> No
 def test_setup_select_passes_source_ref_and_claude_defaults(monkeypatch) -> None:
     installers = _patch_installers(monkeypatch)
 
-    result = _invoke(
-        [
-            "setup",
-            "select",
-            "--host",
-            "codex",
-            "--host",
-            "claude-code",
-            "--source",
-            "oceanbase/powercontext",
-            "--ref",
-            "tested-ref",
-        ]
-    )
+    result = _invoke([
+        "setup",
+        "select",
+        "--host",
+        "codex",
+        "--host",
+        "claude-code",
+        "--source",
+        "oceanbase/powercontext",
+        "--ref",
+        "tested-ref",
+    ])
 
     assert result.exit_code == 0
     installers["codex"].assert_called_once_with(source="oceanbase/powercontext", ref="tested-ref")

--- a/tests/test_setup_select.py
+++ b/tests/test_setup_select.py
@@ -17,18 +17,21 @@ from __future__ import annotations
 import json
 from unittest.mock import Mock
 
+import pytest
 from typer.testing import CliRunner
 
 import powercontext.cli.dsh as dsh_cli
 import powercontext.cli.hermes as hermes_cli
 import powercontext.cli.hosts as hosts_cli
+import powercontext.cli.openclaw as openclaw_cli
+import powercontext.cli.opencode as opencode_cli
 import powercontext.cli.pi as pi_cli
 import powercontext.cli.system as system_cli
 from powercontext.cli.app import create_cli
 from powercontext.cli.hosts import parse_host_selection
-from powercontext.cli.system import SetupError, setup_app
+from powercontext.cli.system import Diagnostic, DiagnosticStatus, SetupError, setup_app
 
-FIRST_CLASS_HOSTS = ("codex", "claude-code", "dsh", "pi", "hermes")
+FIRST_CLASS_HOSTS = ("codex", "claude-code", "dsh", "openclaw", "opencode", "pi", "hermes")
 
 
 def _cli():
@@ -40,10 +43,13 @@ def _invoke(arguments: list[str], *, stdin_text: str | None = None):
 
 
 def _patch_installers(monkeypatch, **replacements: Mock) -> dict[str, Mock]:
+    _patch_diagnostics(monkeypatch)
     installers = {
         "codex": Mock(name="install_codex_plugin", return_value=object()),
         "claude-code": Mock(name="install_claude_code_plugin", return_value=object()),
         "dsh": Mock(name="install_dsh_plugin", return_value=object()),
+        "openclaw": Mock(name="install_openclaw_plugin", return_value=object()),
+        "opencode": Mock(name="install_opencode_plugin", return_value=object()),
         "pi": Mock(name="install_pi_plugin", return_value=object()),
         "hermes": Mock(name="install_hermes_plugin", return_value=object()),
     }
@@ -51,9 +57,28 @@ def _patch_installers(monkeypatch, **replacements: Mock) -> dict[str, Mock]:
     monkeypatch.setattr(system_cli, "install_codex_plugin", installers["codex"])
     monkeypatch.setattr(system_cli, "install_claude_code_plugin", installers["claude-code"])
     monkeypatch.setattr(dsh_cli, "install_dsh_plugin", installers["dsh"])
+    monkeypatch.setattr(openclaw_cli, "install_openclaw_plugin", installers["openclaw"])
+    monkeypatch.setattr(opencode_cli, "install_opencode_plugin", installers["opencode"])
     monkeypatch.setattr(pi_cli, "install_pi_plugin", installers["pi"])
     monkeypatch.setattr(hermes_cli, "install_hermes_plugin", installers["hermes"])
     return installers
+
+
+def _patch_diagnostics(monkeypatch, **replacements: Mock) -> dict[str, Mock]:
+    diagnostics = {
+        "codex": Mock(return_value={"plugin": Diagnostic(DiagnosticStatus.OK, "installed")}),
+        "dsh": Mock(return_value={"plugin": Diagnostic(DiagnosticStatus.OK, "installed")}),
+        "opencode": Mock(return_value={"plugin": Diagnostic(DiagnosticStatus.OK, "installed")}),
+        "pi": Mock(return_value={"package": Diagnostic(DiagnosticStatus.OK, "installed")}),
+        "hermes": Mock(return_value={"plugin": Diagnostic(DiagnosticStatus.OK, "installed")}),
+    }
+    diagnostics.update(replacements)
+    monkeypatch.setattr(system_cli, "run_codex_diagnostics", diagnostics["codex"])
+    monkeypatch.setattr(dsh_cli, "run_dsh_diagnostics", diagnostics["dsh"])
+    monkeypatch.setattr(opencode_cli, "run_opencode_diagnostics", diagnostics["opencode"])
+    monkeypatch.setattr(pi_cli, "run_pi_diagnostics", diagnostics["pi"])
+    monkeypatch.setattr(hermes_cli, "run_hermes_diagnostics", diagnostics["hermes"])
+    return diagnostics
 
 
 def _assert_not_called(*installers: Mock) -> None:
@@ -115,13 +140,21 @@ def test_setup_select_installs_only_the_requested_hosts(monkeypatch) -> None:
             {"host": "codex", "status": "installed"},
             {"host": "claude-code", "status": "skipped"},
             {"host": "dsh", "status": "installed"},
+            {"host": "openclaw", "status": "skipped"},
+            {"host": "opencode", "status": "skipped"},
             {"host": "pi", "status": "skipped"},
             {"host": "hermes", "status": "skipped"},
         ]
     }
     installers["codex"].assert_called_once()
     installers["dsh"].assert_called_once()
-    _assert_not_called(installers["claude-code"], installers["pi"], installers["hermes"])
+    _assert_not_called(
+        installers["claude-code"],
+        installers["openclaw"],
+        installers["opencode"],
+        installers["pi"],
+        installers["hermes"],
+    )
 
 
 def test_setup_select_continues_after_a_selected_host_fails(monkeypatch) -> None:
@@ -142,6 +175,8 @@ def test_setup_select_continues_after_a_selected_host_fails(monkeypatch) -> None
                 "status": "failed",
                 "error": "DeepSeek Harness CLI is not installed or is not on PATH.",
             },
+            {"host": "openclaw", "status": "skipped"},
+            {"host": "opencode", "status": "skipped"},
             {"host": "pi", "status": "skipped"},
             {"host": "hermes", "status": "installed"},
         ]
@@ -189,7 +224,13 @@ def test_setup_select_reads_a_tty_selection_by_number(monkeypatch) -> None:
     assert "claude-code: skipped" in result.output
     installers["codex"].assert_called_once()
     installers["dsh"].assert_called_once()
-    _assert_not_called(installers["claude-code"], installers["pi"], installers["hermes"])
+    _assert_not_called(
+        installers["claude-code"],
+        installers["openclaw"],
+        installers["opencode"],
+        installers["pi"],
+        installers["hermes"],
+    )
 
 
 def test_setup_select_cancels_an_empty_tty_selection(monkeypatch) -> None:
@@ -236,7 +277,7 @@ def test_setup_select_json_writes_the_matrix_without_a_prompt(monkeypatch) -> No
     installers["codex"].assert_called_once()
 
 
-def test_setup_select_passes_source_ref_and_claude_defaults(monkeypatch) -> None:
+def test_setup_select_passes_source_ref_and_host_specific_defaults(monkeypatch) -> None:
     installers = _patch_installers(monkeypatch)
 
     result = _invoke([
@@ -246,6 +287,10 @@ def test_setup_select_passes_source_ref_and_claude_defaults(monkeypatch) -> None
         "codex",
         "--host",
         "claude-code",
+        "--host",
+        "openclaw",
+        "--host",
+        "opencode",
         "--source",
         "oceanbase/powercontext",
         "--ref",
@@ -260,6 +305,99 @@ def test_setup_select_passes_source_ref_and_claude_defaults(monkeypatch) -> None
         server_url="http://127.0.0.1:8000",
         capture_prompts=True,
     )
+    installers["openclaw"].assert_called_once_with(
+        source="oceanbase/powercontext",
+        ref="tested-ref",
+        server_url="http://127.0.0.1:8000",
+        scope_mode="agent",
+    )
+    installers["opencode"].assert_called_once_with(source="oceanbase/powercontext", ref="tested-ref")
+
+
+def test_setup_select_passes_server_and_scope_overrides_to_openclaw(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+
+    result = _invoke([
+        "setup",
+        "select",
+        "--host",
+        "openclaw",
+        "--server-url",
+        "https://memory.example",
+        "--scope-mode",
+        "project",
+    ])
+
+    assert result.exit_code == 0
+    installers["openclaw"].assert_called_once_with(
+        source="oceanbase/powercontext",
+        ref="master",
+        server_url="https://memory.example",
+        scope_mode="project",
+    )
+
+
+@pytest.mark.parametrize(
+    ("host", "module", "attribute"),
+    [
+        ("codex", system_cli, "run_codex_diagnostics"),
+        ("dsh", dsh_cli, "run_dsh_diagnostics"),
+        ("opencode", opencode_cli, "run_opencode_diagnostics"),
+        ("pi", pi_cli, "run_pi_diagnostics"),
+        ("hermes", hermes_cli, "run_hermes_diagnostics"),
+    ],
+)
+def test_setup_select_fails_a_row_when_post_install_verification_fails(
+    monkeypatch,
+    host: str,
+    module: object,
+    attribute: str,
+) -> None:
+    installers = _patch_installers(monkeypatch)
+    verification = Mock(
+        return_value={"plugin": Diagnostic(DiagnosticStatus.FAILED, "PowerContext plugin is not loaded")}
+    )
+    monkeypatch.setattr(module, attribute, verification)
+
+    result = _invoke(["setup", "select", "--host", host, "--json"])
+
+    assert result.exit_code == 1
+    row = next(row for row in json.loads(result.output)["hosts"] if row["host"] == host)
+    assert row == {
+        "host": host,
+        "status": "failed",
+        "error": "post-install verification failed: plugin: PowerContext plugin is not loaded",
+    }
+    installers[host].assert_called_once()
+    verification.assert_called_once_with()
+
+
+def test_setup_select_continues_after_post_install_verification_fails(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+    monkeypatch.setattr(
+        system_cli,
+        "run_codex_diagnostics",
+        Mock(return_value={"plugin": Diagnostic(DiagnosticStatus.FAILED, "plugin is not loaded")}),
+    )
+
+    result = _invoke(["setup", "select", "--host", "codex", "--host", "openclaw", "--json"])
+
+    assert result.exit_code == 1
+    rows = {row["host"]: row for row in json.loads(result.output)["hosts"]}
+    assert rows["codex"]["status"] == "failed"
+    assert rows["openclaw"] == {"host": "openclaw", "status": "installed"}
+    installers["openclaw"].assert_called_once()
+
+
+def test_setup_select_prints_hermes_specific_next_step_only_when_installed(monkeypatch) -> None:
+    _patch_installers(monkeypatch)
+
+    installed = _invoke(["setup", "select", "--host", "hermes"])
+    skipped = _invoke(["setup", "select", "--host", "openclaw"])
+
+    assert installed.exit_code == 0
+    assert "`hermes memory setup`" in installed.output
+    assert "`hermes memory setup`" not in skipped.output
 
 
 def test_setup_dsh_still_fails_closed_when_the_cli_is_missing(monkeypatch) -> None:
@@ -273,6 +411,8 @@ def test_setup_dsh_still_fails_closed_when_the_cli_is_missing(monkeypatch) -> No
 
 def test_parse_host_selection_accepts_names_and_reorders_to_the_catalog() -> None:
     assert parse_host_selection("dsh,codex") == ("codex", "dsh")
-    assert parse_host_selection("5") == ("hermes",)
+    assert parse_host_selection("4") == ("openclaw",)
+    assert parse_host_selection("5") == ("opencode",)
+    assert parse_host_selection("7") == ("hermes",)
     assert parse_host_selection("") is None
     assert parse_host_selection("  ") is None

--- a/tests/test_setup_select.py
+++ b/tests/test_setup_select.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock
+
+from typer.testing import CliRunner
+
+import powercontext.cli.dsh as dsh_cli
+import powercontext.cli.hermes as hermes_cli
+import powercontext.cli.hosts as hosts_cli
+import powercontext.cli.pi as pi_cli
+import powercontext.cli.system as system_cli
+from powercontext.cli.app import create_cli
+from powercontext.cli.hosts import parse_host_selection
+from powercontext.cli.system import SetupError, setup_app
+
+FIRST_CLASS_HOSTS = ("codex", "claude-code", "dsh", "pi", "hermes")
+
+
+def _cli():
+    return create_cli([setup_app])
+
+
+def _invoke(arguments: list[str], *, stdin_text: str | None = None):
+    return CliRunner().invoke(_cli(), arguments, input=stdin_text)
+
+
+def _patch_installers(monkeypatch, **replacements: Mock) -> dict[str, Mock]:
+    installers = {
+        "codex": Mock(name="install_codex_plugin", return_value=object()),
+        "claude-code": Mock(name="install_claude_code_plugin", return_value=object()),
+        "dsh": Mock(name="install_dsh_plugin", return_value=object()),
+        "pi": Mock(name="install_pi_plugin", return_value=object()),
+        "hermes": Mock(name="install_hermes_plugin", return_value=object()),
+    }
+    installers.update(replacements)
+    monkeypatch.setattr(system_cli, "install_codex_plugin", installers["codex"])
+    monkeypatch.setattr(system_cli, "install_claude_code_plugin", installers["claude-code"])
+    monkeypatch.setattr(dsh_cli, "install_dsh_plugin", installers["dsh"])
+    monkeypatch.setattr(pi_cli, "install_pi_plugin", installers["pi"])
+    monkeypatch.setattr(hermes_cli, "install_hermes_plugin", installers["hermes"])
+    return installers
+
+
+def _assert_not_called(*installers: Mock) -> None:
+    for installer in installers:
+        installer.assert_not_called()
+
+
+def test_setup_without_subcommand_prints_help_and_installs_nothing(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+
+    result = _invoke(["setup"])
+
+    assert result.exit_code == 2
+    assert "Usage" in result.output
+    assert "Install and configure PowerContext integrations." in result.output
+    _assert_not_called(*installers.values())
+
+
+def test_setup_select_json_without_host_does_not_install(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+
+    result = _invoke(["setup", "select", "--json"])
+
+    assert result.exit_code == 1
+    assert "--host" in result.output
+    _assert_not_called(*installers.values())
+
+
+def test_setup_select_without_host_requires_host_on_a_non_tty(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+    monkeypatch.setattr(hosts_cli, "stdin_is_tty", lambda: False)
+
+    result = _invoke(["setup", "select"])
+
+    assert result.exit_code == 1
+    assert "--host" in result.output
+    _assert_not_called(*installers.values())
+
+
+def test_setup_select_rejects_an_unknown_host_before_installing(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+
+    result = _invoke(["setup", "select", "--host", "unknown"])
+
+    assert result.exit_code == 1
+    assert "unknown host: unknown" in result.output
+    assert "codex" in result.output
+    _assert_not_called(*installers.values())
+
+
+def test_setup_select_installs_only_the_requested_hosts(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+
+    result = _invoke(["setup", "select", "--host", "codex", "--host", "dsh", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "hosts": [
+            {"host": "codex", "status": "installed"},
+            {"host": "claude-code", "status": "skipped"},
+            {"host": "dsh", "status": "installed"},
+            {"host": "pi", "status": "skipped"},
+            {"host": "hermes", "status": "skipped"},
+        ]
+    }
+    installers["codex"].assert_called_once()
+    installers["dsh"].assert_called_once()
+    _assert_not_called(installers["claude-code"], installers["pi"], installers["hermes"])
+
+
+def test_setup_select_continues_after_a_selected_host_fails(monkeypatch) -> None:
+    installers = _patch_installers(
+        monkeypatch,
+        dsh=Mock(side_effect=SetupError.dsh_unavailable()),
+    )
+
+    result = _invoke(["setup", "select", "--host", "dsh", "--host", "hermes", "--json"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.output) == {
+        "hosts": [
+            {"host": "codex", "status": "skipped"},
+            {"host": "claude-code", "status": "skipped"},
+            {
+                "host": "dsh",
+                "status": "failed",
+                "error": "DeepSeek Harness CLI is not installed or is not on PATH.",
+            },
+            {"host": "pi", "status": "skipped"},
+            {"host": "hermes", "status": "installed"},
+        ]
+    }
+    installers["dsh"].assert_called_once()
+    installers["hermes"].assert_called_once()
+
+
+def test_setup_select_reports_an_unavailable_selected_host_and_continues(monkeypatch) -> None:
+    installers = _patch_installers(
+        monkeypatch,
+        codex=Mock(side_effect=SetupError.codex_unavailable()),
+    )
+
+    result = _invoke(["setup", "select", "--host", "codex", "--host", "pi"])
+
+    assert result.exit_code == 1
+    assert "codex: failed - Codex CLI is not installed or is not on PATH." in result.output
+    assert "pi: installed" in result.output
+    installers["codex"].assert_called_once()
+    installers["pi"].assert_called_once()
+
+
+def test_setup_select_reports_a_successful_rerun_as_installed(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+
+    first = _invoke(["setup", "select", "--host", "codex", "--json"])
+    second = _invoke(["setup", "select", "--host", "codex", "--json"])
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert json.loads(second.output)["hosts"][0] == {"host": "codex", "status": "installed"}
+    assert installers["codex"].call_count == 2
+
+
+def test_setup_select_reads_a_tty_selection_by_number(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+    monkeypatch.setattr(hosts_cli, "stdin_is_tty", lambda: True)
+
+    result = _invoke(["setup", "select"], stdin_text="1,3\n")
+
+    assert result.exit_code == 0
+    assert "codex: installed" in result.output
+    assert "dsh: installed" in result.output
+    assert "claude-code: skipped" in result.output
+    installers["codex"].assert_called_once()
+    installers["dsh"].assert_called_once()
+    _assert_not_called(installers["claude-code"], installers["pi"], installers["hermes"])
+
+
+def test_setup_select_cancels_an_empty_tty_selection(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+    monkeypatch.setattr(hosts_cli, "stdin_is_tty", lambda: True)
+
+    result = _invoke(["setup", "select"], stdin_text="\n")
+
+    assert result.exit_code == 0
+    _assert_not_called(*installers.values())
+
+
+def test_setup_select_rejects_an_invalid_tty_token_without_installing(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+    monkeypatch.setattr(hosts_cli, "stdin_is_tty", lambda: True)
+
+    result = _invoke(["setup", "select"], stdin_text="nope\n")
+
+    assert result.exit_code == 1
+    assert "unknown host: nope" in result.output
+    _assert_not_called(*installers.values())
+
+
+def test_setup_select_deduplicates_repeated_host_flags(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+
+    result = _invoke(["setup", "select", "--host", "codex", "--host", "codex", "--json"])
+
+    assert result.exit_code == 0
+    installers["codex"].assert_called_once()
+
+
+def test_setup_select_json_writes_the_matrix_without_a_prompt(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+    monkeypatch.setattr(hosts_cli, "stdin_is_tty", lambda: True)
+
+    result = _invoke(["setup", "select", "--host", "codex", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["hosts"][0] == {"host": "codex", "status": "installed"}
+    assert "Select hosts" not in result.output
+    assert "Next:" not in result.output
+    installers["codex"].assert_called_once()
+
+
+def test_setup_select_passes_source_ref_and_claude_defaults(monkeypatch) -> None:
+    installers = _patch_installers(monkeypatch)
+
+    result = _invoke(
+        [
+            "setup",
+            "select",
+            "--host",
+            "codex",
+            "--host",
+            "claude-code",
+            "--source",
+            "oceanbase/powercontext",
+            "--ref",
+            "tested-ref",
+        ]
+    )
+
+    assert result.exit_code == 0
+    installers["codex"].assert_called_once_with(source="oceanbase/powercontext", ref="tested-ref")
+    installers["claude-code"].assert_called_once_with(
+        source="oceanbase/powercontext",
+        ref="tested-ref",
+        server_url="http://127.0.0.1:8000",
+        capture_prompts=True,
+    )
+
+
+def test_setup_dsh_still_fails_closed_when_the_cli_is_missing(monkeypatch) -> None:
+    monkeypatch.setattr(dsh_cli, "which", lambda _name: None)
+
+    result = _invoke(["setup", "dsh"])
+
+    assert result.exit_code == 1
+    assert "DeepSeek Harness CLI is not installed" in result.output
+
+
+def test_parse_host_selection_accepts_names_and_reorders_to_the_catalog() -> None:
+    assert parse_host_selection("dsh,codex") == ("codex", "dsh")
+    assert parse_host_selection("5") == ("hermes",)
+    assert parse_host_selection("") is None
+    assert parse_host_selection("  ") is None


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1313.

Depends on #1311. Related to #1301, which remains scoped to `setup select`.

# Rationale for this change

`setup select` can install more than one supported host, but diagnosis still requires one fail-closed `doctor <host>`
command per integration. Chaining those commands exits on the first missing CLI, so a machine that intentionally has
only a subset of the supported hosts looks unhealthy.

This PR adds a read-only overview that reports every catalog host, treats an unavailable CLI as `missing` instead of a
command failure, and still fails when a present host has a broken integration.

# What changes are included in this PR?

- Add `powercontext doctor integrations` and `powercontext doctor integrations --json`.
- Walk the shared #1311 host catalog: `codex`, `claude-code`, `dsh`, `openclaw`, `opencode`, `pi`, and `hermes`.
- Reuse the existing diagnostic functions through a lazy dispatcher. The command does not build its catalog from
  PATH, install anything, start the Server, or launch a host.
- Preserve every host-specific integration check. Most hosts report `plugin`, Pi reports `package`, and OpenCode
  reports both `plugin` and `skill`.
- Classify each host as follows:
  - CLI unavailable and all integration checks skipped: `missing`; the command can still exit 0.
  - CLI present and all integration checks healthy: `present`; the row is healthy.
  - CLI present with a failed CLI call or any failed integration check: `present`; the command exits 1 after printing
    the complete matrix.
- Keep `powercontext doctor` limited to package and Server checks. Existing `doctor <host>` commands remain
  fail-closed when their CLI is unavailable.
- Update the English and Chinese installation, troubleshooting, and interface documentation.
- Add focused coverage for the seven-host JSON and text matrices, missing-host success, present-host failures,
  OpenCode Skill failure, the unchanged default doctor, and single-host fail-closed behavior.

This branch is stacked on #1311 (`feat/cli-setup-select`). Until #1311 merges, the diff against `master` also includes
`setup select`. The doctor-only change is commit `2c152ba`.

# Are there any user-facing changes?

Yes. The following optional read-only commands are new:

```text
powercontext doctor integrations
powercontext doctor integrations --json
```

There is no breaking API or storage-format change. Empty `doctor`, individual `doctor <host>` commands, and
`setup select` keep their existing behavior.

# How was this change tested?

- `uv lock --check`
- `uv run ruff check src/powercontext/cli/hosts.py src/powercontext/cli/system.py tests/test_doctor_integrations.py tests/test_setup_select.py`
- `uv run ruff format --check src/powercontext/cli/hosts.py src/powercontext/cli/system.py tests/test_doctor_integrations.py tests/test_setup_select.py`
- `uv run pytest tests/test_doctor_integrations.py tests/test_setup_select.py tests/test_system_cli.py tests/test_cli_workbuddy.py tests/test_dsh_cli.py tests/test_hermes_cli.py tests/test_openclaw_cli.py tests/test_pi_cli.py`
- `uv run ty check`
- `uv run zensical build -s` in a clean worktree

# AI usage statement

AI assistance was used for implementation and review against the issue contract. The command surface, exit-code
rules, and acceptance criteria follow #1313.
