### PR TITLE
docs: document reviewed Experience and Skill workflows

### DIFF
--- a/docs/en/docs/explanation/experience-and-skill-lifecycle.md
+++ b/docs/en/docs/explanation/experience-and-skill-lifecycle.md
@@ -1,0 +1,71 @@
+---
+title: Understand the Experience and Skill lifecycle
+description: Learn how evidence becomes reviewed Experience and managed Skill Artifacts, and when each one is available.
+---
+
+# Understand the Experience and Skill lifecycle
+
+Experience and managed Skill content passes through the same review boundary. Evidence supports a proposal, a human
+reviews one exact Candidate version, and approval creates an immutable Artifact Revision. Generation never approves
+its own result.
+
+## Evidence comes first
+
+A Source records evidence such as a completed task outcome or human-authored material. An Artifact reference points to
+one exact approved Revision. Generation and proposal operations keep these references as lineage so a reviewer can
+check where the content came from.
+
+References must belong to the same scope as the Candidate. A replacement also identifies the exact Artifact Revision
+it intends to replace.
+
+## Candidates are reviewable proposals
+
+An Experience or Skill operation creates a `pending` Candidate. The Candidate has a current head and numbered,
+immutable versions. Revising it appends a complete replacement proposal as the next version.
+
+Reviewers act on the version they inspected. `expected_version` prevents an approval, rejection, or revision from
+silently applying after another writer changes the Candidate. Approval and rejection are terminal states.
+
+A Candidate is not an Artifact Revision:
+
+- `pending` content has no `result_artifact`;
+- approval writes the proposal and returns its exact `result_artifact` in one transaction;
+- rejection records a decision reason without writing an Artifact.
+
+## Experience captures reusable outcomes
+
+An Experience contains a situation, action, observed outcome, and reusable lesson. Model-backed generation requires
+configured generation inference. A human or integration with complete typed content can use the HTTP or Python
+`propose_experience` operation without a model. Both paths stop at a pending Candidate.
+
+After approval, the current Experience head becomes eligible for recall in `PreparedContext` within the same scope.
+Recall still depends on the query and shared output budget. Pending and rejected Candidates, along with historical
+Experience Revisions, remain excluded.
+
+## Managed Skills contain instructions
+
+A managed Skill contains a name, discovery description, instructions, validation checks, and exact lineage. Its
+generation origin states what supports the proposal:
+
+| Origin | Required direct evidence |
+| --- | --- |
+| `experience` | One or more approved Experience Revisions; exact Sources are optional |
+| `source` | One or more exact Sources and no Artifact references |
+| `usage` | An exact target Skill Revision plus Sources that record its use |
+
+Approval creates an immutable Skill Revision. Managed Skills do not enter `PreparedContext`, install themselves, or
+grant execution authority. An approved Revision becomes available to Codex only after an explicit export creates a
+host-local projection.
+
+## Revisions preserve history
+
+Creating a replacement Candidate requires an exact current target. Approval creates the next Revision under the same
+Artifact identity. If another approval moves the target head first, the stale replacement remains pending and the
+approval reports a conflict. The reviewer must inspect the new head before deciding what to do next.
+
+Earlier approved Revisions remain available for exact reads. An exported Skill directory is only a copy of one exact
+Revision; the managed Artifact remains the content authority.
+
+Use [Review Candidates](../how-to/review-candidates.md) for the review procedure,
+[Create and review an Experience](../how-to/create-and-review-experience.md) for Experience operations, and
+[Create and export a managed Skill](../how-to/create-and-export-skill.md) for Skill operations.

--- a/docs/en/docs/how-to/create-and-export-skill.md
+++ b/docs/en/docs/how-to/create-and-export-skill.md
@@ -117,7 +117,7 @@ The command creates a new directory containing:
 `powercontext.json` records the exact Artifact reference and rendered-content hash. The command refuses to replace an
 existing destination. The managed Skill Revision remains authoritative; the directory is a host-local projection.
 
-Start a new Codex session after export so Codex can discover the repository-local Skill.
+Codex detects the exported repository-local Skill automatically. If it does not appear, restart Codex.
 
 ## Evolve a Skill from usage
 

--- a/docs/en/docs/how-to/create-and-export-skill.md
+++ b/docs/en/docs/how-to/create-and-export-skill.md
@@ -1,0 +1,139 @@
+---
+title: Create and export a managed Skill
+description: Generate a managed Skill Candidate from exact evidence, approve it, and export one Revision to Codex.
+---
+
+# Create and export a managed Skill
+
+Generate a managed Skill when reviewed evidence can support reusable instructions and validation checks. Approval
+creates an immutable Skill Revision. A separate export makes one exact Revision available to Codex.
+
+## Before you begin
+
+Start the Server with a generation model and confirm that managed Skill generation is enabled:
+
+```bash
+export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=provider:model-name
+powercontext server run
+```
+
+In another terminal:
+
+```bash
+powercontext capabilities
+```
+
+The output should report `Managed Skill generation: enabled`. Choose one provenance origin before generating:
+
+| Origin | Use it when |
+| --- | --- |
+| `experience` | One or more approved Experience Revisions support a new Skill |
+| `source` | Exact official or human-authored Sources directly support a new Skill |
+| `usage` | Usage Sources support an update to an exact existing Skill Revision |
+
+## 1. Generate a Candidate
+
+From an approved Experience:
+
+```bash
+powercontext skill generate \
+  --scope-id project:example \
+  --origin experience \
+  --artifact-ref experience/EXPERIENCE_ID@REVISION \
+  --reason "Turn the reviewed lesson into reusable instructions."
+```
+
+From exact Sources instead:
+
+```bash
+powercontext skill generate \
+  --scope-id project:example \
+  --origin source \
+  --source-ref content/SOURCE_ID \
+  --reason "Create a Skill from the approved operating procedure."
+```
+
+The response has either `status: pending` with a Candidate or `status: no_op` with no Candidate. Generation does not
+approve, install, export, or execute the proposal.
+
+## 2. Review and approve the Candidate
+
+Inspect the returned Candidate:
+
+```bash
+powercontext candidate show --scope-id project:example CANDIDATE_ID
+```
+
+Check its name, discovery description, complete instructions, validation checks, and exact lineage. Then approve the
+version you inspected:
+
+```bash
+powercontext candidate approve \
+  --scope-id project:example \
+  --expected-version 1 \
+  CANDIDATE_ID
+```
+
+The response should have `status: approved` and an exact Skill `result_artifact`. Approval does not install the Skill
+or grant execution authority. To revise or reject the proposal, follow [Review Candidates](review-candidates.md).
+
+## 3. Read the exact Skill Revision
+
+Use the Artifact ID and Revision from `result_artifact`:
+
+```bash
+powercontext skill show \
+  --scope-id project:example \
+  --revision 1 \
+  SKILL_ID
+```
+
+The response contains the approved content and its exact Source and Artifact lineage. Managed Skills do not enter
+`PreparedContext`; they remain available through exact reads and explicit export.
+
+## 4. Export the Revision to Codex
+
+For Codex export, the Skill name must contain at most 64 lowercase letters, digits, and single hyphens. Its description
+must contain at most 1,024 characters and no angle brackets. The destination directory name must match the Skill
+`name`. For a repository-local Codex Skill:
+
+```bash
+powercontext skill export \
+  --target codex \
+  --scope-id project:example \
+  --revision 1 \
+  --destination .agents/skills/backend-validation \
+  SKILL_ID
+```
+
+The command creates a new directory containing:
+
+```text
+.agents/skills/backend-validation/
+├── SKILL.md
+└── powercontext.json
+```
+
+`powercontext.json` records the exact Artifact reference and rendered-content hash. The command refuses to replace an
+existing destination. The managed Skill Revision remains authoritative; the directory is a host-local projection.
+
+Start a new Codex session after export so Codex can discover the repository-local Skill.
+
+## Evolve a Skill from usage
+
+Use the `usage` origin with the exact current Skill Revision and Sources that record how it performed:
+
+```bash
+powercontext skill generate \
+  --scope-id project:example \
+  --origin usage \
+  --target skill/SKILL_ID@REVISION \
+  --source-ref content/USAGE_SOURCE_ID \
+  --reason "Update the validation steps from observed usage."
+```
+
+The CLI adds the target to Artifact evidence. Review and approve the replacement Candidate before exporting its new
+Revision. If an export destination already exists, inspect and handle that projection explicitly before exporting
+again; the command never overwrites it.
+
+For external Agent-native Skill discovery and import contracts, see [Interfaces](../reference/interfaces.md).

--- a/docs/en/docs/how-to/create-and-review-experience.md
+++ b/docs/en/docs/how-to/create-and-review-experience.md
@@ -1,0 +1,110 @@
+---
+title: Create and review an Experience
+description: Generate an Experience Candidate from exact evidence, review it, and verify the approved Revision.
+---
+
+# Create and review an Experience
+
+Generate an Experience Candidate when exact task evidence contains a reusable situation, action, outcome, and lesson.
+After approval, the current Experience Revision can participate in `PreparedContext` recall for the same scope.
+
+## Before you begin
+
+Start the Server with a generation model and confirm that Experience generation is enabled:
+
+```bash
+export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=provider:model-name
+powercontext server run
+```
+
+In another terminal:
+
+```bash
+powercontext capabilities
+```
+
+The output should report `Experience generation: enabled`. You also need at least one exact Source or Artifact
+reference in the target scope. Provider credentials come from the selected inference provider.
+
+## 1. Generate a Candidate
+
+Pass the exact evidence that supports the proposed Experience:
+
+```bash
+powercontext experience generate \
+  --scope-id project:example \
+  --source-ref content/SOURCE_ID \
+  --reason "Extract a reusable lesson from the completed task."
+```
+
+Repeat `--source-ref` or `--artifact-ref` when the proposal needs more evidence. The response is one of:
+
+- `status: pending`, with a Candidate to review;
+- `status: no_op`, with no Candidate because the model found nothing to propose.
+
+Generation does not approve or recall the proposal.
+
+## 2. Inspect and review the Candidate
+
+For a pending result, copy its `candidate_id` and `version`, then inspect it:
+
+```bash
+powercontext candidate show --scope-id project:example CANDIDATE_ID
+```
+
+Check all four Experience fields and their exact evidence. Approve only the version you inspected:
+
+```bash
+powercontext candidate approve \
+  --scope-id project:example \
+  --expected-version 1 \
+  CANDIDATE_ID
+```
+
+The response should have `status: approved` and an exact Experience `result_artifact`. To revise or reject instead,
+follow [Review Candidates](review-candidates.md).
+
+## 3. Verify the approved Revision
+
+Read the Candidate again and record `result_artifact`:
+
+```bash
+powercontext candidate show --scope-id project:example CANDIDATE_ID
+```
+
+The approved current head is now eligible for same-scope `PreparedContext` recall. Eligibility does not guarantee
+selection because the Runtime applies the query and shared output budget. Exact Experience reads are available through
+the Python Client and HTTP API.
+
+## Replace an existing Experience
+
+Generate a replacement against the exact current Revision and cite the evidence for the change:
+
+```bash
+powercontext experience generate \
+  --scope-id project:example \
+  --target experience/EXPERIENCE_ID@REVISION \
+  --source-ref content/NEW_SOURCE_ID \
+  --reason "Update the lesson with the verified follow-up result."
+```
+
+The CLI includes the target in Artifact evidence automatically. Review the new Candidate as usual. If another approval
+has already advanced the Artifact head, approval reports an Artifact conflict and leaves this Candidate pending.
+
+## Incubate Experiences on a schedule
+
+To inspect completed task outcomes periodically, configure a separate interval and restart the Server:
+
+```bash
+export POWERCONTEXT_SERVER_RUNTIME_EXPERIENCE_SCHEDULE_SECONDS=30
+export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=provider:model-name
+powercontext server run
+```
+
+The job processes bounded Content Source windows and considers only Sources whose metadata contains
+`"kind": "task-outcome"`. Each activation inspects at most 32 Sources. Ordinary prompt Sources are ignored.
+
+Scheduled incubation stops after creating pending Experience Candidates. It never approves them or puts pending
+content into `PreparedContext`. Use the Review Inbox to make each decision.
+
+For configuration defaults and provider settings, see [Configuration](../reference/configuration.md).

--- a/docs/en/docs/how-to/review-candidates.md
+++ b/docs/en/docs/how-to/review-candidates.md
@@ -1,0 +1,145 @@
+---
+title: Review Candidates
+description: Inspect, revise, approve, or reject pending Experience and Skill Candidates.
+---
+
+# Review Candidates
+
+Use the Review Inbox to decide whether a generated or submitted Experience or managed Skill should become an Artifact
+Revision. Approval writes an immutable Revision. Rejection closes the Candidate without writing an Artifact.
+
+## Before you begin
+
+Start the Server and confirm that it is ready:
+
+```bash
+powercontext ready
+```
+
+You need the `scope_id` that contains the Candidate. This guide starts after an Experience or Skill operation has
+created a pending Candidate.
+
+## 1. List pending Candidates
+
+```bash
+powercontext candidate list --scope-id project:example
+```
+
+The default Review Inbox contains only `pending` Candidate heads. Filter it by family when needed:
+
+```bash
+powercontext candidate list --scope-id project:example --family experience
+powercontext candidate list --scope-id project:example --family skill
+```
+
+The response contains each `candidate_id` and current `version`. If it returns `next_cursor`, pass that value through
+`--cursor` to read the next page. `--limit` accepts values from 1 to 100 and defaults to 50.
+
+## 2. Inspect one Candidate
+
+```bash
+powercontext candidate show --scope-id project:example CANDIDATE_ID
+```
+
+Before deciding, inspect:
+
+- `proposal`, including every Experience field or the complete Skill instructions and validation checks;
+- `source_refs` and `artifact_refs`, and the evidence identified by those exact references;
+- `target`, when the proposal would replace an existing Artifact Revision;
+- `reason`, `family`, `status`, and the current `version`.
+
+Do not approve a claim that its evidence does not support. Review Skill instructions as content that may later be
+exported, and reject any proposal that contains secrets or unsafe instructions. Approval itself does not install or
+execute a Skill.
+
+## 3. Approve, reject, or revise
+
+Use the `version` you inspected as `--expected-version`.
+
+### Approve the exact version
+
+```bash
+powercontext candidate approve \
+  --scope-id project:example \
+  --expected-version 1 \
+  CANDIDATE_ID
+```
+
+The response has `status: approved` and an exact `result_artifact`. Approval commits the proposal and marks the
+Candidate approved in one transaction. The Candidate is then terminal.
+
+### Reject the exact version
+
+```bash
+powercontext candidate reject \
+  --scope-id project:example \
+  --expected-version 1 \
+  --reason "The evidence does not support the proposed lesson." \
+  CANDIDATE_ID
+```
+
+The response has `status: rejected`, preserves the reason in `decision_reason`, and has no `result_artifact`.
+Rejection is terminal.
+
+### Revise an Experience Candidate
+
+A revision is a complete replacement proposal, not a patch. Include the evidence that should belong to the new
+version:
+
+```bash
+powercontext candidate revise experience \
+  --scope-id project:example \
+  --expected-version 1 \
+  --situation "Only one storage backend was tested." \
+  --action "Run the same acceptance scenario on both backends." \
+  --outcome "Both backends passed." \
+  --lesson "Keep acceptance behavior backend-neutral." \
+  --source-ref content/SOURCE_ID \
+  CANDIDATE_ID
+```
+
+The response remains `pending` and has a higher `version`. Inspect that version before making another decision.
+
+### Revise a Skill Candidate
+
+Put longer instructions in a UTF-8 file. Supply either `--instructions` or `--instructions-file`, but not both.
+Repeat `--validation` for each check:
+
+```bash
+powercontext candidate revise skill \
+  --scope-id project:example \
+  --expected-version 1 \
+  --name backend-validation \
+  --description "Validate storage backends consistently." \
+  --instructions-file instructions.md \
+  --validation "SQLite passes." \
+  --validation "OceanBase passes." \
+  --artifact-ref experience/EXPERIENCE_ID@REVISION \
+  CANDIDATE_ID
+```
+
+Use `--target FAMILY/ID@REVISION` only for a replacement. The CLI adds the target to the Candidate's Artifact evidence
+automatically.
+
+## 4. Verify the result
+
+Read the Candidate again:
+
+```bash
+powercontext candidate show --scope-id project:example CANDIDATE_ID
+```
+
+For an approved Candidate, record the exact `result_artifact`. For a rejected Candidate, confirm `decision_reason`.
+The default Inbox no longer lists either terminal state; audit them explicitly when needed:
+
+```bash
+powercontext candidate list --scope-id project:example --status approved
+powercontext candidate list --scope-id project:example --status rejected
+```
+
+If a write reports that the Candidate version is stale, show the Candidate again and review the new version. Do not
+change `--expected-version` without inspecting the replacement. A terminal Candidate cannot be approved, rejected, or
+revised again.
+
+The HTTP API, Python Client, and MCP expose the same five Review operations and concurrency rules. See
+[Interfaces](../reference/interfaces.md) for their contract and availability.

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -27,9 +27,21 @@ overview:
         - title: Memory and Handoff
           description: Learn what belongs in durable Memory and what should remain a temporary Handoff.
           href: en/docs/explanation/memory-and-handoff/
+        - title: Experience and Skill lifecycle
+          description: Understand how evidence becomes a reviewed Artifact Revision and when it becomes available.
+          href: en/docs/explanation/experience-and-skill-lifecycle/
         - title: Configuration
           description: Set storage, providers, interfaces, and runtime behavior.
           href: en/docs/reference/configuration/
+        - title: Review Candidates
+          description: Inspect, revise, approve, or reject pending Experience and Skill proposals.
+          href: en/docs/how-to/review-candidates/
+        - title: Create an Experience
+          description: Generate an Experience from exact evidence, review it, and verify the approved Revision.
+          href: en/docs/how-to/create-and-review-experience/
+        - title: Create a managed Skill
+          description: Generate and review a managed Skill, then export one exact Revision to Codex.
+          href: en/docs/how-to/create-and-export-skill/
         - title: Troubleshoot
           description: Diagnose connection, configuration, and integration problems.
           href: en/docs/how-to/troubleshoot/

--- a/docs/en/docs/reference/configuration.md
+++ b/docs/en/docs/reference/configuration.md
@@ -105,19 +105,12 @@ The same configured generation model gates explicit Experience generation, manag
 and external Skill import or fork. Without it, these operations return a capability error before persisting a
 Candidate. Candidate Review, exact reads, and external Skill scan/list/resolve continue to work.
 
-Experience incubation is a separate APScheduler job with its own persisted Source cursor. Enable it with:
-
-```bash
-export POWERCONTEXT_SERVER_RUNTIME_EXPERIENCE_SCHEDULE_SECONDS=30
-export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=provider:model-name
-powercontext server run
-```
-
-Each activation inspects a fixed window of at most 32 Sources and exposes only Content Sources whose metadata contains
-`"kind": "task-outcome"` to the model. It creates pending Experience Candidates in the Review Inbox; it does not
-approve them, place them in PreparedContext, create a managed Skill, export it for Codex, or execute anything.
-The Memory and Experience jobs share the APScheduler sidecar under `POWERCONTEXT_HOME`, but keep independent job
-identities and business cursors. Unsetting one interval removes only that job.
+Experience incubation is a separate APScheduler job with its own persisted Source cursor. It requires both the
+Experience interval and generation model settings. Each activation inspects at most 32 Sources and exposes only
+Content Sources whose metadata contains `"kind": "task-outcome"`. The Memory and Experience jobs share the scheduler
+sidecar under `POWERCONTEXT_HOME`, but keep independent job identities and business cursors. Unsetting one interval
+removes only that job. See [Create and review an Experience](../how-to/create-and-review-experience.md) for setup and
+verification steps.
 
 ### External Codex Skills
 

--- a/docs/en/docs/reference/configuration.md
+++ b/docs/en/docs/reference/configuration.md
@@ -105,11 +105,12 @@ The same configured generation model gates explicit Experience generation, manag
 and external Skill import or fork. Without it, these operations return a capability error before persisting a
 Candidate. Candidate Review, exact reads, and external Skill scan/list/resolve continue to work.
 
-Experience incubation is a separate APScheduler job with its own persisted Source cursor. It requires both the
-Experience interval and generation model settings. Each activation inspects at most 32 Sources and exposes only
-Content Sources whose metadata contains `"kind": "task-outcome"`. The Memory and Experience jobs share the scheduler
-sidecar under `POWERCONTEXT_HOME`, but keep independent job identities and business cursors. Unsetting one interval
-removes only that job. See [Create and review an Experience](../how-to/create-and-review-experience.md) for setup and
+Experience incubation is a separate APScheduler job with its own persisted Source cursor. It requires both
+`POWERCONTEXT_SERVER_RUNTIME_EXPERIENCE_SCHEDULE_SECONDS` and
+`POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL`. Each activation inspects at most 32 Sources and exposes only Content
+Sources whose metadata contains `"kind": "task-outcome"`. The Memory and Experience jobs share the scheduler sidecar
+under `POWERCONTEXT_HOME`, but keep independent job identities and business cursors. Unsetting one interval removes
+only that job. See [Create and review an Experience](../how-to/create-and-review-experience.md) for setup and
 verification steps.
 
 ### External Codex Skills

--- a/docs/en/docs/reference/interfaces.md
+++ b/docs/en/docs/reference/interfaces.md
@@ -90,15 +90,6 @@ powercontext doctor pi
 powercontext server run
 powercontext ready
 powercontext capabilities
-powercontext candidate list --scope-id project:example
-powercontext candidate list --scope-id project:example --family skill
-powercontext candidate show --scope-id project:example CANDIDATE_ID
-powercontext candidate approve --scope-id project:example --expected-version 1 CANDIDATE_ID
-powercontext candidate reject --scope-id project:example --expected-version 1 --reason unsupported CANDIDATE_ID
-powercontext candidate revise experience --scope-id project:example --expected-version 1 \
-  --situation SITUATION --action ACTION --outcome OUTCOME --lesson LESSON CANDIDATE_ID
-powercontext candidate revise skill --scope-id project:example --expected-version 1 \
-  --name NAME --description DESCRIPTION --instructions-file instructions.md --validation CHECK CANDIDATE_ID
 powercontext experience generate --scope-id project:example --source-ref content/SOURCE_ID
 powercontext skill generate --scope-id project:example --origin experience \
   --artifact-ref experience/EXPERIENCE_ID@REVISION
@@ -119,6 +110,9 @@ not create a second content profile inside the CLI.
 checks the Codex CLI and PowerContext plugin explicitly. `powercontext doctor dsh` checks the DeepSeek Harness CLI
 and that dump-config lists the plugin id `powercontext-dsh`. `powercontext doctor pi` checks the Pi executable and
 that Pi lists the PowerContext package.
+
+The `candidate` command group exposes the human Review Inbox. See [Review Candidates](../how-to/review-candidates.md)
+for the ordered list, inspect, revise, approve, and reject workflow.
 
 Generation and revision commands accept repeatable `--source-ref TYPE/ID` and
 `--artifact-ref FAMILY/ID@REVISION` options instead of serialized request files. `--target FAMILY/ID@REVISION`
@@ -184,36 +178,22 @@ existing generic Artifact head and enters the backend's rebuildable FTS index, m
 `PreparedContext` recall in the same scope. Pending and rejected Candidates, all managed Skills, and historical
 Experience revisions remain excluded.
 
+For the relationship between evidence, Candidate versions, approved Revisions, recall, and export, see
+[Experience and Skill lifecycle](../explanation/experience-and-skill-lifecycle.md).
+
 ## Scheduled Experience incubation
 
-An integration can capture a completed task as a Content Source with metadata `"kind": "task-outcome"`. When the
-Experience schedule is configured, APScheduler scans bounded Source windows and asks the configured schema-bound
-pipeline for reusable situation, action, outcome, and lesson proposals. Each proposal cites exact Sources and enters
-the Review Inbox as a pending Experience Candidate.
-
-Experience incubation has its own persisted Source cursor, independent from Memory extraction. Candidate writes and
-cursor advancement commit together; a generation or write failure leaves the window available for retry. Ordinary
-prompt Sources are not Task Outcomes and are ignored by this job.
-
-Scheduling stops at the review boundary. It never approves an Experience, includes pending content in
-PreparedContext, derives a managed Skill, exports a Skill for Codex, or executes instructions. Skill authoring and
-export remain explicit steps after the supporting Experience is approved.
+The scheduler accepts only Content Sources with metadata `"kind": "task-outcome"`, uses an independent persisted
+cursor, and creates pending Experience Candidates. Candidate writes and cursor advancement commit together. The job
+does not approve content or include pending content in `PreparedContext`. Setup and verification steps are in
+[Create and review an Experience](../how-to/create-and-review-experience.md).
 
 ## Managed Skill export to Codex
 
-A configured generator can produce complete managed Skill content through `generate_skill`; a human or integration
-can submit already-complete typed content through `propose_skill`. The proposal contains a name, discovery
-description, instructions, validation checks, and exact Source or Artifact lineage. It remains a Candidate until a
-reviewer approves the exact Candidate version.
-
-Approval creates an immutable Skill Revision. It does not install the Skill or grant execution authority. To make one
-approved Revision available to Codex, export it explicitly into a new repository or user Skill directory with
-`skill export --target codex`. The command writes `SKILL.md` and `powercontext.json`; the manifest records the exact
-Artifact reference and rendered-content hash. It refuses to replace an existing destination, so updates require an
-intentional new export rather than a silent overwrite.
-
-Codex can discover a repository-local export under `.agents/skills/<name>/SKILL.md`. The Artifact Revision remains
-the content authority; the directory is a host-local projection that can be rebuilt from the same exact Revision.
+Approval creates an immutable Skill Revision but does not install it or grant execution authority. The Codex exporter
+writes `SKILL.md` and `powercontext.json` into a new destination and refuses to replace an existing directory. The
+manifest binds the projection to one exact Artifact Revision and rendered-content hash. See
+[Create and export a managed Skill](../how-to/create-and-export-skill.md) for the procedure.
 
 ## External Agent-native Skills
 

--- a/docs/en/docs/reference/interfaces.md
+++ b/docs/en/docs/reference/interfaces.md
@@ -112,7 +112,7 @@ and that dump-config lists the plugin id `powercontext-dsh`. `powercontext docto
 that Pi lists the PowerContext package.
 
 The `candidate` command group exposes the human Review Inbox. See [Review Candidates](../how-to/review-candidates.md)
-for the ordered list, inspect, revise, approve, and reject workflow.
+for the ordered workflow to list, inspect, revise, approve, or reject Candidates.
 
 Generation and revision commands accept repeatable `--source-ref TYPE/ID` and
 `--artifact-ref FAMILY/ID@REVISION` options instead of serialized request files. `--target FAMILY/ID@REVISION`

--- a/docs/zh/docs/explanation/experience-and-skill-lifecycle.md
+++ b/docs/zh/docs/explanation/experience-and-skill-lifecycle.md
@@ -1,0 +1,66 @@
+---
+title: 理解 Experience 与 Skill 生命周期
+description: 了解证据如何变成经过审核的 Experience 和 managed Skill Artifact，以及它们何时可用。
+---
+
+# 理解 Experience 与 Skill 生命周期
+
+Experience 和 managed Skill 使用同一个审核边界。证据支撑 proposal，人工审核一个精确 Candidate version，批准后
+创建不可变的 Artifact Revision。Generation 不会自行批准结果。
+
+## 先有证据
+
+Source 记录已完成的任务结果、人工材料等证据。Artifact 引用指向一个精确的 approved Revision。Generation 和 proposal
+操作保留这些引用作为 lineage，reviewer 可以据此核对内容来源。
+
+引用必须与 Candidate 属于同一个 scope。替换现有内容时，还必须标明要替换的精确 Artifact Revision。
+
+## Candidate 是待审核 proposal
+
+Experience 或 Skill 操作会创建 `pending` Candidate。Candidate 有当前 head 和带编号的不可变 version。修订会把一份完整的
+替代 proposal 追加为下一个 version。
+
+Reviewer 只能操作自己检查过的 version。`expected_version` 防止 Candidate 被其他写入者修改后，批准、拒绝或修订仍静默
+作用于旧内容。批准和拒绝都是终态。
+
+Candidate 不是 Artifact Revision：
+
+- `pending` 内容没有 `result_artifact`；
+- 批准会在同一个事务中写入 proposal，并返回精确的 `result_artifact`；
+- 拒绝只记录 decision reason，不写入 Artifact。
+
+## Experience 保存可复用结果
+
+Experience 包含 situation、action、observed outcome 和 reusable lesson。使用模型生成时必须配置 generation inference。
+已经拥有完整类型化内容的人或 integration 可以通过 HTTP 或 Python `propose_experience` operation 提交，不需要模型。
+两条路径都只会创建 pending Candidate。
+
+批准后，当前 Experience head 可以在同一 scope 内参与 `PreparedContext` 召回。是否被选中仍取决于 query 和共享输出预算。
+Pending、rejected Candidate 以及历史 Experience Revision 都不会进入召回。
+
+## Managed Skill 保存指令
+
+Managed Skill 包含名称、用于发现的描述、instructions、validation checks 和精确 lineage。Generation origin 声明 proposal
+使用哪种直接证据：
+
+| Origin | 必需的直接证据 |
+| --- | --- |
+| `experience` | 一个或多个 approved Experience Revision；可以附带精确 Source |
+| `source` | 一个或多个精确 Source，不能引用 Artifact |
+| `usage` | 一个精确 target Skill Revision，以及记录使用情况的 Source |
+
+批准会创建不可变的 Skill Revision。Managed Skill 不会进入 `PreparedContext`，也不会自行安装或授予执行权限。只有显式
+导出并创建 host-local projection 后，Codex 才能使用某个 approved Revision。
+
+## Revision 保留历史
+
+创建 replacement Candidate 时必须提供精确的当前 target。批准会在同一 Artifact identity 下创建下一个 Revision。如果
+其他批准先推进了 target head，旧 replacement 会保持 pending，批准请求返回 conflict。Reviewer 必须先检查新的 head，
+再决定如何处理。
+
+更早的 approved Revision 仍可被精确读取。导出的 Skill 目录只是某个精确 Revision 的副本，managed Artifact 始终是内容
+权威。
+
+审核步骤见[审核 Candidate](../how-to/review-candidates.md)，Experience 操作见
+[创建并审核 Experience](../how-to/create-and-review-experience.md)，Skill 操作见
+[创建并导出 managed Skill](../how-to/create-and-export-skill.md)。

--- a/docs/zh/docs/how-to/create-and-export-skill.md
+++ b/docs/zh/docs/how-to/create-and-export-skill.md
@@ -115,7 +115,7 @@ powercontext skill export \
 `powercontext.json` 记录精确 Artifact 引用和渲染内容哈希。目标目录已存在时，命令会拒绝覆盖。Managed Skill
 Revision 始终是内容权威，目录只是 host-local projection。
 
-导出后开启新的 Codex 会话，让 Codex 发现代码库级 Skill。
+Codex 会自动检测导出的代码库级 Skill。如果没有出现，再重启 Codex。
 
 ## 根据 usage 演进 Skill
 

--- a/docs/zh/docs/how-to/create-and-export-skill.md
+++ b/docs/zh/docs/how-to/create-and-export-skill.md
@@ -1,0 +1,136 @@
+---
+title: 创建并导出 managed Skill
+description: 根据精确证据生成 managed Skill Candidate，批准后将一个 Revision 导出给 Codex。
+---
+
+# 创建并导出 managed Skill
+
+当经过审核的证据能够支撑可复用 instructions 和 validation checks 时，可以生成 managed Skill。批准会创建不可变的
+Skill Revision；另一次显式导出才会让 Codex 使用某个精确 Revision。
+
+## 开始之前
+
+配置 generation model 并启动 Server，然后确认 managed Skill generation 已启用：
+
+```bash
+export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=provider:model-name
+powercontext server run
+```
+
+在另一个终端中运行：
+
+```bash
+powercontext capabilities
+```
+
+输出应包含 `Managed Skill generation: enabled`。生成前选择一种 provenance origin：
+
+| Origin | 适用情况 |
+| --- | --- |
+| `experience` | 一个或多个 approved Experience Revision 能够支撑新 Skill |
+| `source` | 精确的官方或人工 Source 能够直接支撑新 Skill |
+| `usage` | Usage Source 能够支撑对某个精确现有 Skill Revision 的更新 |
+
+## 1. 生成 Candidate
+
+根据 approved Experience 生成：
+
+```bash
+powercontext skill generate \
+  --scope-id project:example \
+  --origin experience \
+  --artifact-ref experience/EXPERIENCE_ID@REVISION \
+  --reason "把经过审核的经验转为可复用指令。"
+```
+
+也可以直接根据精确 Source 生成：
+
+```bash
+powercontext skill generate \
+  --scope-id project:example \
+  --origin source \
+  --source-ref content/SOURCE_ID \
+  --reason "根据已批准的操作规程创建 Skill。"
+```
+
+响应包含 `status: pending` 和 Candidate，或者返回 `status: no_op` 且没有 Candidate。Generation 不会批准、安装、
+导出或执行 proposal。
+
+## 2. 检查并批准 Candidate
+
+检查返回的 Candidate：
+
+```bash
+powercontext candidate show --scope-id project:example CANDIDATE_ID
+```
+
+检查名称、用于发现的描述、完整 instructions、validation checks 和精确 lineage。然后批准你检查过的 version：
+
+```bash
+powercontext candidate approve \
+  --scope-id project:example \
+  --expected-version 1 \
+  CANDIDATE_ID
+```
+
+响应应包含 `status: approved` 和精确的 Skill `result_artifact`。批准不会安装 Skill，也不会授予执行权限。需要修订或
+拒绝 proposal 时，按照[审核 Candidate](review-candidates.md) 操作。
+
+## 3. 读取精确 Skill Revision
+
+使用 `result_artifact` 中的 Artifact ID 和 Revision：
+
+```bash
+powercontext skill show \
+  --scope-id project:example \
+  --revision 1 \
+  SKILL_ID
+```
+
+响应包含 approved content 及其精确 Source、Artifact lineage。Managed Skill 不会进入 `PreparedContext`，只能通过
+exact read 和显式导出使用。
+
+## 4. 将 Revision 导出给 Codex
+
+导出给 Codex 时，Skill name 最多包含 64 个小写字母、数字和单连字符；description 最多包含 1,024 个字符，并且不能有
+尖括号。目标目录名必须与 Skill `name` 一致。导出为代码库级 Codex Skill：
+
+```bash
+powercontext skill export \
+  --target codex \
+  --scope-id project:example \
+  --revision 1 \
+  --destination .agents/skills/backend-validation \
+  SKILL_ID
+```
+
+该命令创建一个新目录：
+
+```text
+.agents/skills/backend-validation/
+├── SKILL.md
+└── powercontext.json
+```
+
+`powercontext.json` 记录精确 Artifact 引用和渲染内容哈希。目标目录已存在时，命令会拒绝覆盖。Managed Skill
+Revision 始终是内容权威，目录只是 host-local projection。
+
+导出后开启新的 Codex 会话，让 Codex 发现代码库级 Skill。
+
+## 根据 usage 演进 Skill
+
+使用 `usage` origin，并提供精确 current Skill Revision 和记录实际使用结果的 Source：
+
+```bash
+powercontext skill generate \
+  --scope-id project:example \
+  --origin usage \
+  --target skill/SKILL_ID@REVISION \
+  --source-ref content/USAGE_SOURCE_ID \
+  --reason "根据实际使用结果更新验证步骤。"
+```
+
+CLI 会自动把 target 加入 Artifact 证据。审核并批准 replacement Candidate 后，才能导出新 Revision。如果导出目录已经
+存在，应先明确检查和处理该 projection，再重新导出；命令不会覆盖已有目录。
+
+外部 Agent-native Skill 的发现和导入契约见[接口](../reference/interfaces.md)。

--- a/docs/zh/docs/how-to/create-and-review-experience.md
+++ b/docs/zh/docs/how-to/create-and-review-experience.md
@@ -1,0 +1,109 @@
+---
+title: 创建并审核 Experience
+description: 根据精确证据生成 Experience Candidate，完成审核，并验证 approved Revision。
+---
+
+# 创建并审核 Experience
+
+当精确任务证据中包含可复用的 situation、action、outcome 和 lesson 时，可以生成 Experience Candidate。批准后，当前
+Experience Revision 可以参与同一 scope 的 `PreparedContext` 召回。
+
+## 开始之前
+
+配置 generation model 并启动 Server，然后确认 Experience generation 已启用：
+
+```bash
+export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=provider:model-name
+powercontext server run
+```
+
+在另一个终端中运行：
+
+```bash
+powercontext capabilities
+```
+
+输出应包含 `Experience generation: enabled`。目标 scope 中还需要至少一个精确 Source 或 Artifact 引用。Provider
+凭据由所选 inference provider 读取。
+
+## 1. 生成 Candidate
+
+传入能够支撑 Experience proposal 的精确证据：
+
+```bash
+powercontext experience generate \
+  --scope-id project:example \
+  --source-ref content/SOURCE_ID \
+  --reason "从已完成任务中提取可复用经验。"
+```
+
+Proposal 需要更多证据时，可以重复使用 `--source-ref` 或 `--artifact-ref`。响应有两种结果：
+
+- `status: pending`，并返回需要审核的 Candidate；
+- `status: no_op`，表示模型没有提出内容，因此没有 Candidate。
+
+Generation 不会批准 proposal，也不会让它进入召回。
+
+## 2. 检查并审核 Candidate
+
+收到 pending 结果后，复制其中的 `candidate_id` 和 `version`，然后检查内容：
+
+```bash
+powercontext candidate show --scope-id project:example CANDIDATE_ID
+```
+
+检查全部四个 Experience 字段及其精确证据。只批准你已经检查过的 version：
+
+```bash
+powercontext candidate approve \
+  --scope-id project:example \
+  --expected-version 1 \
+  CANDIDATE_ID
+```
+
+响应应包含 `status: approved` 和精确的 Experience `result_artifact`。需要修订或拒绝时，按照
+[审核 Candidate](review-candidates.md) 操作。
+
+## 3. 验证 approved Revision
+
+再次读取 Candidate，并记录 `result_artifact`：
+
+```bash
+powercontext candidate show --scope-id project:example CANDIDATE_ID
+```
+
+Approved current head 现在可以参与同 scope 的 `PreparedContext` 召回。Runtime 仍会根据 query 和共享输出预算选择内容，
+因此符合召回条件不代表一定被选中。Python Client 和 HTTP API 支持精确读取 Experience。
+
+## 替换已有 Experience
+
+基于精确的 current Revision 生成 replacement，并引用支撑这次修改的证据：
+
+```bash
+powercontext experience generate \
+  --scope-id project:example \
+  --target experience/EXPERIENCE_ID@REVISION \
+  --source-ref content/NEW_SOURCE_ID \
+  --reason "根据已经验证的后续结果更新经验。"
+```
+
+CLI 会自动把 target 加入 Artifact 证据。之后照常审核新 Candidate。如果其他批准已经推进 Artifact head，批准请求会返回
+Artifact conflict，并让这个 Candidate 保持 pending。
+
+## 定时孵化 Experience
+
+需要定期检查已完成的任务结果时，配置独立 interval 并重启 Server：
+
+```bash
+export POWERCONTEXT_SERVER_RUNTIME_EXPERIENCE_SCHEDULE_SECONDS=30
+export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=provider:model-name
+powercontext server run
+```
+
+该 job 处理有界的 Content Source window，并且只考虑 metadata 包含 `"kind": "task-outcome"` 的 Source。每次
+activation 最多检查 32 条 Source，普通 Prompt Source 会被忽略。
+
+定时孵化只会创建 pending Experience Candidate。它不会自动批准，也不会把 pending 内容放入 `PreparedContext`。
+每个 Candidate 都需要通过 Review Inbox 决定。
+
+配置默认值和 provider 设置见[配置](../reference/configuration.md)。

--- a/docs/zh/docs/how-to/review-candidates.md
+++ b/docs/zh/docs/how-to/review-candidates.md
@@ -1,0 +1,141 @@
+---
+title: 审核 Candidate
+description: 检查、修订、批准或拒绝待审核的 Experience 和 Skill Candidate。
+---
+
+# 审核 Candidate
+
+使用 Review Inbox 判断生成或提交的 Experience、managed Skill 是否应成为 Artifact Revision。批准会写入不可变的
+Revision；拒绝会关闭 Candidate，但不会写入 Artifact。
+
+## 开始之前
+
+启动 Server，并确认它已经就绪：
+
+```bash
+powercontext ready
+```
+
+你需要知道 Candidate 所在的 `scope_id`。本指南从 Experience 或 Skill 操作已经创建 pending Candidate 后开始。
+
+## 1. 列出待审核 Candidate
+
+```bash
+powercontext candidate list --scope-id project:example
+```
+
+默认 Review Inbox 只列出 `pending` Candidate head。需要时可以按 family 筛选：
+
+```bash
+powercontext candidate list --scope-id project:example --family experience
+powercontext candidate list --scope-id project:example --family skill
+```
+
+响应包含每个 Candidate 的 `candidate_id` 和当前 `version`。如果响应返回 `next_cursor`，通过 `--cursor` 读取下一页。
+`--limit` 可设为 1 到 100，默认值为 50。
+
+## 2. 检查一个 Candidate
+
+```bash
+powercontext candidate show --scope-id project:example CANDIDATE_ID
+```
+
+做决定前，检查以下内容：
+
+- `proposal`，包括全部 Experience 字段，或完整的 Skill 指令与验证项；
+- `source_refs`、`artifact_refs`，以及这些精确引用所标识的证据；
+- `target`，如果该提案会替换已有 Artifact Revision；
+- `reason`、`family`、`status` 和当前 `version`。
+
+证据不能支持的结论不要批准。Skill 指令以后可能被导出，因此包含密钥或不安全指令的 proposal 也应拒绝。批准操作本身
+不会安装或执行 Skill。
+
+## 3. 批准、拒绝或修订
+
+将你刚检查的 `version` 作为 `--expected-version`。
+
+### 批准精确版本
+
+```bash
+powercontext candidate approve \
+  --scope-id project:example \
+  --expected-version 1 \
+  CANDIDATE_ID
+```
+
+响应包含 `status: approved` 和精确的 `result_artifact`。批准会在同一个事务中提交 proposal 并将 Candidate
+标记为 approved。此后 Candidate 进入终态。
+
+### 拒绝精确版本
+
+```bash
+powercontext candidate reject \
+  --scope-id project:example \
+  --expected-version 1 \
+  --reason "证据不能支持提议的经验结论。" \
+  CANDIDATE_ID
+```
+
+响应包含 `status: rejected`，拒绝理由保存在 `decision_reason` 中，并且没有 `result_artifact`。拒绝后 Candidate
+进入终态。
+
+### 修订 Experience Candidate
+
+修订提交的是完整替代 proposal，不是局部补丁。请同时提供新版本应保留的证据：
+
+```bash
+powercontext candidate revise experience \
+  --scope-id project:example \
+  --expected-version 1 \
+  --situation "只测试了一个存储后端。" \
+  --action "在两个后端运行相同的验收场景。" \
+  --outcome "两个后端都通过了测试。" \
+  --lesson "验收行为应与后端无关。" \
+  --source-ref content/SOURCE_ID \
+  CANDIDATE_ID
+```
+
+响应仍为 `pending`，但 `version` 会增加。做下一次决定前，请检查这个新版本。
+
+### 修订 Skill Candidate
+
+较长的指令应放在 UTF-8 文件中。`--instructions` 和 `--instructions-file` 只能选择一个；每个验证项分别使用
+一次 `--validation`：
+
+```bash
+powercontext candidate revise skill \
+  --scope-id project:example \
+  --expected-version 1 \
+  --name backend-validation \
+  --description "以一致方式验证存储后端。" \
+  --instructions-file instructions.md \
+  --validation "SQLite 通过测试。" \
+  --validation "OceanBase 通过测试。" \
+  --artifact-ref experience/EXPERIENCE_ID@REVISION \
+  CANDIDATE_ID
+```
+
+只有替换现有 Artifact 时才使用 `--target FAMILY/ID@REVISION`。CLI 会自动将 target 加入 Candidate 的 Artifact
+证据。
+
+## 4. 验证审核结果
+
+再次读取 Candidate：
+
+```bash
+powercontext candidate show --scope-id project:example CANDIDATE_ID
+```
+
+Candidate 已批准时，记录精确的 `result_artifact`；Candidate 已拒绝时，确认 `decision_reason`。默认 Inbox 不再列出
+这两种终态，需要审计时应显式查询：
+
+```bash
+powercontext candidate list --scope-id project:example --status approved
+powercontext candidate list --scope-id project:example --status rejected
+```
+
+如果写操作报告 Candidate 版本过期，请重新显示 Candidate 并审核新版本。不要在未检查替代内容时直接修改
+`--expected-version`。进入终态的 Candidate 不能再次批准、拒绝或修订。
+
+HTTP API、Python Client 和 MCP 暴露相同的五个 Review 操作，并使用相同的并发规则。接口契约和可用范围见
+[接口](../reference/interfaces.md)。

--- a/docs/zh/docs/index.md
+++ b/docs/zh/docs/index.md
@@ -27,9 +27,21 @@ overview:
         - title: Memory 与 Handoff
           description: 了解哪些信息应该长期保留，哪些内容只需要临时交接。
           href: zh/docs/explanation/memory-and-handoff/
+        - title: Experience 与 Skill 生命周期
+          description: 了解证据如何变成经过审核的 Artifact Revision，以及它何时可用。
+          href: zh/docs/explanation/experience-and-skill-lifecycle/
         - title: 配置
           description: 设置存储、provider、接口和运行行为。
           href: zh/docs/reference/configuration/
+        - title: 审核 Candidate
+          description: 检查、修订、批准或拒绝待审核的 Experience 和 Skill 提案。
+          href: zh/docs/how-to/review-candidates/
+        - title: 创建 Experience
+          description: 根据精确证据生成 Experience，完成审核并验证 approved Revision。
+          href: zh/docs/how-to/create-and-review-experience/
+        - title: 创建 managed Skill
+          description: 生成并审核 managed Skill，再将一个精确 Revision 导出给 Codex。
+          href: zh/docs/how-to/create-and-export-skill/
         - title: 排查问题
           description: 诊断连接、配置和集成问题。
           href: zh/docs/how-to/troubleshoot/

--- a/docs/zh/docs/reference/configuration.md
+++ b/docs/zh/docs/reference/configuration.md
@@ -103,8 +103,9 @@ Candidate Review、exact read 和 external Skill scan/list/resolve 仍可使用�
 
 Experience 孵化使用独立的 APScheduler job 和持久化 Source cursor，需要同时设置
 `POWERCONTEXT_SERVER_RUNTIME_EXPERIENCE_SCHEDULE_SECONDS` 与 `POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL`。
-每次 activation 最多检查 32 条 Source，并且只把 metadata 包含 `"kind": "task-outcome"` 的 Content Source 暴露给模型。
-Memory 和 Experience job 共用 `POWERCONTEXT_HOME` 下的 scheduler sidecar，但拥有独立的 job identity 和业务 cursor；取消其中一个 interval 只会移除对应 job。
+每次 activation 最多检查 32 条 Source，并且只把 metadata 包含 `"kind": "task-outcome"` 的 Content Source
+暴露给模型。Memory 和 Experience job 共用 `POWERCONTEXT_HOME` 下的 scheduler sidecar，但拥有独立的 job identity
+和业务 cursor；取消其中一个 interval 只会移除对应 job。
 设置与验证步骤见[创建并审核 Experience](../how-to/create-and-review-experience.md)。
 
 ### 外部 Codex Skill

--- a/docs/zh/docs/reference/configuration.md
+++ b/docs/zh/docs/reference/configuration.md
@@ -101,11 +101,11 @@ search request 最终 `limit` 的结果。它不会修改已存储 Memory 或索
 external Skill import/fork。未配置模型时，这些 operation 会在持久化 Candidate 前返回 capability error；
 Candidate Review、exact read 和 external Skill scan/list/resolve 仍可使用。
 
-Experience 孵化使用独立的 APScheduler job 和持久化 Source cursor，同时需要 Experience interval 和 generation
-model 设置。每次 activation 最多检查 32 条 Source，并且只把 metadata 包含 `"kind": "task-outcome"` 的 Content
-Source 暴露给模型。Memory 和 Experience job 共用 `POWERCONTEXT_HOME` 下的 scheduler sidecar，但拥有独立的 job
-identity 和业务 cursor；取消其中一个 interval 只会移除对应 job。设置和验证步骤见
-[创建并审核 Experience](../how-to/create-and-review-experience.md)。
+Experience 孵化使用独立的 APScheduler job 和持久化 Source cursor，需要同时设置
+`POWERCONTEXT_SERVER_RUNTIME_EXPERIENCE_SCHEDULE_SECONDS` 与 `POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL`。
+每次 activation 最多检查 32 条 Source，并且只把 metadata 包含 `"kind": "task-outcome"` 的 Content Source 暴露给模型。
+Memory 和 Experience job 共用 `POWERCONTEXT_HOME` 下的 scheduler sidecar，但拥有独立的 job identity 和业务 cursor；取消其中一个 interval 只会移除对应 job。
+设置与验证步骤见[创建并审核 Experience](../how-to/create-and-review-experience.md)。
 
 ### 外部 Codex Skill
 

--- a/docs/zh/docs/reference/configuration.md
+++ b/docs/zh/docs/reference/configuration.md
@@ -101,19 +101,11 @@ search request 最终 `limit` 的结果。它不会修改已存储 Memory 或索
 external Skill import/fork。未配置模型时，这些 operation 会在持久化 Candidate 前返回 capability error；
 Candidate Review、exact read 和 external Skill scan/list/resolve 仍可使用。
 
-Experience 孵化使用独立的 APScheduler job 和持久化 Source cursor，可通过以下配置启用：
-
-```bash
-export POWERCONTEXT_SERVER_RUNTIME_EXPERIENCE_SCHEDULE_SECONDS=30
-export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=provider:model-name
-powercontext server run
-```
-
-每次 activation 固定检查最多 32 条 Source，并且只把 metadata 包含 `"kind": "task-outcome"` 的 Content Source
-暴露给模型。该 job 会在 Review Inbox 中创建 pending Experience Candidate；它不会自动批准、进入
-PreparedContext、创建 managed Skill、将它导出给 Codex 或执行任何内容。Memory 和 Experience job 共用
-`POWERCONTEXT_HOME` 下的 APScheduler sidecar，但拥有独立的 job identity 和业务 cursor；取消其中一个 interval
-只会移除对应 job。
+Experience 孵化使用独立的 APScheduler job 和持久化 Source cursor，同时需要 Experience interval 和 generation
+model 设置。每次 activation 最多检查 32 条 Source，并且只把 metadata 包含 `"kind": "task-outcome"` 的 Content
+Source 暴露给模型。Memory 和 Experience job 共用 `POWERCONTEXT_HOME` 下的 scheduler sidecar，但拥有独立的 job
+identity 和业务 cursor；取消其中一个 interval 只会移除对应 job。设置和验证步骤见
+[创建并审核 Experience](../how-to/create-and-review-experience.md)。
 
 ### 外部 Codex Skill
 

--- a/docs/zh/docs/reference/interfaces.md
+++ b/docs/zh/docs/reference/interfaces.md
@@ -81,15 +81,6 @@ powercontext doctor pi
 powercontext server run
 powercontext ready
 powercontext capabilities
-powercontext candidate list --scope-id project:example
-powercontext candidate list --scope-id project:example --family skill
-powercontext candidate show --scope-id project:example CANDIDATE_ID
-powercontext candidate approve --scope-id project:example --expected-version 1 CANDIDATE_ID
-powercontext candidate reject --scope-id project:example --expected-version 1 --reason unsupported CANDIDATE_ID
-powercontext candidate revise experience --scope-id project:example --expected-version 1 \
-  --situation SITUATION --action ACTION --outcome OUTCOME --lesson LESSON CANDIDATE_ID
-powercontext candidate revise skill --scope-id project:example --expected-version 1 \
-  --name NAME --description DESCRIPTION --instructions-file instructions.md --validation CHECK CANDIDATE_ID
 powercontext experience generate --scope-id project:example --source-ref content/SOURCE_ID
 powercontext skill generate --scope-id project:example --origin experience \
   --artifact-ref experience/EXPERIENCE_ID@REVISION
@@ -109,6 +100,9 @@ powercontext external-skill import --scope-id project:example --fingerprint SHA2
 `powercontext doctor` 检查安装包和 Server，不要求任何集成；`powercontext doctor codex` 显式检查 Codex CLI
 和 PowerContext 插件；`powercontext doctor dsh` 检查 DeepSeek Harness CLI，以及 dump-config 是否列出插件 id
 `powercontext-dsh`；`powercontext doctor pi` 检查 Pi 可执行文件，以及 Pi 是否列出了 PowerContext package。
+
+`candidate` 命令组提供面向人工的 Review Inbox。列出、检查、修订、批准和拒绝的操作步骤见
+[审核 Candidate](../how-to/review-candidates.md)。
 
 Generation 和 revision 命令通过可重复的 `--source-ref TYPE/ID` 与
 `--artifact-ref FAMILY/ID@REVISION` 接收精确引用，不再读取序列化请求文件。
@@ -173,34 +167,20 @@ Experience 经 Review 批准后，确定性的 `searchable_text` 会写入现有
 索引，从而可在同一 scope 内被 `PreparedContext` 召回。pending/rejected Candidate、所有 managed Skill 和历史
 Experience Revision 仍不会进入 PreparedContext。
 
+证据、Candidate version、approved Revision、召回和导出的关系见
+[Experience 与 Skill 生命周期](../explanation/experience-and-skill-lifecycle.md)。
+
 ## 后台 Experience 孵化
 
-Integration 可以把已完成任务采集为 metadata 含 `"kind": "task-outcome"` 的 Content Source。启用
-Experience schedule 后，APScheduler 会扫描有上限的 Source window，并让配置好的 schema-bound pipeline
-生成可复用的 situation、action、outcome 和 lesson。每条 proposal 都引用精确 Source，并以 pending
-Experience Candidate 进入 Review Inbox。
-
-Experience 孵化使用独立于 Memory extraction 的持久化 Source cursor。Candidate 写入和 cursor 推进会在同一
-事务提交；generation 或写入失败时，该 window 保留给下次重试。普通 Prompt Source 不是 Task Outcome，
-不会进入这个 job。
-
-后台流程止于审核边界：它不会批准 Experience、把 pending 内容放入 PreparedContext、派生 managed Skill、
-把 Skill 导出给 Codex，或执行 instructions。只有支撑它的 Experience 获批后，Skill authoring 和导出才作为
-显式步骤继续。
+Scheduler 只接收 metadata 含 `"kind": "task-outcome"` 的 Content Source，使用独立的持久化 cursor，并创建
+pending Experience Candidate。Candidate 写入和 cursor 推进在同一事务提交。该 job 不会批准内容，也不会把 pending
+内容放入 `PreparedContext`。设置与验证步骤见[创建并审核 Experience](../how-to/create-and-review-experience.md)。
 
 ## 把 managed Skill 导出给 Codex
 
-配置好的生成器可通过 `generate_skill` 生成完整 managed Skill；已经拥有完整类型化内容的人或 integration
-可通过 `propose_skill` 提交。proposal 包括名称、用于发现的描述、instructions、validation，以及精确的
-Source 或 Artifact lineage。在 reviewer 批准精确 Candidate version 之前，它始终只是 Candidate。
-
-批准会创建不可变的 Skill Revision，但不会安装 Skill，也不会授予执行权限。要让 Codex 使用某个已批准
-Revision，必须通过 `skill export --target codex` 将它显式导出到新的代码库级或用户级 Skill 目录。该命令生成
-`SKILL.md` 和 `powercontext.json`；manifest 会记录精确 Artifact 引用和渲染内容哈希。目标目录已存在时命令会
-拒绝覆盖，更新必须是一次明确的新导出，不能静默替换。
-
-Codex 可以发现 `.agents/skills/<name>/SKILL.md` 下的代码库级导出。Artifact Revision 始终是内容权威，目录
-只是 host-local projection，可以从同一个精确 Revision 重建。
+批准会创建不可变的 Skill Revision，但不会安装 Skill 或授予执行权限。Codex exporter 将 `SKILL.md` 和
+`powercontext.json` 写入新的目标目录，并拒绝覆盖已有目录。Manifest 将 projection 绑定到一个精确 Artifact Revision
+及其渲染内容哈希。操作步骤见[创建并导出 managed Skill](../how-to/create-and-export-skill.md)。
 
 ## 外部 Agent-native Skill
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -17,7 +17,11 @@ nav = [
                 { "Codex quickstart" = "en/docs/tutorials/codex-quickstart.md" },
                 { "Install and run" = "en/docs/how-to/install-and-run.md" },
                 { "Memory and Handoff" = "en/docs/explanation/memory-and-handoff.md" },
+                { "Experience and Skill lifecycle" = "en/docs/explanation/experience-and-skill-lifecycle.md" },
                 { "Hand off work in Codex" = "en/docs/how-to/handoff-with-codex.md" },
+                { "Review Candidates" = "en/docs/how-to/review-candidates.md" },
+                { "Create and review an Experience" = "en/docs/how-to/create-and-review-experience.md" },
+                { "Create and export a managed Skill" = "en/docs/how-to/create-and-export-skill.md" },
                 { "Troubleshoot" = "en/docs/how-to/troubleshoot.md" },
             ] },
             { "Integrations" = [
@@ -81,7 +85,11 @@ nav = [
                 { "Codex 快速入门" = "zh/docs/tutorials/codex-quickstart.md" },
                 { "安装和运行" = "zh/docs/how-to/install-and-run.md" },
                 { "理解 Memory 和 Handoff" = "zh/docs/explanation/memory-and-handoff.md" },
+                { "Experience 与 Skill 生命周期" = "zh/docs/explanation/experience-and-skill-lifecycle.md" },
                 { "在 Codex 中交接工作" = "zh/docs/how-to/handoff-with-codex.md" },
+                { "审核 Candidate" = "zh/docs/how-to/review-candidates.md" },
+                { "创建并审核 Experience" = "zh/docs/how-to/create-and-review-experience.md" },
+                { "创建并导出 managed Skill" = "zh/docs/how-to/create-and-export-skill.md" },
                 { "排查问题" = "zh/docs/how-to/troubleshoot.md" },
             ] },
             { "集成方式" = [


### PR DESCRIPTION
Part of #1226

## Summary

- Add synchronized English and Chinese Candidate Review how-to guides.
- Explain the Experience and managed Skill lifecycle and review boundary.
- Document Experience generation, review, replacement, and scheduled incubation.
- Document managed Skill generation, review, exact reads, evolution, and Codex export.
- Move procedural guidance out of interface and configuration reference pages.
- Update English and Chinese documentation navigation.

## Validation

- `.\.venv\Scripts\zensical.exe build -s`
- `git diff --check`
- Verified commands and behavior against the CLI, OpenAPI, Python Client, Runtime, MCP, and tests.

## AI usage

Used the `documentation-writer` and `humanizer` skills to draft and edit the documentation. The author manually reviewed the final content.