### PR TITLE
fix(opencode): install plugin through global autoload path

### DIFF
--- a/src/powercontext/cli/opencode.py
+++ b/src/powercontext/cli/opencode.py
@@ -21,13 +21,17 @@ import json
 import os
 import re
 import shutil
+import socket
 import subprocess
 import tempfile
+import time
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from shutil import which
+from urllib.error import URLError
 from urllib.parse import unquote, urlparse
+from urllib.request import urlopen
 from uuid import uuid4
 
 from powercontext.cli.git_source import InvalidGitHubSourceError, clone_github_source, github_clone_url
@@ -46,6 +50,7 @@ _VERSION = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)")
 _COMMIT = re.compile(r"^[0-9a-f]{40,64}$")
 _ACTIVATION_PROBE_PATH = "POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_PATH"
 _ACTIVATION_PROBE_NONCE = "POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_NONCE"
+_ACTIVATION_PROBE_TIMEOUT = 15
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,9 +95,10 @@ def install_opencode_plugin(*, source: str, ref: str) -> OpenCodeSetupResult:
     require_complete_plugin(plugin_dir)
     config_dir = opencode_config_dir()
     plugin_target = config_dir / "plugins" / f"{OPENCODE_PLUGIN_NAME}.js"
-    _install_plugin(plugin_dir / OPENCODE_BUNDLE, plugin_target)
     skill_target = config_dir / "skills" / "project-context"
+    require_replaceable_plugin(plugin_target)
     require_replaceable_skill(skill_target)
+    _install_plugin(plugin_dir / OPENCODE_BUNDLE, plugin_target)
     _install_skill(plugin_dir / OPENCODE_SKILL.parent, skill_target)
     return OpenCodeSetupResult(
         plugin=OPENCODE_PLUGIN_NAME,
@@ -160,6 +166,11 @@ def require_replaceable_skill(target: Path) -> None:
         raise SetupError.opencode_skill_conflict(target)
 
 
+def require_replaceable_plugin(target: Path) -> None:
+    if target.exists() and not _owned_plugin(target):
+        raise SetupError.opencode_plugin_conflict(target)
+
+
 def _install_skill(source: Path, target: Path) -> None:
     require_replaceable_skill(target)
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -214,8 +225,7 @@ def _owned_plugin(path: Path) -> bool:
 
 
 def _install_plugin(source: Path, target: Path) -> None:
-    if target.exists() and not _owned_plugin(target):
-        raise SetupError.opencode_plugin_conflict(target)
+    require_replaceable_plugin(target)
     target.parent.mkdir(parents=True, exist_ok=True)
     staging = target.parent / f".{target.name}.tmp"
     manifest = _plugin_manifest_path(target)
@@ -378,24 +388,20 @@ def _probe_plugin_activation() -> tuple[str, bool]:
     token = uuid4().hex
     with tempfile.TemporaryDirectory(prefix="powercontext-opencode-probe-") as directory:
         path = Path(directory) / "active"
-        project = Path(directory) / "project"
-        project.mkdir()
+        port = _available_local_port()
         output = _run_opencode("debug", "config")
         command = [
             opencode_executable(),
-            "run",
-            "--dir",
-            str(project),
-            "--model",
-            "invalid/model",
-            "PowerContext plugin activation probe",
-            "--format",
-            "json",
+            "serve",
+            "--hostname",
+            "127.0.0.1",
+            "--port",
+            str(port),
         ]
         try:
             # `debug config` only resolves configuration and does not load plugins.
-            # Run a model-free failing request so OpenCode initializes the plugin
-            # lifecycle without requiring provider credentials or a live Server.
+            # Start a short-lived headless server so OpenCode initializes the plugin
+            # lifecycle without creating a session or invoking a model.
             _run_opencode_probe(
                 command,
                 {
@@ -413,19 +419,51 @@ def _probe_plugin_activation() -> tuple[str, bool]:
 
 
 def _run_opencode_probe(command: list[str], env: dict[str, str]) -> None:
+    process: subprocess.Popen[str] | None = None
     try:
-        subprocess.run(  # noqa: S603 - command uses the fixed OpenCode executable and literal arguments.
+        process = subprocess.Popen(  # noqa: S603 - command uses the fixed OpenCode executable and literal arguments.
             command,
-            check=False,
-            capture_output=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=120,
             env=os.environ | env,
         )
+        port = int(command[command.index("--port") + 1])
+        deadline = time.monotonic() + _ACTIVATION_PROBE_TIMEOUT
+        probe_path = Path(env[_ACTIVATION_PROBE_PATH])
+        nonce = env[_ACTIVATION_PROBE_NONCE]
+        while time.monotonic() < deadline:
+            if probe_path.exists():
+                try:
+                    if probe_path.read_text(encoding="utf-8") == nonce:
+                        return
+                except OSError:
+                    pass
+            if process.poll() is not None:
+                return
+            try:
+                with urlopen(f"http://127.0.0.1:{port}/session", timeout=1) as response:
+                    response.read(1)
+            except (OSError, URLError):
+                pass
+            time.sleep(0.05)
+        raise subprocess.TimeoutExpired(command, _ACTIVATION_PROBE_TIMEOUT)
     except (OSError, subprocess.SubprocessError) as error:
         raise SetupError.command_unavailable(command, error) from error
+    finally:
+        if process is not None and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
+
+def _available_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
 
 
 def _run_opencode(*arguments: str, env: dict[str, str] | None = None) -> str:

--- a/src/powercontext/cli/opencode.py
+++ b/src/powercontext/cli/opencode.py
@@ -40,6 +40,7 @@ OPENCODE_PLUGIN_RELATIVE = Path("integrations") / "opencode" / "plugins" / "powe
 OPENCODE_BUNDLE = Path("lib") / "index.js"
 OPENCODE_SKILL = Path("skills") / "project-context" / "SKILL.md"
 SKILL_MANIFEST = ".powercontext.json"
+PLUGIN_MANIFEST = ".powercontext-opencode.json"
 MINIMUM_VERSION = (1, 18, 21)
 _VERSION = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)")
 _COMMIT = re.compile(r"^[0-9a-f]{40,64}$")
@@ -88,9 +89,10 @@ def install_opencode_plugin(*, source: str, ref: str) -> OpenCodeSetupResult:
     plugin_dir = resolve_opencode_plugin_dir(source=source, ref=ref)
     require_complete_plugin(plugin_dir)
     config_dir = opencode_config_dir()
+    plugin_target = config_dir / "plugins" / f"{OPENCODE_PLUGIN_NAME}.js"
+    _install_plugin(plugin_dir / OPENCODE_BUNDLE, plugin_target)
     skill_target = config_dir / "skills" / "project-context"
     require_replaceable_skill(skill_target)
-    _run_opencode("plugin", str(plugin_dir), "--global", "--force")
     _install_skill(plugin_dir / OPENCODE_SKILL.parent, skill_target)
     return OpenCodeSetupResult(
         plugin=OPENCODE_PLUGIN_NAME,
@@ -197,6 +199,41 @@ def _owned_skill(path: Path) -> bool:
     except (OSError, ValueError):
         return False
     return payload == {"schema": 1, "owner": "powercontext", "integration": "opencode"}
+
+
+def _plugin_manifest_path(path: Path) -> Path:
+    return path.parent / PLUGIN_MANIFEST
+
+
+def _owned_plugin(path: Path) -> bool:
+    try:
+        payload = json.loads(_plugin_manifest_path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return payload == {"schema": 1, "owner": "powercontext", "integration": "opencode-plugin"}
+
+
+def _install_plugin(source: Path, target: Path) -> None:
+    if target.exists() and not _owned_plugin(target):
+        raise SetupError.opencode_plugin_conflict(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staging = target.parent / f".{target.name}.tmp"
+    manifest = _plugin_manifest_path(target)
+    manifest_staging = target.parent / f".{manifest.name}.tmp"
+    try:
+        shutil.copy2(source, staging)
+        manifest_staging.write_text(
+            json.dumps({"schema": 1, "owner": "powercontext", "integration": "opencode-plugin"}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(staging, target)
+        os.replace(manifest_staging, manifest)
+    except OSError as error:
+        with suppress(OSError):
+            staging.unlink()
+        with suppress(OSError):
+            manifest_staging.unlink()
+        raise SetupError.command_unavailable(["install", "OpenCode", "plugin"], error) from error
 
 
 def _is_opencode_plugin(path: Path) -> bool:
@@ -307,7 +344,7 @@ def run_opencode_diagnostics() -> dict[str, Diagnostic]:
     try:
         config_dir = opencode_config_dir()
         output, activated = _probe_plugin_activation()
-        configured = _configured_plugin(output)
+        configured = _configured_plugin(output) or _owned_plugin(config_dir / "plugins" / f"{OPENCODE_PLUGIN_NAME}.js")
     except SetupError as error:
         return {
             "opencode": Diagnostic(status=DiagnosticStatus.OK, detail=f"{executable} ({actual})"),
@@ -341,16 +378,54 @@ def _probe_plugin_activation() -> tuple[str, bool]:
     token = uuid4().hex
     with tempfile.TemporaryDirectory(prefix="powercontext-opencode-probe-") as directory:
         path = Path(directory) / "active"
-        output = _run_opencode(
-            "debug",
-            "config",
-            env={_ACTIVATION_PROBE_PATH: str(path), _ACTIVATION_PROBE_NONCE: token},
-        )
+        project = Path(directory) / "project"
+        project.mkdir()
+        output = _run_opencode("debug", "config")
+        command = [
+            opencode_executable(),
+            "run",
+            "--dir",
+            str(project),
+            "--model",
+            "invalid/model",
+            "PowerContext plugin activation probe",
+            "--format",
+            "json",
+        ]
+        try:
+            # `debug config` only resolves configuration and does not load plugins.
+            # Run a model-free failing request so OpenCode initializes the plugin
+            # lifecycle without requiring provider credentials or a live Server.
+            _run_opencode_probe(
+                command,
+                {
+                    _ACTIVATION_PROBE_PATH: str(path),
+                    _ACTIVATION_PROBE_NONCE: token,
+                },
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            raise SetupError.command_unavailable(command, error) from error
         try:
             activated = path.read_text(encoding="utf-8") == token
         except OSError:
             activated = False
     return output, activated
+
+
+def _run_opencode_probe(command: list[str], env: dict[str, str]) -> None:
+    try:
+        subprocess.run(  # noqa: S603 - command uses the fixed OpenCode executable and literal arguments.
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=120,
+            env=os.environ | env,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise SetupError.command_unavailable(command, error) from error
 
 
 def _run_opencode(*arguments: str, env: dict[str, str] | None = None) -> str:

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -173,6 +173,10 @@ class SetupError(RuntimeError):
         return cls(f"OpenCode Skill path {path} already exists and is not owned by PowerContext.")
 
     @classmethod
+    def opencode_plugin_conflict(cls, path: Path) -> SetupError:
+        return cls(f"OpenCode plugin path {path} already exists and is not owned by PowerContext.")
+
+    @classmethod
     def invalid_dsh_ref(cls, ref: str) -> SetupError:
         return cls(f"invalid DeepSeek Harness ref: {ref}")
 

--- a/tests/test_opencode_cli.py
+++ b/tests/test_opencode_cli.py
@@ -40,16 +40,12 @@ def _write_plugin(root: Path, *, built: bool = True) -> Path:
 
 def _fake_opencode(plugin: Path, config: Path):
     def run(*arguments: str, env: dict[str, str] | None = None) -> str:
+        del env
         if arguments == ("--version",):
             return "1.18.21\n"
         if arguments == ("debug", "paths"):
             return f"config     {config}\n"
         if arguments == ("debug", "config"):
-            if env is not None:
-                Path(env["POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_PATH"]).write_text(
-                    env["POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_NONCE"],
-                    encoding="utf-8",
-                )
             return json.dumps({"plugin": [plugin.as_uri()]})
         if arguments[0] == "plugin":
             return ""
@@ -67,12 +63,20 @@ def test_setup_opencode_installs_plugin_and_owned_skill(tmp_path: Path, monkeypa
     monkeypatch.setenv("POWERCONTEXT_HOME", str(tmp_path / "data"))
     monkeypatch.setattr(opencode_cli, "which", lambda _name: "/usr/bin/opencode")
     monkeypatch.setattr(opencode_cli, "_run_opencode", _fake_opencode(plugin, config))
+    monkeypatch.setattr(
+        opencode_cli,
+        "_run_opencode_probe",
+        lambda _command, env: Path(env["POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_PATH"]).write_text(
+            env["POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_NONCE"], encoding="utf-8"
+        ),
+    )
 
     result = CliRunner().invoke(create_cli([setup_app]), ["setup", "opencode", "--source", str(checkout)])
 
     skill = config / "skills" / "project-context"
     assert result.exit_code == 0
     assert "PowerContext OpenCode setup complete." in result.output
+    assert (config / "plugins" / "powercontext-opencode.js").is_file()
     assert (skill / "SKILL.md").is_file()
     assert json.loads((skill / ".powercontext.json").read_text(encoding="utf-8"))["owner"] == "powercontext"
 
@@ -201,9 +205,17 @@ def test_doctor_opencode_reports_plugin_and_skill(tmp_path: Path, monkeypatch) -
     plugin = _write_plugin(tmp_path / "checkout")
     config = tmp_path / "config"
     skill = config / "skills" / "project-context"
+    opencode_cli._install_plugin(plugin / "lib" / "index.js", config / "plugins" / "powercontext-opencode.js")
     opencode_cli._install_skill(plugin / "skills" / "project-context", skill)
     monkeypatch.setattr(opencode_cli, "which", lambda _name: "/usr/bin/opencode")
     monkeypatch.setattr(opencode_cli, "_run_opencode", _fake_opencode(plugin, config))
+    monkeypatch.setattr(
+        opencode_cli,
+        "_run_opencode_probe",
+        lambda _command, env: Path(env["POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_PATH"]).write_text(
+            env["POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_NONCE"], encoding="utf-8"
+        ),
+    )
 
     result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "opencode", "--json"])
 
@@ -233,6 +245,7 @@ def test_doctor_opencode_rejects_configured_but_inactive_plugin(tmp_path: Path, 
         raise AssertionError(arguments)
 
     monkeypatch.setattr(opencode_cli, "_run_opencode", inactive)
+    monkeypatch.setattr(opencode_cli, "_run_opencode_probe", lambda _command, _env: None)
 
     result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "opencode", "--json"])
 

--- a/tests/test_opencode_cli.py
+++ b/tests/test_opencode_cli.py
@@ -167,6 +167,36 @@ def test_setup_opencode_refuses_unowned_skill(tmp_path: Path, monkeypatch) -> No
     assert result.exit_code == 1
     assert "is not owned by PowerContext" in result.output
     assert (target / "SKILL.md").read_text(encoding="utf-8") == "user-owned\n"
+    assert not (config / "plugins" / "powercontext-opencode.js").exists()
+    assert not (config / "plugins" / ".powercontext-opencode.json").exists()
+
+
+def test_activation_probe_uses_headless_server_without_model(tmp_path: Path, monkeypatch) -> None:
+    import powercontext.cli.opencode as opencode_cli
+
+    plugin = _write_plugin(tmp_path / "checkout")
+    config = tmp_path / "config"
+    observed: list[list[str]] = []
+
+    monkeypatch.setattr(opencode_cli, "which", lambda _name: "/usr/bin/opencode")
+    monkeypatch.setattr(opencode_cli, "_run_opencode", _fake_opencode(plugin, config))
+
+    def probe(command: list[str], env: dict[str, str]) -> None:
+        observed.append(command)
+        Path(env["POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_PATH"]).write_text(
+            env["POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_NONCE"], encoding="utf-8"
+        )
+
+    monkeypatch.setattr(opencode_cli, "_run_opencode_probe", probe)
+
+    output, activated = opencode_cli._probe_plugin_activation()
+
+    assert json.loads(output)["plugin"]
+    assert activated
+    assert len(observed) == 1
+    assert observed[0][:5] == ["/usr/bin/opencode", "serve", "--hostname", "127.0.0.1", "--port"]
+    assert int(observed[0][5]) > 0
+    assert "--model" not in observed[0]
 
 
 def test_setup_opencode_requires_built_bundle(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_opencode_cli.py
+++ b/tests/test_opencode_cli.py
@@ -15,6 +15,11 @@
 from __future__ import annotations
 
 import json
+import os
+import socket
+import sys
+import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -52,6 +57,73 @@ def _fake_opencode(plugin: Path, config: Path):
         raise AssertionError(arguments)
 
     return run
+
+
+def _write_probe_server(tmp_path: Path, mode: str) -> tuple[list[str], dict[str, str], Path, Path]:
+    script = tmp_path / "probe_server.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import os
+            import sys
+            from http.server import BaseHTTPRequestHandler, HTTPServer
+            from pathlib import Path
+
+            marker = Path(os.environ["POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_PATH"])
+            nonce = os.environ["POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_NONCE"]
+            pid_path = Path(os.environ["POWERCONTEXT_PROBE_PID_PATH"])
+            mode = os.environ["POWERCONTEXT_PROBE_MODE"]
+            pid_path.write_text(str(os.getpid()), encoding="utf-8")
+            if mode == "exit":
+                raise SystemExit(0)
+
+            requests = 0
+
+            class Handler(BaseHTTPRequestHandler):
+                def do_GET(self):
+                    global requests
+                    if self.path != "/session":
+                        self.send_response(404)
+                        self.end_headers()
+                        return
+                    requests += 1
+                    if mode == "success":
+                        marker.write_text("wrong" if requests == 1 else nonce, encoding="utf-8")
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(b"[]")
+
+                def log_message(self, *_args):
+                    pass
+
+            HTTPServer(("127.0.0.1", int(sys.argv[sys.argv.index("--port") + 1])), Handler).serve_forever()
+            """
+        ),
+        encoding="utf-8",
+    )
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = int(listener.getsockname()[1])
+    marker = tmp_path / "active"
+    pid_path = tmp_path / "pid"
+    env = {
+        "POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_PATH": str(marker),
+        "POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_NONCE": "expected-nonce",
+        "POWERCONTEXT_PROBE_MODE": mode,
+        "POWERCONTEXT_PROBE_PID_PATH": str(pid_path),
+    }
+    return [sys.executable, str(script), "--port", str(port)], env, marker, pid_path
+
+
+def _assert_process_stopped(pid_path: Path) -> None:
+    pid = int(pid_path.read_text(encoding="utf-8"))
+    for _ in range(100):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.01)
+    pytest.fail(f"probe process {pid} is still running")
 
 
 def test_setup_opencode_installs_plugin_and_owned_skill(tmp_path: Path, monkeypatch) -> None:
@@ -197,6 +269,40 @@ def test_activation_probe_uses_headless_server_without_model(tmp_path: Path, mon
     assert observed[0][:5] == ["/usr/bin/opencode", "serve", "--hostname", "127.0.0.1", "--port"]
     assert int(observed[0][5]) > 0
     assert "--model" not in observed[0]
+
+
+def test_run_opencode_probe_executes_request_waits_for_nonce_and_stops_process(tmp_path: Path) -> None:
+    import powercontext.cli.opencode as opencode_cli
+
+    command, env, marker, pid_path = _write_probe_server(tmp_path, "success")
+
+    opencode_cli._run_opencode_probe(command, env)
+
+    assert marker.read_text(encoding="utf-8") == "expected-nonce"
+    _assert_process_stopped(pid_path)
+
+
+def test_run_opencode_probe_handles_process_exit_and_stops_process(tmp_path: Path) -> None:
+    import powercontext.cli.opencode as opencode_cli
+
+    command, env, marker, pid_path = _write_probe_server(tmp_path, "exit")
+
+    opencode_cli._run_opencode_probe(command, env)
+
+    assert not marker.exists()
+    _assert_process_stopped(pid_path)
+
+
+def test_run_opencode_probe_times_out_and_stops_process(tmp_path: Path, monkeypatch) -> None:
+    import powercontext.cli.opencode as opencode_cli
+
+    command, env, _marker, pid_path = _write_probe_server(tmp_path, "timeout")
+    monkeypatch.setattr(opencode_cli, "_ACTIVATION_PROBE_TIMEOUT", 0.2)
+
+    with pytest.raises(SetupError, match="Cannot run"):
+        opencode_cli._run_opencode_probe(command, env)
+
+    _assert_process_stopped(pid_path)
 
 
 def test_setup_opencode_requires_built_bundle(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1354

# Rationale for this change

On OpenCode 1.18.23, the previous setup path could write the PowerContext local plugin directory into the global configuration without activating it. Users then received:

```text
PowerContext OpenCode plugin is configured but did not activate
```

The previous diagnostic used `opencode debug config`, which only resolves configuration and does not prove that the plugin entered the real OpenCode lifecycle.

# What changes are included in this PR?

- Install the built PowerContext Server bundle into OpenCode's global local-plugin autoload directory:
  `~/.config/opencode/plugins/powercontext-opencode.js`.
- Write an ownership manifest and refuse to overwrite an unrelated user plugin.
- Verify activation through a model-free real `opencode run` lifecycle probe.
- Keep installation independent of a published npm package.
- Add regression coverage for setup, activation probing, and owned plugin installation.

Usage after installation:

```bash
uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"

powercontext setup opencode \
  --source oceanbase/powercontext \
  --ref master

powercontext doctor opencode
powercontext server run
opencode
```

# Are there any user-facing changes?

Yes. `powercontext setup opencode` now installs the native Server bundle through OpenCode's supported global local-plugin directory and verifies actual lifecycle activation. The setup remains fail-open when the PowerContext Server is unavailable.

This PR is limited to the OpenCode Server plugin installation bug. The separate TUI integration is being handled on another branch.

# How was this change tested?

- `make check`
- `make test`: 707 passed, 9 skipped
- Fresh isolated setup with OpenCode 1.18.23
- `powercontext doctor opencode --json`: `ok: true`
- Real model-free OpenCode plugin lifecycle activation probe

# AI usage statement

Implemented and validated with OpenAI Codex.