### PR TITLE
fix(docs): improve reference and content readability

### DIFF
--- a/theme/powercontext/assets/stylesheets/powercontext.css
+++ b/theme/powercontext/assets/stylesheets/powercontext.css
@@ -2944,6 +2944,54 @@ body {
   margin-top: 60px;
 }
 
+.reference-content .doc-heading > code {
+  border: 0;
+  background: transparent;
+  color: var(--pc-ink);
+  padding: 0;
+}
+
+.reference-content .doc-heading > code.highlight,
+.reference-content .doc-heading > code.highlight span {
+  color: var(--pc-ink);
+}
+
+.reference-content .doc-label > code {
+  border-color: var(--pc-rule);
+  background: var(--pc-surface-secondary);
+  color: var(--pc-tertiary);
+  font-size: 0.72em;
+  font-weight: 550;
+}
+
+.reference-content .doc-contents:not(.first) {
+  margin-left: 0;
+  border-left: 0;
+  padding-left: 0;
+}
+
+.reference-content .doc-object.doc-class {
+  margin-top: 44px;
+}
+
+.reference-content .doc-object.doc-function,
+.reference-content .doc-object.doc-attribute {
+  margin-top: 30px;
+  padding-left: 24px;
+}
+
+.reference-content .doc-contents > p {
+  color: var(--pc-text);
+  font-size: 15px;
+  line-height: 1.72;
+}
+
+.md-main__inner:has(.reference-content .doc-object)
+  .pc-page-sidebar--toc
+  .md-nav__item:has(> .md-nav__link[href^="#powercontext."]) {
+  display: none;
+}
+
 .article-content .md-typeset__table {
   box-sizing: border-box;
   overflow-x: auto;
@@ -3021,6 +3069,11 @@ body {
 
   .reference-content .md-typeset > h1 {
     margin-top: 46px;
+  }
+
+  .reference-content .doc-object.doc-function,
+  .reference-content .doc-object.doc-attribute {
+    padding-left: 0;
   }
 }
 

--- a/theme/powercontext/assets/stylesheets/powercontext.css
+++ b/theme/powercontext/assets/stylesheets/powercontext.css
@@ -2264,6 +2264,12 @@ body {
   font-weight: 620;
 }
 
+.md-typeset a.text-link,
+.md-typeset a.text-link:hover,
+.md-typeset a.text-link:focus-visible {
+  color: var(--pc-blue-700);
+}
+
 .release-meta strong {
   color: var(--pc-blue-700);
   font-family: var(--pc-font-code);
@@ -2381,26 +2387,10 @@ body {
   font-weight: 620;
 }
 
-.record-index-title span {
-  color: var(--pc-tertiary);
-  font-size: 11px;
-}
-
-.record-columns--compact,
 .record-row--compact {
   display: grid;
   gap: 24px;
   grid-template-columns: 54px minmax(0, 1fr);
-}
-
-.record-columns {
-  border-bottom: 1px solid var(--pc-rule-strong);
-  padding: 0 4px 8px 0;
-  color: var(--pc-tertiary);
-  font-size: 11px;
-  font-weight: 650;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
 }
 
 .record-row {
@@ -2432,18 +2422,6 @@ body {
 
 .record-row:hover h2 {
   color: var(--pc-blue-700);
-}
-
-.record-proposal code {
-  display: block;
-  overflow: hidden;
-  margin-top: 6px;
-  background: transparent;
-  color: var(--pc-tertiary);
-  font-size: 11px;
-  padding: 0;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .md-main__inner:has(.record-content) {
@@ -2768,10 +2746,6 @@ body {
     flex-direction: column;
   }
 
-  .record-columns {
-    display: none;
-  }
-
   .record-row--compact {
     gap: 12px;
     grid-template-columns: 40px minmax(0, 1fr);
@@ -2992,7 +2966,8 @@ body {
   display: none;
 }
 
-.article-content .md-typeset__table {
+.article-content .md-typeset__table,
+.record-content .md-typeset__table {
   box-sizing: border-box;
   overflow-x: auto;
   width: 100%;
@@ -3002,9 +2977,31 @@ body {
   border-radius: 8px;
 }
 
-.article-content .md-typeset__table table {
+.article-content .md-typeset__table table,
+.record-content .md-typeset__table table {
   margin: 0;
   border: 0;
+  border-radius: 0;
+}
+
+.article-content .md-typeset__table:has(tr > :nth-child(3)) table,
+.record-content .md-typeset__table:has(tr > :nth-child(3)) table {
+  min-width: 640px;
+}
+
+.article-content .md-typeset__table:has(tr > :nth-child(4)) table,
+.record-content .md-typeset__table:has(tr > :nth-child(4)) table {
+  min-width: 700px;
+}
+
+.article-content .md-typeset__table:has(tr > :nth-child(5)) table,
+.record-content .md-typeset__table:has(tr > :nth-child(5)) table {
+  min-width: 760px;
+}
+
+.article-content .md-typeset__table:has(tr > :nth-child(3)) td code,
+.record-content .md-typeset__table:has(tr > :nth-child(3)) td code {
+  white-space: nowrap;
 }
 
 .article-content .md-typeset > table:not([class]) {
@@ -3358,7 +3355,6 @@ body {
   margin-right: 0;
 }
 
-.pc-records-index .record-columns--compact,
 .pc-records-index .record-row--compact {
   gap: 40px;
   grid-template-columns: 140px minmax(0, 1fr);
@@ -3370,7 +3366,6 @@ body {
     grid-template-columns: 1fr;
   }
 
-  .pc-records-index .record-columns--compact,
   .pc-records-index .record-row--compact {
     gap: 12px;
     grid-template-columns: 40px minmax(0, 1fr);

--- a/theme/powercontext/records.html
+++ b/theme/powercontext/records.html
@@ -56,9 +56,7 @@
                     {% if is_meetings %}
                       <div class="record-index-title">
                         <h2 id="record-index-title">{{ "会议纪要" if is_zh else "Meeting notes" }}</h2>
-                        <span>{{ (record_group.children | length) - 2 }} {{ "条记录" if is_zh else "records" }}</span>
                       </div>
-                      <div class="record-columns record-columns--compact" aria-hidden="true"><span>{{ "日期" if is_zh else "Date" }}</span><span>{{ "记录" if is_zh else "Record" }}</span></div>
                     {% endif %}
                     {% for record in record_group.children %}
                       {% if loop.index0 > 0 and record.title not in ["RFC Template", "RFC 模板"] %}
@@ -66,7 +64,6 @@
                           <span class="record-number pc-listing-meta">{{ "0000" if record.title in ["RFC Template", "RFC 模板"] else record.title[:4] }}</span>
                           <div class="record-proposal pc-listing-content">
                             <h2>{% if is_meetings or record.title in ["RFC Template", "RFC 模板"] %}{{ record.title }}{% else %}{{ record.title[5:] }}{% endif %}</h2>
-                            {% if not is_meetings %}<code>{{ record.title | lower | replace(" ", "_") }}</code>{% endif %}
                           </div>
                         </a>
                       {% endif %}

--- a/zensical.toml
+++ b/zensical.toml
@@ -158,6 +158,11 @@ nav = [
 [project.plugins.mkdocstrings.handlers.python]
 paths = ["src/powercontext"]
 
+[project.plugins.mkdocstrings.handlers.python.options]
+heading_level = 3
+show_root_toc_entry = false
+show_source = false
+
 [project.plugins.search]
 lang = ["en", "zh"]
 


### PR DESCRIPTION
# Which issue or RFC does this PR close?

N/A.

# Rationale for this change

Some documentation pages were difficult to scan, especially generated API references and multi-column tables on small screens. RFC and meeting indexes also contained redundant labels.

# What changes are included in this PR?

- Simplify generated API signatures, source links, and table-of-contents entries.
- Keep multi-column Markdown tables readable through contained horizontal scrolling.
- Remove redundant RFC slugs, meeting table headers, and incorrect record counts.
- Improve secondary link contrast in light and dark modes.

# Are there any user-facing changes?

Yes. Documentation layout and readability are improved across desktop and mobile viewports. Runtime APIs, persisted data, and configuration behavior are unchanged.

# How was this change tested?

- `make docs-test`
- Commit hooks, including `ty check`
- Layout checks across 106 English and Chinese routes at desktop and mobile widths
- Manual review of representative pages in light and dark modes

# AI usage statement

Used Codex with GPT-5 to inspect the Zensical theme, implement the CSS and template changes, and verify the rendered documentation.