### PR TITLE
fix(dsh): declare required plugin services

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -52,6 +52,18 @@ jobs:
       - name: Run end-to-end tests
         run: make e2e-test
 
+  dsh-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Set up project tools
+        uses: jdx/mise-action@v2
+
+      - name: Test DSH package
+        run: make js-test
+
   pi-package:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Check out
         uses: actions/checkout@v7
 
+      - name: Set up the Python environment
+        uses: ./.github/actions/setup-python-env
+
       - name: Set up project tools
         uses: jdx/mise-action@v2
 

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,16 @@ js-api-generate-check: ## Verify generated JS operations are current.
 	@uv run python scripts/generate_js_operations.py --check
 
 .PHONY: js-test
-js-test: ## Run DeepSeek Harness plugin unit tests.
+js-test: ## Install, build, and test the DeepSeek Harness plugin.
+	@pnpm --dir integrations/dsh/plugins/powercontext install --frozen-lockfile --config.auto-install-peers=false
 	@pnpm --dir integrations/dsh/plugins/powercontext test
+	@pnpm --dir integrations/dsh/plugins/powercontext build
+	@git diff --exit-code -- \
+		integrations/dsh/plugins/powercontext/openapi/powercontext.yaml \
+		integrations/dsh/plugins/powercontext/src/operations.generated.ts \
+		integrations/dsh/plugins/powercontext/lib
+	@pnpm --dir integrations/dsh/plugins/powercontext test
+	@pnpm --dir integrations/dsh/plugins/powercontext test:e2e
 
 .PHONY: openclaw-plugin-build
 openclaw-plugin-build: ## Build the external OpenClaw memory plugin.

--- a/integrations/dsh/plugins/powercontext/lib/index.js
+++ b/integrations/dsh/plugins/powercontext/lib/index.js
@@ -321,6 +321,12 @@ const OPERATIONS = {
 		location: "body",
 		scope: false
 	},
+	list_handoff_report_known_scopes: {
+		method: "POST",
+		path: "/v1/handoff-reports/scopes/list-known",
+		location: "body",
+		scope: false
+	},
 	get_handoff_report_project: {
 		method: "POST",
 		path: "/v1/handoff-reports/projects/get",
@@ -355,7 +361,7 @@ const OPERATIONS = {
 		method: "POST",
 		path: "/v1/handoff-reports/get",
 		location: "body",
-		scope: false
+		scope: true
 	},
 	record_handoff_report_activity: {
 		method: "POST",
@@ -566,6 +572,14 @@ var PowerContextClient = class {
 		});
 	}
 };
+
+//#endregion
+//#region src/dsh-service.ts
+function requireService(ctx, name$1) {
+	const service = ctx.get(name$1);
+	if (service == null) throw new Error(`${PLUGIN_NAME} requires the "${name$1}" service`);
+	return service;
+}
 
 //#endregion
 //#region src/secrets.ts
@@ -920,9 +934,7 @@ async function handlePcCommand(rawInput, runtime, scopeId, signal) {
 	};
 }
 function registerCommands(ctx, runtime) {
-	const commands = ctx.get("commands");
-	if (!commands) return;
-	commands.register({
+	requireService(ctx, "commands").register({
 		name: "pc",
 		description: "PowerContext status, search, review, and diagnostics",
 		handler: async (invocation) => {
@@ -1303,18 +1315,14 @@ If PowerContext is unavailable, say so once and continue the task.
 Revising or retiring memory requires the exact citation returned by the Server.
 Do not approve artifact candidates unless the user explicitly asked; use /pc review approve instead.`;
 function registerGuidance(ctx) {
-	const systemPrompt = ctx.get("systemPrompt");
-	if (!systemPrompt) return;
-	systemPrompt.section({
+	requireService(ctx, "systemPrompt").section({
 		name: "tool:powercontext",
 		order: 120,
 		text: GUIDANCE
 	});
 }
 function registerSkill(ctx) {
-	const skills = ctx.get("skills");
-	if (!skills) return;
-	skills.register({
+	requireService(ctx, "skills").register({
 		name: "project-context",
 		description: "Restore project memory or transfer current work through PowerContext.",
 		source: "runtime",
@@ -1805,7 +1813,13 @@ function registerTools(ctx, runtime, defineTool) {
 //#endregion
 //#region src/index.ts
 const name = PLUGIN_NAME;
-const inject = ["tools", "agents"];
+const inject = [
+	"tools",
+	"agents",
+	"commands",
+	"skills",
+	"systemPrompt"
+];
 const Config = { "~standard": {
 	version: 1,
 	vendor: "powercontext-dsh",

--- a/integrations/dsh/plugins/powercontext/openapi/powercontext.yaml
+++ b/integrations/dsh/plugins/powercontext/openapi/powercontext.yaml
@@ -1275,6 +1275,33 @@ paths:
           $ref: "#/components/responses/InvalidRequest"
         "500":
           $ref: "#/components/responses/InternalError"
+  /v1/handoff-reports/scopes/list-known:
+    post:
+      tags: [handoff-reports]
+      summary: List scopes that contain a committed Handoff
+      operationId: list_handoff_report_known_scopes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ListHandoffReportKnownScopesRequest"
+      responses:
+        "200":
+          description: A cursor-paginated page of scopes that can be rendered as Handoff Reports.
+          headers:
+            X-PowerContext-Request-ID:
+              $ref: "#/components/headers/RequestId"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KnownHandoffScopePage"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          $ref: "#/components/responses/InvalidRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /v1/handoff-reports/projects/get:
     post:
       tags: [handoff-reports]
@@ -3078,10 +3105,10 @@ components:
           pattern: '^[\x21-\x7E]+$'
         provider:
           type: string
-          enum: [codex]
+          enum: [codex, claude_code]
         agent_kind:
           type: string
-          enum: [codex]
+          enum: [codex, claude_code]
         host_id:
           type: string
           minLength: 1
@@ -3378,12 +3405,19 @@ components:
     GetHandoffReportRequest:
       type: object
       additionalProperties: false
-      required: [project_id]
+      required: [scope_id]
       properties:
+        scope_id:
+          type: string
+          minLength: 1
+          maxLength: 256
         project_id:
           type: string
           minLength: 1
           maxLength: 256
+          nullable: true
+          deprecated: true
+          description: Retained for wire compatibility and ignored when generating a scope report.
         locale:
           $ref: "#/components/schemas/ReportLocale"
           nullable: true
@@ -3401,6 +3435,39 @@ components:
           default: false
         period:
           $ref: "#/components/schemas/HandoffReportPeriodRequest"
+          nullable: true
+    ListHandoffReportKnownScopesRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        cursor:
+          type: string
+          nullable: true
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 50
+    KnownHandoffScope:
+      type: object
+      additionalProperties: false
+      required: [scope_id]
+      properties:
+        scope_id:
+          type: string
+          minLength: 1
+          maxLength: 256
+    KnownHandoffScopePage:
+      type: object
+      additionalProperties: false
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/KnownHandoffScope"
+        next_cursor:
+          type: string
           nullable: true
     HandoffReportPeriodRequest:
       type: object

--- a/integrations/dsh/plugins/powercontext/package.json
+++ b/integrations/dsh/plugins/powercontext/package.json
@@ -34,7 +34,7 @@
     "sync:openapi": "node scripts/sync-openapi.mjs",
     "gen": "node scripts/gen-operations.mjs",
     "gen:check": "node scripts/gen-operations.mjs --check",
-    "build": "node scripts/gen-operations.mjs && tsdown",
+    "build": "node scripts/gen-operations.mjs && tsdown && node scripts/normalize-build-output.mjs",
     "prepare": "node scripts/prepare.mjs",
     "test": "vitest run --exclude=tests/e2e/**",
     "test:e2e": "vitest run tests/e2e",

--- a/integrations/dsh/plugins/powercontext/package.json
+++ b/integrations/dsh/plugins/powercontext/package.json
@@ -82,6 +82,7 @@
     }
   },
   "devDependencies": {
+    "@deepseek-ai/cordis": "4.0.1",
     "@types/node": "^24.3.0",
     "tsdown": "^0.16.2",
     "typescript": "^5.9.2",

--- a/integrations/dsh/plugins/powercontext/pnpm-lock.yaml
+++ b/integrations/dsh/plugins/powercontext/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
 
   .:
     devDependencies:
+      '@deepseek-ai/cordis':
+        specifier: 4.0.1
+        version: 4.0.1
       '@types/node':
         specifier: ^24.3.0
         version: 24.13.3
@@ -60,6 +63,21 @@ packages:
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@deepseek-ai/cordis@4.0.1':
+    resolution: {integrity: sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==}
+    hasBin: true
+    peerDependencies:
+      '@deepseek-ai/cordis-plugin-include': ^1.0.6
+      '@deepseek-ai/cordis-plugin-loader': ^1.0.2
+    peerDependenciesMeta:
+      '@deepseek-ai/cordis-plugin-include':
+        optional: true
+      '@deepseek-ai/cordis-plugin-loader':
+        optional: true
+
+  '@deepseek-ai/cosmokit@1.8.2':
+    resolution: {integrity: sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -588,6 +606,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -1022,6 +1043,13 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@deepseek-ai/cordis@4.0.1':
+    dependencies:
+      '@deepseek-ai/cosmokit': 1.8.2
+      '@standard-schema/spec': 1.1.0
+
+  '@deepseek-ai/cosmokit@1.8.2': {}
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -1322,6 +1350,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.3':
     dependencies:

--- a/integrations/dsh/plugins/powercontext/pnpm-workspace.yaml
+++ b/integrations/dsh/plugins/powercontext/pnpm-workspace.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+autoInstallPeers: false
+
+allowBuilds:
+  esbuild: true

--- a/integrations/dsh/plugins/powercontext/scripts/normalize-build-output.mjs
+++ b/integrations/dsh/plugins/powercontext/scripts/normalize-build-output.mjs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const OUTPUTS = ['index.js', 'index.d.ts', 'invariant.js', 'invariant.d.ts']
+
+export function normalizeBuildOutput() {
+  for (const name of OUTPUTS) {
+    const path = join(root, 'lib', name)
+    const contents = readFileSync(path, 'utf8')
+    if (!contents.endsWith('\n')) writeFileSync(path, `${contents}\n`)
+  }
+}
+
+const invokedDirectly = process.argv[1] !== undefined
+  && import.meta.url === pathToFileURL(process.argv[1]).href
+if (invokedDirectly) normalizeBuildOutput()

--- a/integrations/dsh/plugins/powercontext/scripts/prepare.mjs
+++ b/integrations/dsh/plugins/powercontext/scripts/prepare.mjs
@@ -38,7 +38,10 @@ const gen = run('gen-operations.mjs')
 if (gen.status !== 0) process.exit(gen.status ?? 1)
 
 const tsdown = spawnSync('tsdown', { cwd: root, stdio: 'inherit', shell: true })
-if (tsdown.status === 0) process.exit(0)
+if (tsdown.status === 0) {
+  const normalize = run('normalize-build-output.mjs')
+  process.exit(normalize.status ?? 1)
+}
 if (existsSync(built)) {
   console.warn('powercontext-dsh: tsdown unavailable; using prebuilt lib/')
   process.exit(0)

--- a/integrations/dsh/plugins/powercontext/scripts/sync-openapi.mjs
+++ b/integrations/dsh/plugins/powercontext/scripts/sync-openapi.mjs
@@ -25,11 +25,12 @@ function existingFile(path) {
   return path && existsSync(path) ? resolve(path) : undefined
 }
 
-function walkForOpenApi(startDir) {
+function walkForOpenApi(startDir, ignoredPath) {
   let dir = resolve(startDir)
+  const ignored = ignoredPath ? resolve(ignoredPath) : undefined
   for (let i = 0; i < 8; i += 1) {
     const candidate = join(dir, 'openapi', 'powercontext.yaml')
-    if (existsSync(candidate)) return resolve(candidate)
+    if (existsSync(candidate) && resolve(candidate) !== ignored) return resolve(candidate)
     const parent = resolve(dir, '..')
     if (parent === dir) break
     dir = parent
@@ -37,25 +38,25 @@ function walkForOpenApi(startDir) {
   return undefined
 }
 
-export function resolvePowerContextRoot() {
+export function resolvePowerContextRoot(packageRoot = root) {
   const fromEnv = process.env.POWERCONTEXT_ROOT?.trim()
   if (fromEnv && existsSync(fromEnv)) return resolve(fromEnv)
-  const yamlPath = walkForOpenApi(root)
+  const fallback = join(packageRoot, 'openapi', 'powercontext.yaml')
+  const yamlPath = walkForOpenApi(packageRoot, fallback)
   if (!yamlPath) return undefined
   return resolve(dirname(yamlPath), '..')
 }
 
-export function resolveOpenApiPath() {
+export function resolveOpenApiPath(packageRoot = root) {
   const fromEnv = existingFile(process.env.POWERCONTEXT_OPENAPI?.trim())
   if (fromEnv) return fromEnv
-  const checkout = resolvePowerContextRoot()
+  const checkout = resolvePowerContextRoot(packageRoot)
   const fromRoot = checkout
     ? existingFile(join(checkout, 'openapi', 'powercontext.yaml'))
     : undefined
   if (fromRoot) return fromRoot
-  const walked = walkForOpenApi(root)
-  if (walked) return walked
-  if (existsSync(dest)) return dest
+  const fallback = existingFile(join(packageRoot, 'openapi', 'powercontext.yaml'))
+  if (fallback) return fallback
   throw new Error(
     'openapi/powercontext.yaml is missing. Point POWERCONTEXT_ROOT or POWERCONTEXT_OPENAPI at a PowerContext checkout.',
   )

--- a/integrations/dsh/plugins/powercontext/src/commands.ts
+++ b/integrations/dsh/plugins/powercontext/src/commands.ts
@@ -15,6 +15,7 @@
  */
 
 import type { JsonObject } from './client.ts'
+import { requireService } from './dsh-service.ts'
 import { invokeOperation, type PluginRuntime, type ToolResult } from './invoke.ts'
 import { UNSCOPED_MESSAGE } from './scope.ts'
 
@@ -117,14 +118,13 @@ export function registerCommands(
   ctx: { get: (name: string) => unknown },
   runtime: PluginRuntime,
 ): void {
-  const commands = ctx.get('commands') as {
+  const commands = requireService<{
     register: (definition: {
       name: string
       description: string
       handler: (invocation: { rawInput: string; signal: AbortSignal; agent: { session: { header: { cwd?: string } } } }) => Promise<CommandResult>
     }) => unknown
-  } | undefined
-  if (!commands) return
+  }>(ctx, 'commands')
   commands.register({
     name: 'pc',
     description: 'PowerContext status, search, review, and diagnostics',

--- a/integrations/dsh/plugins/powercontext/src/cordis-augmentation.d.ts
+++ b/integrations/dsh/plugins/powercontext/src/cordis-augmentation.d.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@deepseek-ai/cordis'
+
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    tools: { register(tool: unknown): () => void }
+    commands: { register(definition: Record<string, unknown>): unknown }
+    skills: { register(skill: Record<string, unknown>): unknown }
+    systemPrompt: { section(section: { name: string; order: number; text: string }): unknown }
+    on(event: string, handler: (...args: never[]) => unknown): () => void
+  }
+}

--- a/integrations/dsh/plugins/powercontext/src/dsh-service.ts
+++ b/integrations/dsh/plugins/powercontext/src/dsh-service.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PLUGIN_NAME } from './errors.ts'
+
+export function requireService<T>(
+  ctx: { get: (name: string) => unknown },
+  name: string,
+): T {
+  const service = ctx.get(name)
+  if (service == null) {
+    throw new Error(`${PLUGIN_NAME} requires the "${name}" service`)
+  }
+  return service as T
+}

--- a/integrations/dsh/plugins/powercontext/src/dsh-shims.d.ts
+++ b/integrations/dsh/plugins/powercontext/src/dsh-shims.d.ts
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-declare module '@deepseek-ai/cordis' {
-  export interface Context {
-    tools: { register(tool: unknown): () => void }
-    commands: { register(definition: Record<string, unknown>): unknown }
-    skills: { register(skill: Record<string, unknown>): unknown }
-    systemPrompt: { section(section: { name: string; order: number; text: string }): unknown }
-    on(event: string, handler: (...args: never[]) => unknown): () => void
-    get(name: string): unknown
-    logger: { warn(message: string): void; debug?(message: string): void }
-  }
-}
-
 declare module '@deepseek-ai/schemastery' {
   type Schema<T = unknown> = {
     (value: unknown): T

--- a/integrations/dsh/plugins/powercontext/src/dsh-shims.d.ts
+++ b/integrations/dsh/plugins/powercontext/src/dsh-shims.d.ts
@@ -17,6 +17,9 @@
 declare module '@deepseek-ai/cordis' {
   export interface Context {
     tools: { register(tool: unknown): () => void }
+    commands: { register(definition: Record<string, unknown>): unknown }
+    skills: { register(skill: Record<string, unknown>): unknown }
+    systemPrompt: { section(section: { name: string; order: number; text: string }): unknown }
     on(event: string, handler: (...args: never[]) => unknown): () => void
     get(name: string): unknown
     logger: { warn(message: string): void; debug?(message: string): void }

--- a/integrations/dsh/plugins/powercontext/src/index.ts
+++ b/integrations/dsh/plugins/powercontext/src/index.ts
@@ -28,7 +28,7 @@ import { registerTools } from './tools.ts'
 
 export const name = PLUGIN_NAME
 
-export const inject = ['tools', 'agents']
+export const inject = ['tools', 'agents', 'commands', 'skills', 'systemPrompt']
 
 export interface Config extends PluginConfig {}
 

--- a/integrations/dsh/plugins/powercontext/src/skill.ts
+++ b/integrations/dsh/plugins/powercontext/src/skill.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { requireService } from './dsh-service.ts'
 import { PROJECT_CONTEXT_SKILL } from './skill-body.ts'
 
 export const GUIDANCE = `PowerContext provides durable project memory shared across agent sessions.
@@ -24,10 +25,9 @@ Revising or retiring memory requires the exact citation returned by the Server.
 Do not approve artifact candidates unless the user explicitly asked; use /pc review approve instead.`
 
 export function registerGuidance(ctx: { get: (name: string) => unknown }): void {
-  const systemPrompt = ctx.get('systemPrompt') as {
+  const systemPrompt = requireService<{
     section: (section: { name: string; order: number; text: string }) => unknown
-  } | undefined
-  if (!systemPrompt) return
+  }>(ctx, 'systemPrompt')
   systemPrompt.section({
     name: 'tool:powercontext',
     order: 120,
@@ -36,7 +36,7 @@ export function registerGuidance(ctx: { get: (name: string) => unknown }): void 
 }
 
 export function registerSkill(ctx: { get: (name: string) => unknown }): void {
-  const skills = ctx.get('skills') as {
+  const skills = requireService<{
     register: (skill: {
       name: string
       description: string
@@ -44,8 +44,7 @@ export function registerSkill(ctx: { get: (name: string) => unknown }): void {
       content: string
       whenToUse?: string
     }) => unknown
-  } | undefined
-  if (!skills) return
+  }>(ctx, 'skills')
   skills.register({
     name: 'project-context',
     description: 'Restore project memory or transfer current work through PowerContext.',

--- a/integrations/dsh/plugins/powercontext/tests/e2e/call-through.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/e2e/call-through.spec.ts
@@ -14,12 +14,207 @@
  * limitations under the License.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Context, Service } from '@deepseek-ai/cordis'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { PowerContextClient } from '../../src/client.ts'
+import * as plugin from '../../src/index.ts'
+import { GUIDANCE } from '../../src/skill.ts'
+import { PROJECT_CONTEXT_SKILL } from '../../src/skill-body.ts'
 import { startPowerContextServer } from '../../scripts/e2e-server.mjs'
+
+vi.mock('../../src/peers.ts', () => ({
+  loadPeer: async (specifier: string) => {
+    if (specifier === '@deepseek-ai/dsh-tools') {
+      return { defineTool: (definition: Record<string, unknown>) => definition }
+    }
+    if (specifier === '@deepseek-ai/dsh-llm') {
+      return { createUserMessage: (input: unknown) => input }
+    }
+    throw new Error(`unexpected peer ${specifier}`)
+  },
+}))
 
 const SCOPE_ID = 'project:dsh-e2e'
 const TEXT = 'Keep the DSH plugin on the public HTTP contract.'
+const REQUIRED_SERVICES = ['tools', 'agents', 'commands', 'skills', 'systemPrompt'] as const
+
+type RequiredService = typeof REQUIRED_SERVICES[number]
+type PcHandler = (invocation: {
+  rawInput: string
+  signal: AbortSignal
+  agent: { session: { header: { cwd?: string } } }
+}) => Promise<{ kind: string; text: string }>
+
+type CommandDefinition = { name: string; handler: PcHandler }
+type SkillRegistration = { name: string; content: string }
+type PromptSection = { name: string; text: string }
+
+type Registrations = {
+  tools: Record<string, unknown>[]
+  commands: CommandDefinition[]
+  skills: SkillRegistration[]
+  sections: PromptSection[]
+}
+
+abstract class RegistrationService<T> extends Service {
+  constructor(ctx: Context, name: string, private readonly registrations: T[]) {
+    super(ctx, name)
+  }
+
+  protected registerOwned(value: T, label: string): () => void {
+    return this.ctx.effect(() => {
+      this.registrations.push(value)
+      return () => {
+        const index = this.registrations.indexOf(value)
+        if (index >= 0) this.registrations.splice(index, 1)
+      }
+    }, label)
+  }
+}
+
+class ToolsService extends RegistrationService<Record<string, unknown>> {
+  constructor(ctx: Context, registrations: Record<string, unknown>[]) {
+    super(ctx, 'tools', registrations)
+  }
+
+  register(tool: Record<string, unknown>): () => void {
+    return this.registerOwned(tool, 'tools.register()')
+  }
+}
+
+class AgentsService extends Service {
+  constructor(ctx: Context) {
+    super(ctx, 'agents')
+  }
+}
+
+class CommandsService extends RegistrationService<CommandDefinition> {
+  constructor(ctx: Context, registrations: CommandDefinition[]) {
+    super(ctx, 'commands', registrations)
+  }
+
+  register(definition: CommandDefinition): () => void {
+    return this.registerOwned(definition, 'commands.register()')
+  }
+}
+
+class SkillsService extends RegistrationService<SkillRegistration> {
+  constructor(ctx: Context, registrations: SkillRegistration[]) {
+    super(ctx, 'skills', registrations)
+  }
+
+  register(skill: SkillRegistration): () => void {
+    return this.registerOwned(skill, 'skills.register()')
+  }
+}
+
+class SystemPromptService extends RegistrationService<PromptSection> {
+  constructor(ctx: Context, registrations: PromptSection[]) {
+    super(ctx, 'systemPrompt', registrations)
+  }
+
+  section(section: PromptSection): () => void {
+    return this.registerOwned(section, 'systemPrompt.section()')
+  }
+}
+
+function emptyRegistrations(): Registrations {
+  return { tools: [], commands: [], skills: [], sections: [] }
+}
+
+class PluginHarness {
+  readonly ctx = new Context()
+  readonly registrations = emptyRegistrations()
+  readonly fiber
+  private readonly providers = new Map<RequiredService, ReturnType<Context['plugin']>>()
+
+  constructor(baseUrl: string, scopeId: string) {
+    this.fiber = this.ctx.plugin(plugin, {
+      baseUrl,
+      scopeId,
+      requestTimeoutMs: 5000,
+      capturePrompts: true,
+    })
+  }
+
+  async provide(name: RequiredService): Promise<void> {
+    if (this.providers.has(name)) throw new Error(`service ${name} is already provided`)
+    let provider: ReturnType<Context['plugin']>
+    if (name === 'tools') {
+      provider = this.ctx.plugin(ToolsService, this.registrations.tools)
+    } else if (name === 'agents') {
+      provider = this.ctx.plugin(AgentsService)
+    } else if (name === 'commands') {
+      provider = this.ctx.plugin(CommandsService, this.registrations.commands)
+    } else if (name === 'skills') {
+      provider = this.ctx.plugin(SkillsService, this.registrations.skills)
+    } else {
+      provider = this.ctx.plugin(SystemPromptService, this.registrations.sections)
+    }
+    this.providers.set(name, provider)
+    await provider
+  }
+
+  async provideAll(): Promise<void> {
+    for (const name of REQUIRED_SERVICES) await this.provide(name)
+    await this.fiber
+  }
+
+  async remove(name: RequiredService): Promise<void> {
+    const provider = this.providers.get(name)
+    if (!provider) throw new Error(`service ${name} is not provided`)
+    this.providers.delete(name)
+    await provider.dispose()
+    await this.fiber.await()
+  }
+
+  commandHandler(): PcHandler {
+    const command = this.registrations.commands.find(item => item.name === 'pc')
+    if (!command) throw new Error('expected /pc handler')
+    return command.handler
+  }
+
+  async dispose(): Promise<void> {
+    await this.fiber.dispose()
+    for (const provider of [...this.providers.values()].reverse()) {
+      await provider.dispose()
+    }
+    this.providers.clear()
+  }
+}
+
+function registrationCounts(registrations: Registrations) {
+  return {
+    tools: registrations.tools.length,
+    commands: registrations.commands.length,
+    skills: registrations.skills.length,
+    sections: registrations.sections.length,
+  }
+}
+
+function invokePc(handler: PcHandler, rawInput: string) {
+  return handler({
+    rawInput,
+    signal: AbortSignal.timeout(5000),
+    agent: { session: { header: {} } },
+  })
+}
+
+function parseCommandPayload(text: string): { ok: boolean; data?: unknown } {
+  return JSON.parse(text) as { ok: boolean; data?: unknown }
+}
+
+async function withHarness<T>(
+  baseUrl: string,
+  callback: (harness: PluginHarness) => Promise<T>,
+): Promise<T> {
+  const harness = new PluginHarness(baseUrl, SCOPE_ID)
+  try {
+    return await callback(harness)
+  } finally {
+    await harness.dispose()
+  }
+}
 
 describe('plugin HTTP call-through without a model', () => {
   let server
@@ -77,5 +272,81 @@ describe('plugin HTTP call-through without a model', () => {
       metadata: { origin: 'dsh', event: 'e2e' },
     })
     expect(captured.kind).toBe('json')
+  })
+
+  it('declares every DSH service required by apply', () => {
+    expect(plugin.inject).toEqual(REQUIRED_SERVICES)
+  })
+
+  it('waits for every dependency before mounting all plugin surfaces', async () => {
+    await withHarness(server.baseUrl, async (harness) => {
+      await Promise.resolve()
+      expect(registrationCounts(harness.registrations)).toEqual({
+        tools: 0, commands: 0, skills: 0, sections: 0,
+      })
+
+      for (const name of REQUIRED_SERVICES.slice(0, -1)) {
+        await harness.provide(name)
+        expect(registrationCounts(harness.registrations)).toEqual({
+          tools: 0, commands: 0, skills: 0, sections: 0,
+        })
+      }
+
+      await harness.provide(REQUIRED_SERVICES.at(-1)!)
+      await harness.fiber
+      expect(harness.registrations.tools.length).toBeGreaterThan(0)
+      expect(harness.registrations.commands.map(item => item.name)).toEqual(['pc'])
+      expect(harness.registrations.skills).toEqual([expect.objectContaining({
+        name: 'project-context',
+        content: PROJECT_CONTEXT_SKILL,
+      })])
+      expect(harness.registrations.sections).toEqual([expect.objectContaining({
+        name: 'tool:powercontext',
+        text: GUIDANCE,
+      })])
+      const status = await invokePc(harness.commandHandler(), '')
+      expect(status.kind).toBe('success')
+      expect(status.text).toContain(`scope=${SCOPE_ID}`)
+    })
+  })
+
+  it('runs /pc doctor, stats, capabilities, and review against the live server', async () => {
+    await withHarness(server.baseUrl, async (harness) => {
+      await harness.provideAll()
+      const handler = harness.commandHandler()
+      const doctor = await invokePc(handler, 'doctor')
+      expect(doctor.kind).toBe('success')
+      expect(parseCommandPayload(doctor.text).ok).toBe(true)
+
+      const stats = await invokePc(handler, 'stats')
+      expect(stats.kind).toBe('success')
+      expect(parseCommandPayload(stats.text).ok).toBe(true)
+
+      const capabilities = await invokePc(handler, 'capabilities')
+      expect(capabilities.kind).toBe('success')
+      expect(parseCommandPayload(capabilities.text).ok).toBe(true)
+
+      const review = await invokePc(handler, 'review')
+      expect(review.kind).toBe('success')
+      expect(parseCommandPayload(review.text).ok).toBe(true)
+    })
+  })
+
+  it('unmounts and restores every surface when a required service changes', async () => {
+    await withHarness(server.baseUrl, async (harness) => {
+      await harness.provideAll()
+      const activeCounts = registrationCounts(harness.registrations)
+
+      await harness.remove('commands')
+      expect(registrationCounts(harness.registrations)).toEqual({
+        tools: 0, commands: 0, skills: 0, sections: 0,
+      })
+      expect(harness.fiber.getEffects()).toEqual([])
+
+      await harness.provide('commands')
+      await harness.fiber
+      expect(registrationCounts(harness.registrations)).toEqual(activeCounts)
+      expect(harness.registrations.commands.map(item => item.name)).toEqual(['pc'])
+    })
   })
 })

--- a/integrations/dsh/plugins/powercontext/tests/e2e/call-through.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/e2e/call-through.spec.ts
@@ -57,8 +57,11 @@ type Registrations = {
 }
 
 abstract class RegistrationService<T> extends Service {
-  constructor(ctx: Context, name: string, private readonly registrations: T[]) {
+  private readonly registrations: T[]
+
+  constructor(ctx: Context, name: string, registrations: T[]) {
     super(ctx, name)
+    this.registrations = registrations
   }
 
   protected registerOwned(value: T, label: string): () => void {

--- a/integrations/dsh/plugins/powercontext/tests/operations-coverage.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/operations-coverage.spec.ts
@@ -51,7 +51,7 @@ describe('operations coverage', () => {
       location: 'body',
       scope: true,
     })
-    expect(OPERATIONS.get_handoff_report.scope).toBe(false)
+    expect(OPERATIONS.get_handoff_report.scope).toBe(true)
     expect(OPERATIONS.get_capabilities.location).toBeNull()
   })
 

--- a/integrations/dsh/plugins/powercontext/tests/plugin-surfaces.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/plugin-surfaces.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { PowerContextClient } from '../src/client.ts'
+import { registerCommands } from '../src/commands.ts'
+import { resolveConfig } from '../src/config.ts'
+import { requireService } from '../src/dsh-service.ts'
+import { inject } from '../src/index.ts'
+import type { PluginRuntime } from '../src/invoke.ts'
+import { GUIDANCE, registerGuidance, registerSkill } from '../src/skill.ts'
+import { PROJECT_CONTEXT_SKILL } from '../src/skill-body.ts'
+
+function runtime(): PluginRuntime {
+  const config = resolveConfig({ baseUrl: 'http://127.0.0.1:8000' })
+  return {
+    client: new PowerContextClient({ baseUrl: config.baseUrl, requestTimeoutMs: 1000, fetch: async () => new Response('{}') }),
+    config,
+    resolveScope: async () => 'project:demo',
+    log: () => undefined,
+  }
+}
+
+describe('plugin inject contract', () => {
+  it('declares every DSH service the plugin registers against', () => {
+    expect(inject).toEqual(['tools', 'agents', 'commands', 'skills', 'systemPrompt'])
+  })
+})
+
+describe('requireService', () => {
+  it('returns the named service when present', () => {
+    expect(requireService({ get: (name) => name === 'commands' ? { ok: true } : undefined }, 'commands')).toEqual({ ok: true })
+  })
+
+  it('rejects a missing service instead of returning undefined', () => {
+    expect(() => requireService({ get: () => undefined }, 'commands')).toThrow(
+      'powercontext-dsh requires the "commands" service',
+    )
+  })
+})
+
+describe('registerCommands', () => {
+  it('fails loudly when the commands service is missing', () => {
+    expect(() => registerCommands({ get: () => undefined }, runtime())).toThrow(/commands/)
+  })
+
+  it('registers /pc when the commands service is present', () => {
+    const registered: Array<{ name: string }> = []
+    registerCommands({
+      get: (name) => name === 'commands'
+        ? { register: (definition: { name: string }) => registered.push(definition) }
+        : undefined,
+    }, runtime())
+    expect(registered.map((item) => item.name)).toEqual(['pc'])
+  })
+})
+
+describe('registerSkill', () => {
+  it('fails loudly when the skills service is missing', () => {
+    expect(() => registerSkill({ get: () => undefined })).toThrow(/skills/)
+  })
+
+  it('registers project-context when the skills service is present', () => {
+    const registered: Array<{ name: string; content: string; source: string }> = []
+    registerSkill({
+      get: (name) => name === 'skills'
+        ? { register: (skill: { name: string; content: string; source: string }) => registered.push(skill) }
+        : undefined,
+    })
+    expect(registered).toEqual([expect.objectContaining({
+      name: 'project-context',
+      source: 'runtime',
+      content: PROJECT_CONTEXT_SKILL,
+    })])
+  })
+})
+
+describe('plugin surface mount', () => {
+  it('registers /pc, skill, and guidance together when all services exist', () => {
+    const commands: Array<{ name: string }> = []
+    const skills: Array<{ name: string }> = []
+    const sections: Array<{ name: string }> = []
+    const ctx = {
+      get: (name: string) => {
+        if (name === 'commands') return { register: (definition: { name: string }) => commands.push(definition) }
+        if (name === 'skills') return { register: (skill: { name: string }) => skills.push(skill) }
+        if (name === 'systemPrompt') return { section: (section: { name: string }) => sections.push(section) }
+        return undefined
+      },
+    }
+    registerCommands(ctx, runtime())
+    registerSkill(ctx)
+    registerGuidance(ctx)
+    expect(commands.map((item) => item.name)).toEqual(['pc'])
+    expect(skills.map((item) => item.name)).toEqual(['project-context'])
+    expect(sections.map((item) => item.name)).toEqual(['tool:powercontext'])
+  })
+})
+
+describe('registerGuidance', () => {
+  it('fails loudly when the systemPrompt service is missing', () => {
+    expect(() => registerGuidance({ get: () => undefined })).toThrow(/systemPrompt/)
+  })
+
+  it('registers PowerContext guidance when the systemPrompt service is present', () => {
+    const sections: Array<{ name: string; text: string }> = []
+    registerGuidance({
+      get: (name) => name === 'systemPrompt'
+        ? { section: (section: { name: string; text: string }) => sections.push(section) }
+        : undefined,
+    })
+    expect(sections).toEqual([expect.objectContaining({
+      name: 'tool:powercontext',
+      text: GUIDANCE,
+    })])
+  })
+})

--- a/integrations/dsh/plugins/powercontext/tests/sync-openapi.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/sync-openapi.spec.ts
@@ -25,6 +25,11 @@ const originalEnv = {
   POWERCONTEXT_ROOT: process.env.POWERCONTEXT_ROOT,
 }
 
+function clearOverrides() {
+  delete process.env.POWERCONTEXT_OPENAPI
+  delete process.env.POWERCONTEXT_ROOT
+}
+
 afterEach(() => {
   if (originalEnv.POWERCONTEXT_OPENAPI === undefined) delete process.env.POWERCONTEXT_OPENAPI
   else process.env.POWERCONTEXT_OPENAPI = originalEnv.POWERCONTEXT_OPENAPI
@@ -50,5 +55,31 @@ describe('resolveOpenApiPath', () => {
     process.env.POWERCONTEXT_ROOT = root
     expect(resolveOpenApiPath()).toBe(yamlPath)
     expect(resolvePowerContextRoot()).toBe(root)
+  })
+
+  it('prefers the repository contract over the plugin fallback', () => {
+    const checkout = mkdtempSync(join(tmpdir(), 'pc-checkout-'))
+    const pluginRoot = join(checkout, 'integrations', 'dsh', 'plugins', 'powercontext')
+    const repositoryYaml = join(checkout, 'openapi', 'powercontext.yaml')
+    const fallbackYaml = join(pluginRoot, 'openapi', 'powercontext.yaml')
+    mkdirSync(join(checkout, 'openapi'), { recursive: true })
+    mkdirSync(join(pluginRoot, 'openapi'), { recursive: true })
+    writeFileSync(repositoryYaml, 'openapi: 3.1.0\ninfo:\n  title: repository\n')
+    writeFileSync(fallbackYaml, 'openapi: 3.1.0\ninfo:\n  title: fallback\n')
+    clearOverrides()
+
+    expect(resolvePowerContextRoot(pluginRoot)).toBe(checkout)
+    expect(resolveOpenApiPath(pluginRoot)).toBe(repositoryYaml)
+  })
+
+  it('uses the plugin contract as a standalone fallback', () => {
+    const pluginRoot = mkdtempSync(join(tmpdir(), 'pc-standalone-'))
+    const fallbackYaml = join(pluginRoot, 'openapi', 'powercontext.yaml')
+    mkdirSync(join(pluginRoot, 'openapi'))
+    writeFileSync(fallbackYaml, 'openapi: 3.1.0\n')
+    clearOverrides()
+
+    expect(resolvePowerContextRoot(pluginRoot)).toBeUndefined()
+    expect(resolveOpenApiPath(pluginRoot)).toBe(fallbackYaml)
   })
 })


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1370.

# Rationale for this change

The DSH plugin used five runtime services but declared only `tools` and `agents` in its top-level Cordis injection contract. If `commands`, `skills`, or `systemPrompt` was absent during `apply()`, registration silently returned and left a partially mounted plugin. Because those services were outside the injection lifecycle, later startup, replacement, or HMR did not reliably restore the skipped surfaces.

The plugin is incomplete without any of these services. Declaring all five lets Cordis enforce readiness and lifecycle ownership: the plugin waits for every dependency, disposes as a unit when one disappears, and remounts as a unit when it returns.

# What changes are included in this PR?

- Declare `tools`, `agents`, `commands`, `skills`, and `systemPrompt` as required plugin services.
- Add a shared `requireService()` guard so invalid direct registration paths fail visibly instead of silently returning.
- Add focused registration contract tests for `/pc`, the `project-context` skill, and system-prompt guidance.
- Upgrade the DSH call-through suite to install the plugin through a real Cordis `Context` and verify pending, mount, dependency removal, remount, and live `/pc` command behavior.
- Pin Cordis 4.0.1 as a development dependency so the lifecycle regression test runs against the DSH-compatible runtime contract.
- Make the repository OpenAPI contract take precedence during monorepo builds while retaining the plugin copy as a standalone fallback.
- Synchronize the standalone OpenAPI copy, regenerate the operation table and bundle, and normalize generated EOF newlines so release builds are reproducible.
- Add a dedicated DSH CI job that tests before build, builds, verifies zero generated drift, tests again, and runs the Cordis e2e suite.

# Are there any user-facing changes?

Yes. `/pc`, the project-context skill, tool registrations, recall guidance, and the pre-step hook now mount and unmount atomically. Profiles that omit a required service remain pending instead of appearing healthy with silently missing functionality. Release bundles also retain the current repository API operation metadata. There is no configuration format or persisted-data change.

# How was this change tested?

- `uv lock --locked`
- `uv run prek run -a`
- `uv run python scripts/generate_api.py --check`
- `uv run python scripts/generate_js_operations.py --check`
- `uv run python -m pytest tests/test_api_contract.py tests/test_js_operations.py` (29 passed)
- `uv run python -m pytest tests/e2e/test_dsh_http_chain.py tests/test_dsh_cli.py -q` (8 passed)
- `pnpm test` before and after `pnpm build` (72 passed each)
- `pnpm test:e2e` (8 passed)
- generated OpenAPI, operation table, and bundle remain unchanged after `pnpm build`
- `pnpm pack:release`, with the packed bundle verified to retain `list_handoff_report_known_scopes` and `get_handoff_report.scope = true`
- `pnpm test && pnpm run typecheck` in `integrations/pi/plugins/powercontext` (29 passed; type check passed)
- `uv run zensical build -s` from a clean worktree

# AI usage statement

OpenAI Codex was used to review the Cordis/DSH lifecycle and release-generation contracts, implement the fixes and regression tests, and run validation. The resulting diff, generated artifacts, package contents, and test behavior were manually reviewed before submission.