### PR TITLE
fix(opencode): keep interrupted plugin installs recoverable

### DIFF
--- a/src/powercontext/cli/opencode.py
+++ b/src/powercontext/cli/opencode.py
@@ -236,8 +236,10 @@ def _install_plugin(source: Path, target: Path) -> None:
             json.dumps({"schema": 1, "owner": "powercontext", "integration": "opencode-plugin"}, indent=2) + "\n",
             encoding="utf-8",
         )
-        os.replace(staging, target)
+        # Install the ownership manifest first: an interruption then leaves a manifest without a
+        # plugin, which the next setup run replaces instead of an unowned plugin conflict.
         os.replace(manifest_staging, manifest)
+        os.replace(staging, target)
     except OSError as error:
         with suppress(OSError):
             staging.unlink()

--- a/tests/test_opencode_cli.py
+++ b/tests/test_opencode_cli.py
@@ -221,6 +221,42 @@ def test_opencode_skill_refresh_replaces_only_an_owned_installation(tmp_path: Pa
     assert not list(target.parent.glob(".project-context.*"))
 
 
+def test_interrupted_plugin_install_recovers_on_retry(tmp_path: Path, monkeypatch) -> None:
+    import powercontext.cli.opencode as opencode_cli
+
+    source = tmp_path / "index.js"
+    source.write_text("export default {}\n", encoding="utf-8")
+    target = tmp_path / "config" / "plugins" / "powercontext-opencode.js"
+    manifest = target.parent / ".powercontext-opencode.json"
+    real_replace = os.replace
+    replacements = 0
+
+    def interrupted_replace(first: Path, second: Path) -> None:
+        nonlocal replacements
+        replacements += 1
+        if replacements == 2:
+            raise OSError
+        real_replace(first, second)
+
+    monkeypatch.setattr(opencode_cli.os, "replace", interrupted_replace)
+    with pytest.raises(SetupError):
+        opencode_cli._install_plugin(source, target)
+
+    assert manifest.is_file()
+    assert not target.exists()
+    assert not list(target.parent.glob("*.tmp"))
+
+    monkeypatch.setattr(opencode_cli.os, "replace", real_replace)
+    opencode_cli._install_plugin(source, target)
+
+    assert target.read_text(encoding="utf-8") == "export default {}\n"
+    assert json.loads(manifest.read_text(encoding="utf-8")) == {
+        "schema": 1,
+        "owner": "powercontext",
+        "integration": "opencode-plugin",
+    }
+
+
 def test_setup_opencode_refuses_unowned_skill(tmp_path: Path, monkeypatch) -> None:
     import powercontext.cli.opencode as opencode_cli
 


### PR DESCRIPTION
# Rationale for this change

`_install_plugin` placed the plugin bundle before its ownership manifest. An interruption between the two atomic renames left the plugin installed without `.powercontext-opencode.json`: every later `setup opencode` run then reported an unowned-plugin conflict until the file was deleted by hand.

# What changes are included in this PR?

- Install the ownership manifest before the plugin bundle. The manifest content is constant, so the interrupted state becomes a manifest without a plugin, which the next setup run replaces instead of refusing to overwrite.
- Add a regression test that interrupts the second rename and asserts a retry completes without manual cleanup.

# Are there any user-facing changes?

Yes. A setup interrupted mid-install is now self-healing on retry instead of requiring manual deletion of the installed plugin.

# How was this change tested?

- `uv run pytest -q tests/test_opencode_cli.py` — 14 passed.
- Full suite: 908 passed, 9 skipped (the OpenCode host e2e fails identically on stock master with locally installed OpenCode 1.18.23 due to the documented environment limitation).
- Mutation check: reverting the ordering change makes the new test fail.

# AI usage statement

Prepared with an AI coding assistant; the change was verified with automated tests and mutation checks as listed above.