### PR TITLE
fix(server): keep successful Skill publication responses intact

### DIFF
--- a/src/powercontext/server/web.py
+++ b/src/powercontext/server/web.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Mapping
 from functools import cache
 from typing import Literal
@@ -28,6 +29,7 @@ from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, PackageLoader, select_autoescape
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from powercontext._logging import log_safely
 from powercontext.artifacts import ArtifactRef
 from powercontext.builtin.artifacts.skill import AgentKind, AgentSkillTarget, ExternalSkillResolutionStatus
 from powercontext.builtin.artifacts.skill.projection import (
@@ -40,6 +42,8 @@ from powercontext.builtin.review import CandidateStatus
 from powercontext.builtin.runtime import GetArtifactCandidateRequest, GetSkillRequest, ListExternalSkillsRequest
 from powercontext.http import ErrorDetail, ErrorResponse
 from powercontext.limits import MAX_ARTIFACT_ID_LENGTH
+
+logger = logging.getLogger(__name__)
 
 _PAGE_HEADERS = {
     "Cache-Control": "no-store",
@@ -160,7 +164,14 @@ class _DashboardSkillProjectionRoutes:
                 "The approved managed Skill could not be published to the configured Agent target.",
                 details={"reason": str(error)},
             )
-        await application.external_skills.for_scope(request.scope_id).scan()
+        # The publication itself succeeded above; registry bookkeeping failure must not turn the
+        # response into a 500 because _skill_projection_response reports on-disk state anyway.
+        try:
+            await application.external_skills.for_scope(request.scope_id).scan()
+        except Exception as error:
+            log_safely(
+                logger, logging.WARNING, "PowerContext external Skill scan failed after publication", exc_info=error
+            )
         return await _skill_projection_response(application, request.scope_id, skill, self._targets)
 
 

--- a/src/powercontext/server/web.py
+++ b/src/powercontext/server/web.py
@@ -371,13 +371,19 @@ async def _skill_projection_response(
     skill,
     targets_config: tuple[AgentSkillTarget, ...],
 ) -> DashboardSkillProjection:
-    registrations = (
-        ()
-        if not targets_config
-        else await application.external_skills.for_scope(scope_id).list(
-            ListExternalSkillsRequest(include_unavailable=True)
-        )
-    )
+    if not targets_config:
+        registrations = ()
+        # Registry discovery is best-effort bookkeeping; when it cannot be read (for example an
+        # unavailable registry database), report on-disk state with stale discovery instead of
+        # failing the whole response after the projection was already published.
+    else:
+        try:
+            registrations = await application.external_skills.for_scope(scope_id).list(
+                ListExternalSkillsRequest(include_unavailable=True)
+            )
+        except Exception as error:
+            log_safely(logger, logging.WARNING, "PowerContext external Skill registry discovery failed", exc_info=error)
+            registrations = ()
     targets = []
     for target in targets_config:
         status = await asyncio.to_thread(inspect_skill_projection, skill.as_ref(), skill.content, target)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -490,6 +490,111 @@ def test_publish_reports_success_when_post_publish_scan_fails(tmp_path, caplog) 
     assert len(scan_failures) == 1
 
 
+class _RegistryUnavailableScopedExternalSkills:
+    """Delegate everything to the real scoped application except registry reads and writes."""
+
+    def __init__(self, inner) -> None:
+        self._inner = inner
+
+    async def scan(self):
+        raise OSError
+
+    async def list(self, *args, **kwargs):
+        raise OSError
+
+    def __getattr__(self, name: str):
+        return getattr(self._inner, name)
+
+
+class _RegistryUnavailableExternalSkills:
+    def __init__(self, inner) -> None:
+        self._inner = inner
+
+    def for_scope(self, scope_id: str):
+        return _RegistryUnavailableScopedExternalSkills(self._inner.for_scope(scope_id))
+
+
+def test_publish_reports_stale_discovery_when_registry_database_is_unavailable(tmp_path, caplog) -> None:
+    codex_skill_root = tmp_path / "repository" / ".agents" / "skills"
+    settings = ServerSettings(
+        auth=BearerAuthConfig(enabled=True, token=SecretStr("dashboard-secret")),
+        dashboard=DashboardConfig(
+            enabled=True,
+            scopes=[DashboardScopeConfig(scope_id="project:powercontext", display_name="PowerContext")],
+        ),
+        database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'publish-registry-down.db'}"),
+        external_skills=ExternalSkillsConfig(
+            host_id="dashboard-test",
+            targets=(
+                AgentSkillTarget(
+                    target_id="codex-project",
+                    agent_kind="codex",
+                    installation_scope="project",
+                    path=codex_skill_root,
+                    allow_managed_publish=True,
+                ),
+            ),
+        ),
+        mcp=McpConfig(enabled=False),
+    )
+    app = create_server_app(settings=settings)
+
+    with TestClient(app) as client, caplog.at_level(logging.WARNING):
+        source = client.post(
+            "/v1/sources/content",
+            headers=_AUTH_HEADERS,
+            json={
+                "scope_id": "project:powercontext",
+                "source_id": "managed-skill-evidence",
+                "content": "The contract workflow was reviewed and its validation passed.",
+            },
+        ).json()["source"]
+        candidate = client.post(
+            "/v1/skill/propose",
+            headers=_AUTH_HEADERS,
+            json={
+                "scope_id": "project:powercontext",
+                "proposal": {
+                    "name": "review-contract-change",
+                    "description": "Use when changing the reviewed public contract.",
+                    "instructions": "Regenerate the client and inspect the contract diff.",
+                    "validation": ["Run the contract tests."],
+                },
+                "source_refs": [source],
+                "artifact_refs": [],
+            },
+        ).json()
+        approved = client.post(
+            "/v1/artifact-candidates/approve",
+            headers=_AUTH_HEADERS,
+            json={
+                "scope_id": "project:powercontext",
+                "candidate_id": candidate["candidate_id"],
+                "expected_version": candidate["version"],
+            },
+        ).json()
+        selection = {
+            "scope_id": "project:powercontext",
+            "candidate_id": approved["candidate_id"],
+            "artifact": approved["result_artifact"],
+        }
+        application = app.state.application
+        application.external_skills = _RegistryUnavailableExternalSkills(application.external_skills)
+        published = client.post(
+            "/dashboard/skill-projections/publish",
+            headers=_AUTH_HEADERS,
+            json={**selection, "target_id": "codex-project"},
+        )
+
+    assert published.status_code == 200
+    assert published.json()["targets"][0]["state"] == "current"
+    assert published.json()["targets"][0]["discovery"] == "unavailable"
+    assert codex_skill_root.joinpath("review-contract-change").joinpath("SKILL.md").is_file()
+    warnings = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+    assert sum("scan failed" in message for message in warnings) == 1
+    assert sum("discovery failed" in message for message in warnings) == 1
+
+
 def test_handoff_report_page_is_available_without_the_statistics_dashboard(tmp_path) -> None:
     database_path = tmp_path / "handoff-dashboard.db"
     disabled_app = create_server_app(settings=_handoff_report_settings(database_path, enabled=False))

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -388,6 +388,108 @@ def test_review_publishes_an_approved_managed_skill_into_configured_agent_target
     }
 
 
+class _ScanFailingScopedExternalSkills:
+    """Delegate everything to the real scoped application except scan."""
+
+    def __init__(self, inner) -> None:
+        self._inner = inner
+
+    async def scan(self):
+        raise OSError
+
+    def __getattr__(self, name: str):
+        return getattr(self._inner, name)
+
+
+class _ScanFailingExternalSkills:
+    def __init__(self, inner) -> None:
+        self._inner = inner
+
+    def for_scope(self, scope_id: str):
+        return _ScanFailingScopedExternalSkills(self._inner.for_scope(scope_id))
+
+
+def test_publish_reports_success_when_post_publish_scan_fails(tmp_path, caplog) -> None:
+    codex_skill_root = tmp_path / "repository" / ".agents" / "skills"
+    settings = ServerSettings(
+        auth=BearerAuthConfig(enabled=True, token=SecretStr("dashboard-secret")),
+        dashboard=DashboardConfig(
+            enabled=True,
+            scopes=[DashboardScopeConfig(scope_id="project:powercontext", display_name="PowerContext")],
+        ),
+        database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'publish-scan-failure.db'}"),
+        external_skills=ExternalSkillsConfig(
+            host_id="dashboard-test",
+            targets=(
+                AgentSkillTarget(
+                    target_id="codex-project",
+                    agent_kind="codex",
+                    installation_scope="project",
+                    path=codex_skill_root,
+                    allow_managed_publish=True,
+                ),
+            ),
+        ),
+        mcp=McpConfig(enabled=False),
+    )
+    app = create_server_app(settings=settings)
+
+    with TestClient(app) as client, caplog.at_level(logging.WARNING):
+        source = client.post(
+            "/v1/sources/content",
+            headers=_AUTH_HEADERS,
+            json={
+                "scope_id": "project:powercontext",
+                "source_id": "managed-skill-evidence",
+                "content": "The contract workflow was reviewed and its validation passed.",
+            },
+        ).json()["source"]
+        candidate = client.post(
+            "/v1/skill/propose",
+            headers=_AUTH_HEADERS,
+            json={
+                "scope_id": "project:powercontext",
+                "proposal": {
+                    "name": "review-contract-change",
+                    "description": "Use when changing the reviewed public contract.",
+                    "instructions": "Regenerate the client and inspect the contract diff.",
+                    "validation": ["Run the contract tests."],
+                },
+                "source_refs": [source],
+                "artifact_refs": [],
+            },
+        ).json()
+        approved = client.post(
+            "/v1/artifact-candidates/approve",
+            headers=_AUTH_HEADERS,
+            json={
+                "scope_id": "project:powercontext",
+                "candidate_id": candidate["candidate_id"],
+                "expected_version": candidate["version"],
+            },
+        ).json()
+        selection = {
+            "scope_id": "project:powercontext",
+            "candidate_id": approved["candidate_id"],
+            "artifact": approved["result_artifact"],
+        }
+        application = app.state.application
+        application.external_skills = _ScanFailingExternalSkills(application.external_skills)
+        published = client.post(
+            "/dashboard/skill-projections/publish",
+            headers=_AUTH_HEADERS,
+            json={**selection, "target_id": "codex-project"},
+        )
+
+    assert published.status_code == 200
+    assert published.json()["targets"][0]["state"] == "current"
+    assert codex_skill_root.joinpath("review-contract-change").joinpath("SKILL.md").is_file()
+    scan_failures = [
+        record for record in caplog.records if record.levelno == logging.WARNING and "scan failed" in record.message
+    ]
+    assert len(scan_failures) == 1
+
+
 def test_handoff_report_page_is_available_without_the_statistics_dashboard(tmp_path) -> None:
     database_path = tmp_path / "handoff-dashboard.db"
     disabled_app = create_server_app(settings=_handoff_report_settings(database_path, enabled=False))


### PR DESCRIPTION
# Rationale for this change

The Dashboard publish route ran the external Skill registry scan outside error handling. If the scan raised (filesystem or registry errors), the client received a 500 even though the Skill had already been published to the Agent target, and there was no signal about what had failed.

# What changes are included in this PR?

- Wrap the post-publication scan in logging-and-continue: the projection is already written to disk, so a scan failure is logged as a warning instead of failing the request.
- Add a regression test that makes `scan()` raise, asserts publish still returns 200 with `state: current`, verifies the file landed on disk, and checks exactly one warning is logged.

# Are there any user-facing changes?

Yes. A registry scan failure after a successful publication now returns the normal Dashboard response (with registry discovery possibly stale) plus a logged warning, rather than an unrelated 500.

# How was this change tested?

- `uv run pytest -q tests/test_dashboard.py` — 8 passed.
- Full suite: 908 passed, 9 skipped (the OpenCode host e2e fails identically on stock master with locally installed OpenCode 1.18.23 due to the documented environment limitation).
- Mutation check: reverting the handler change makes the new test fail with the propagated OSError.

# AI usage statement

Prepared with an AI coding assistant; the change was verified with automated tests and mutation checks as listed above.