### PR TITLE
feat(metrics): expose process runtime metrics

### DIFF
--- a/src/powercontext/server/metrics.py
+++ b/src/powercontext/server/metrics.py
@@ -22,7 +22,17 @@ from time import perf_counter
 from typing import Any
 
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
-from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Gauge, Histogram, generate_latest
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    GCCollector,
+    Histogram,
+    PlatformCollector,
+    ProcessCollector,
+    generate_latest,
+)
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from typing_extensions import override
 
@@ -34,6 +44,9 @@ class ServerMetrics:
 
     def __init__(self) -> None:
         self.registry = CollectorRegistry()
+        ProcessCollector(registry=self.registry)
+        PlatformCollector(registry=self.registry)
+        GCCollector(registry=self.registry)
         self.transport_requests = Counter(
             "powercontext_server_transport_requests_total",
             "External transport requests completed by the Server.",

--- a/tests/test_server_metrics.py
+++ b/tests/test_server_metrics.py
@@ -15,12 +15,15 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from typing import Any
 
 import httpx
+import pytest
 from fastapi.testclient import TestClient
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
+from prometheus_client.parser import text_string_to_metric_families
 
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
 from powercontext.builtin.runtime import RuntimeConfig
@@ -89,6 +92,20 @@ def test_metrics_endpoint_is_absent_when_disabled(tmp_path) -> None:
         response = client.get("/metrics")
 
     assert response.status_code == 404
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Prometheus process metrics require Linux procfs")
+def test_metrics_endpoint_exposes_process_cpu_and_memory(tmp_path) -> None:
+    app = create_server_app(settings=_settings(tmp_path / "runtime.db"))
+
+    with TestClient(app) as client:
+        metrics = client.get("/metrics").text
+
+    samples = {
+        sample.name: sample.value for family in text_string_to_metric_families(metrics) for sample in family.samples
+    }
+    assert samples["process_cpu_seconds_total"] >= 0
+    assert samples["process_resident_memory_bytes"] > 0
 
 
 def test_one_off_scope_ids_keep_runtime_scope_cache_bounded(tmp_path) -> None:


### PR DESCRIPTION
## Which issue or RFC does this PR close?

Related to #1214 and RFC 0046.

## Rationale for this change

PowerContext uses a private Prometheus registry, so the Python client default process and runtime metrics were missing.

## What changes are included in this PR?

Registers the official process, platform, and GC collectors. Adds a behavior test confirming that /metrics exposes process CPU and RSS.

## Are there any user-facing changes?

Linux deployments gain standard process and Python runtime metrics. There are no configuration or API changes.

## How was this change tested?

- make check
- make test: 965 passed, 10 skipped
- make docs-test
- Real Server scrape against /metrics

## AI usage statement

Codex with GPT-5 was used for implementation, testing, and PR wording.