### PR TITLE
chore(release): prepare v0.1.0

### DIFF
--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -14,7 +14,23 @@ hide:
 
 <div class="editorial-list release-list pc-listing-list">
   <article class="editorial-row release-entry pc-listing-row">
-    <div class="editorial-meta release-meta pc-listing-meta"><strong>v0.0.2</strong><span>Aug 20, 2026</span><span>Latest release</span></div>
+    <div class="editorial-meta release-meta pc-listing-meta"><strong>v0.1.0</strong><span>Aug 31, 2026</span><span>Latest release</span></div>
+    <div class="editorial-body release-body pc-listing-content">
+      <h2>A broader, safer context runtime</h2>
+      <p>This release expands PowerContext across agent hosts while strengthening local and service deployments.</p>
+      <ul class="release-highlights">
+        <li>Connect Hermes Agent, OpenCode, Pi Coding Agent, OpenClaw, WorkBuddy, Pydantic AI, LangChain, and LangGraph through first-class integrations and diagnostics.</li>
+        <li>Run scheduled processing with tracing, inspect scoped Handoff Reports, and configure PowerContext interactively from the CLI.</li>
+        <li>Use embedded seekDB or bundled sqlite-vec persistence with explicit embedding dimensions and clearer readiness failures.</li>
+        <li>Apply safer transport defaults, secret-safe persistence diagnostics, and more complete installation, deployment, and HTTP API guidance.</li>
+      </ul>
+      <div class="release-install"><code>uv tool install --force "powercontext[cli,server]==0.1.0"</code></div>
+      <div class="listing-actions"><a class="primary-button large" href="https://github.com/oceanbase/powercontext/releases/tag/powercontext-v0.1.0">Read release notes</a><a class="text-link" href="../docs/">Open documentation <span aria-hidden="true">→</span></a></div>
+    </div>
+  </article>
+
+  <article class="editorial-row release-entry pc-listing-row">
+    <div class="editorial-meta release-meta pc-listing-meta"><strong>v0.0.2</strong><span>Aug 20, 2026</span><span>Previous release</span></div>
     <div class="editorial-body release-body pc-listing-content">
       <h2>Work continuity across agents</h2>
       <p>This release adds an evidence-backed workflow for carrying work across sessions and agent hosts.</p>
@@ -30,7 +46,7 @@ hide:
   </article>
 
   <article class="editorial-row release-entry pc-listing-row">
-    <div class="editorial-meta release-meta pc-listing-meta"><strong>v0.0.1</strong><span>Aug 13, 2026</span><span>Previous release</span></div>
+    <div class="editorial-meta release-meta pc-listing-meta"><strong>v0.0.1</strong><span>Aug 13, 2026</span><span>Earlier release</span></div>
     <div class="editorial-body release-body pc-listing-content">
       <h2>First PowerContext release</h2>
       <p>This release establishes durable, project-scoped context across agent sessions.</p>

--- a/docs/zh/changelog/index.md
+++ b/docs/zh/changelog/index.md
@@ -14,7 +14,23 @@ hide:
 
 <div class="editorial-list release-list pc-listing-list">
   <article class="editorial-row release-entry pc-listing-row">
-    <div class="editorial-meta release-meta pc-listing-meta"><strong>v0.0.2</strong><span>2026 年 8 月 20 日</span><span>最新版本</span></div>
+    <div class="editorial-meta release-meta pc-listing-meta"><strong>v0.1.0</strong><span>2026 年 8 月 31 日</span><span>最新版本</span></div>
+    <div class="editorial-body release-body pc-listing-content">
+      <h2>覆盖更广、更安全的上下文运行层</h2>
+      <p>这个版本扩展了 PowerContext 对 Agent host 的覆盖，并增强了本地与服务化部署能力。</p>
+      <ul class="release-highlights">
+        <li>通过正式集成和诊断能力连接 Hermes Agent、OpenCode、Pi Coding Agent、OpenClaw、WorkBuddy、Pydantic AI、LangChain 和 LangGraph。</li>
+        <li>运行带 tracing 的定时处理任务，查看按 scope 划分的 Handoff Report，并通过 CLI 交互式配置 PowerContext。</li>
+        <li>使用嵌入式 seekDB 或内置 sqlite-vec 持久化，显式指定 embedding 维度，并获得更清晰的 readiness 故障信息。</li>
+        <li>应用更安全的传输默认值和不泄露敏感信息的持久化诊断，并获得更完整的安装、部署与 HTTP API 指南。</li>
+      </ul>
+      <div class="release-install"><code>uv tool install --force "powercontext[cli,server]==0.1.0"</code></div>
+      <div class="listing-actions"><a class="primary-button large" href="https://github.com/oceanbase/powercontext/releases/tag/powercontext-v0.1.0">查看发布说明</a><a class="text-link" href="../docs/">打开文档 <span aria-hidden="true">→</span></a></div>
+    </div>
+  </article>
+
+  <article class="editorial-row release-entry pc-listing-row">
+    <div class="editorial-meta release-meta pc-listing-meta"><strong>v0.0.2</strong><span>2026 年 8 月 20 日</span><span>历史版本</span></div>
     <div class="editorial-body release-body pc-listing-content">
       <h2>跨 Agent 的工作连续性</h2>
       <p>这个版本提供基于证据的工作流，用于在不同会话和 Agent host 之间延续工作。</p>

--- a/integrations/dsh/plugins/powercontext/openapi/powercontext.yaml
+++ b/integrations/dsh/plugins/powercontext/openapi/powercontext.yaml
@@ -16,7 +16,7 @@ openapi: 3.0.3
 info:
   title: PowerContext API
   description: Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.
-  version: 0.0.2
+  version: 0.1.0
 security:
   - BearerAuth: []
   - {}

--- a/openapi/powercontext.yaml
+++ b/openapi/powercontext.yaml
@@ -16,7 +16,7 @@ openapi: 3.0.3
 info:
   title: PowerContext API
   description: Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.
-  version: 0.0.2
+  version: 0.1.0
 security:
   - BearerAuth: []
   - {}

--- a/src/powercontext/http/_generated/operations.py
+++ b/src/powercontext/http/_generated/operations.py
@@ -100,7 +100,7 @@ from powercontext.http._generated.models import (
 OPENAPI_VERSION = "3.0.3"
 API_TITLE = "PowerContext API"
 API_DESCRIPTION = "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities."
-API_VERSION = "0.0.2"
+API_VERSION = "0.1.0"
 
 RequestT = TypeVar("RequestT")
 ResponseT = TypeVar("ResponseT")

--- a/src/powercontext/http/_generated/schema.py
+++ b/src/powercontext/http/_generated/schema.py
@@ -7,7 +7,7 @@ OPENAPI_SCHEMA: dict[str, JsonValue] = {
     "info": {
         "title": "PowerContext API",
         "description": "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.",
-        "version": "0.0.2",
+        "version": "0.1.0",
     },
     "paths": {
         "/health/live": {


### PR DESCRIPTION
# Which issue or RFC does this PR close?

N/A — release preparation for PowerContext v0.1.0.

# Rationale for this change

Prepare the repository contract and user-facing release history for PowerContext v0.1.0. The Python distribution version is derived from VCS tags, so the eventual GitHub Release must use `powercontext-v0.1.0`; the shared repository history already contains an unrelated legacy `v0.1.0` tag.

# What changes are included in this PR?

- Bump the canonical OpenAPI contract version to 0.1.0.
- Regenerate the checked-in Python API metadata and synchronize the DeepSeek Harness OpenAPI copy.
- Add bilingual v0.1.0 changelog entries with the release install command, highlights, date, and tag-specific release link.
- Mark the earlier changelog entries as previous releases.

# Are there any user-facing changes?

Yes. The OpenAPI metadata reports version 0.1.0, and the English and Chinese changelogs advertise the new release and installation command. This PR does not introduce a breaking API or persisted-format change.

After this PR is merged, publishing the GitHub Release from tag `powercontext-v0.1.0` will produce the Python package version `0.1.0` through Hatch VCS.

# How was this change tested?

- `make check`
- `make contract-test` (29 passed)
- `make docs-test` (strict bilingual documentation build, no issues)
- In an isolated local clone, tagged the commit as `powercontext-v0.1.0` and verified `uvx --from hatchling --with hatch-vcs hatchling version` returned `0.1.0`.

# AI usage statement

OpenAI Codex was used to inspect the release conventions, update the contract and bilingual changelog, regenerate checked-in artifacts, and run the validation commands listed above.
