### PR TITLE
feat(site): add benchmark results page

### DIFF
--- a/docs/en/benchmarks/index.md
+++ b/docs/en/benchmarks/index.md
@@ -1,0 +1,204 @@
+---
+template: benchmark.html
+page_type: benchmark
+title: Benchmarks
+description: How PowerContext performs on long-term conversational memory and repository-level software engineering evaluations.
+hide:
+  - navigation
+  - toc
+benchmark:
+  hero:
+    label: Benchmark evidence
+    title:
+      - Context,
+      - under pressure.
+    lead: Two public evaluations test long-term recall and repository-level software engineering with measurable outcomes.
+    actions_label: Jump to a benchmark
+    actions:
+      - label: See LoCoMo
+        target: locomo
+      - label: See SWE-bench
+        target: swe-bench
+    visual_label: Key results from the LoCoMo and SWE-bench Pro evaluations
+    results:
+      - name: LoCoMo
+        value: 90.78
+        decimals: 2
+        suffix: "%"
+        display: 90.78%
+        accessible: 90.78 percent accuracy
+        metric: question-answer accuracy
+      - name: SWE-bench Pro
+        value: 86.73
+        decimals: 2
+        suffix: "%"
+        display: 86.73%
+        accessible: 86.73 percent task resolution
+        metric: tasks resolved with PowerContext on
+  orientation:
+    title: Two benchmarks. Two different questions.
+    lead: "Memory quality matters twice: first when an agent must recover what happened, then when it must use context to finish real work."
+    tests:
+      - name: LoCoMo
+        question: Can the system remember a long-running conversation?
+        answer: It measures direct recall, temporal reasoning, multi-step reasoning, and context grounded open-domain answers.
+        target: locomo
+        link: Explore the memory test
+      - name: SWE-bench Pro
+        question: Can an agent turn context into a working patch?
+        answer: It gives Codex a real repository and issue, then grades the resulting patch with executable tests.
+        target: swe-bench
+        link: Explore the coding test
+  locomo:
+    title: LoCoMo tests long-term recall.
+    lead: The public dataset contains long, multi-session conversations. PowerContext is evaluated on the answerable question set, where facts can be separated by many sessions.
+    facts:
+      - label: Conversations
+        value: "10"
+      - label: Scored questions
+        value: 1,540
+      - label: Question types
+        value: "4"
+    categories_label: LoCoMo question categories used in the PowerContext result
+    categories:
+      - name: Single-hop
+        count: "841"
+        description: Recover one fact from the conversation history.
+      - name: Temporal
+        count: "321"
+        description: Reason about dates, order, and duration across sessions.
+      - name: Multi-hop
+        count: "282"
+        description: Connect several facts before producing an answer.
+      - name: Open-domain
+        count: "96"
+        description: Combine conversation evidence with general knowledge.
+    results_title: One run, three ways to carry context.
+    results_lead: Switch metrics to compare PowerContext, PowerMem, and placing the entire conversation in the prompt.
+    tabs_label: LoCoMo result metric
+    metrics:
+      - id: accuracy
+        label: Accuracy
+        callout: +37.88 points
+        callout_detail: above full context
+        chart_label: Accuracy comparison. Higher values are better.
+        direction: Higher is better.
+        rows:
+          - name: PowerContext
+            display: 90.78%
+            scale: 90.78
+          - name: PowerMem
+            display: 87.79%
+            scale: 87.79
+          - name: Full context
+            display: 52.9%
+            scale: 52.9
+      - id: latency
+        label: Search p95
+        callout: 12.4x
+        callout_detail: full context took longer
+        chart_label: Search p95 latency comparison. Lower values are better.
+        direction: Lower is better.
+        rows:
+          - name: PowerContext
+            display: 1.38 s
+            scale: 8.06
+          - name: PowerMem
+            display: 1.44 s
+            scale: 8.41
+          - name: Full context
+            display: 17.12 s
+            scale: 100
+      - id: tokens
+        label: Answer tokens
+        callout: 93.7% fewer
+        callout_detail: than full context
+        chart_label: Answer tokens per question comparison. Lower values are better.
+        direction: Lower is better.
+        rows:
+          - name: PowerContext
+            display: about 1.65k
+            scale: 6.35
+          - name: PowerMem
+            display: about 0.9k
+            scale: 3.46
+          - name: Full context
+            display: 26k
+            scale: 100
+    scope_title: What this result covers
+    scope: The 90.78% result is 1,398 correct answers from 1,540 questions in categories 1-4. It does not claim results for LoCoMo event summarization or multimodal dialogue generation.
+  swe:
+    title: SWE-bench Pro tests whether context changes the patch.
+    lead: Each task starts from a real codebase and issue. Codex edits the repository, and the official task tests decide whether the patch resolves the problem.
+    method:
+      - title: Same task set
+        description: 731 public v2 repository issues in both arms.
+      - title: Same model
+        description: gpt-5.6-sol with medium reasoning in Codex.
+      - title: Controlled switch
+        description: OFF disables plugins. ON enables the installed PowerContext plugin.
+    scores:
+      - label: PowerContext OFF
+        count: 602
+        rate: 82.35% resolved
+        accessible: 602 of 731 tasks resolved with PowerContext off
+        kind: "off"
+      - label: PowerContext ON
+        count: 634
+        rate: 86.73% resolved
+        accessible: 634 of 731 tasks resolved with PowerContext on
+        kind: "on"
+    delta: "+32"
+    delta_label: more tasks resolved
+    delta_accessible: PowerContext on resolved 32 more tasks
+    caption: In the reported paired run, PowerContext ON improved task resolution by 4.38 percentage points.
+    scope_title: How to read this result
+    scope: This is a PowerContext paired evaluation on a pinned SWE-bench Pro public v2 dataset, not an official leaderboard submission. Agent runs are stochastic, so the numbers describe this run rather than a universal guarantee.
+  reading:
+    title: Read each result for the question it answers.
+    lead: The two evaluations share a context theme, but their inputs, outputs, and graders are intentionally different.
+    columns:
+      dimension: Evaluation dimension
+    rows:
+      - dimension: What is tested
+        locomo: Long-term conversational recall and reasoning
+        swe: Repository-level issue resolution
+      - dimension: Input
+        locomo: Multi-session dialogue history and a question
+        swe: A repository, an issue, and a clean task environment
+      - dimension: Output
+        locomo: A grounded natural-language answer
+        swe: A code patch
+      - dimension: Primary score
+        locomo: Judge-rated answer accuracy
+        swe: Official executable tests passed
+  sources:
+    title: Evidence and methodology
+    lead: Follow the dataset, paper, harness, and published PowerContext figures from the original sources.
+    items:
+      - type: Paper
+        label: Evaluating Very Long-Term Conversational Memory of LLM Agents
+        href: https://aclanthology.org/2024.acl-long.747/
+        description: The ACL 2024 paper that defines LoCoMo and its long-term memory tasks.
+      - type: Dataset
+        label: snap-research/locomo
+        href: https://github.com/snap-research/locomo
+        description: The public ten-conversation dataset and annotations.
+      - type: Benchmark
+        label: scaleapi/SWE-bench_Pro-os
+        href: https://github.com/scaleapi/SWE-bench_Pro-os
+        description: The public benchmark repository and official evaluation path.
+      - type: Harness
+        label: PowerContext evaluation console
+        href: https://github.com/oceanbase/powercontext/tree/master/evaluation
+        description: The pinned dataset, OFF and ON arms, isolated runner, and reporting contracts.
+      - type: Results
+        label: Published PowerContext benchmark figures
+        href: https://github.com/oceanbase/powercontext#benchmarks
+        description: The current project README values used on this page.
+  cta:
+    title: Inspect the system behind the scores.
+    lead: PowerContext is open source. Review the implementation, evaluation harness, and contracts directly.
+    label: View on GitHub
+    href: https://github.com/oceanbase/powercontext
+---

--- a/docs/en/blog/index.md
+++ b/docs/en/blog/index.md
@@ -12,10 +12,10 @@ hide:
 <p class="pc-page-lead">Engineering notes and design explanations from the PowerContext maintainers.</p>
 
 <section class="pc-blog-empty pc-listing-list pc-listing-row">
-  <p class="pc-blog-empty__date pc-listing-meta">No posts yet</p>
+  <p class="pc-blog-empty__date pc-listing-meta">Benchmarks</p>
   <div class="pc-listing-content">
-    <h2>Engineering notes will start with implemented work.</h2>
-    <p>The project currently records product and API decisions as RFCs. A post belongs here only when there is a concrete implementation or operating lesson to examine.</p>
-    <p><a href="../rfcs/">Read the current RFCs <span aria-hidden="true">→</span></a></p>
+    <h2>Long-term memory and real repository work, measured.</h2>
+    <p>See what LoCoMo and SWE-bench Pro evaluate, how PowerContext was tested, and what the reported results do and do not prove.</p>
+    <p><a href="../benchmarks/">Explore the benchmarks <span aria-hidden="true">→</span></a></p>
   </div>
 </section>

--- a/docs/zh/benchmarks/index.md
+++ b/docs/zh/benchmarks/index.md
@@ -1,0 +1,204 @@
+---
+template: benchmark.html
+page_type: benchmark
+title: Benchmark
+description: PowerContext 在长程对话记忆与真实仓库软件工程评测中的表现。
+hide:
+  - navigation
+  - toc
+benchmark:
+  hero:
+    label: Benchmark 评测证据
+    title:
+      - 把上下文能力，
+      - 放进压力测试。
+    lead: 两项公开评测，分别检验长程记忆与真实仓库软件工程，并给出可核对的结果。
+    actions_label: 跳转到具体评测
+    actions:
+      - label: 查看 LoCoMo
+        target: locomo
+      - label: 查看 SWE-bench
+        target: swe-bench
+    visual_label: LoCoMo 与 SWE-bench Pro 评测的关键结果
+    results:
+      - name: LoCoMo
+        value: 90.78
+        decimals: 2
+        suffix: "%"
+        display: 90.78%
+        accessible: 问答准确率 90.78%
+        metric: 问答准确率
+      - name: SWE-bench Pro
+        value: 86.73
+        decimals: 2
+        suffix: "%"
+        display: 86.73%
+        accessible: 任务解决率 86.73%
+        metric: 开启 PowerContext 后的任务解决率
+  orientation:
+    title: 两个 Benchmark，回答两个不同问题。
+    lead: Agent 先要找回发生过什么，再要把上下文用于真实工作。两项评测分别检验这两层能力。
+    tests:
+      - name: LoCoMo
+        question: 系统能记住一段长期对话吗？
+        answer: 评测直接回忆、时间推理、多步推理，以及结合对话证据的开放域回答。
+        target: locomo
+        link: 查看记忆评测
+      - name: SWE-bench Pro
+        question: Agent 能把上下文变成可用补丁吗？
+        answer: 给 Codex 一个真实仓库和 Issue，再用可执行测试评判最终补丁。
+        target: swe-bench
+        link: 查看编码评测
+  locomo:
+    title: LoCoMo 检验长程记忆。
+    lead: 公开数据集包含跨多个 Session 的长对话。PowerContext 在可回答问题集上接受评测，相关事实可能相隔很多轮对话。
+    facts:
+      - label: 长对话
+        value: "10"
+      - label: 计分问题
+        value: 1,540
+      - label: 问题类型
+        value: "4"
+    categories_label: PowerContext 结果覆盖的 LoCoMo 问题类型
+    categories:
+      - name: 单跳回忆
+        count: "841"
+        description: 从长对话中找回一条明确事实。
+      - name: 时间推理
+        count: "321"
+        description: 推理跨 Session 的日期、顺序与持续时间。
+      - name: 多跳推理
+        count: "282"
+        description: 连接多条事实后生成答案。
+      - name: 开放域问答
+        count: "96"
+        description: 结合对话证据与通用知识回答。
+    results_title: 同一次评测，三种上下文方式。
+    results_lead: 切换指标，对比 PowerContext、PowerMem，以及把完整对话直接放入 Prompt 的方式。
+    tabs_label: LoCoMo 结果指标
+    metrics:
+      - id: accuracy
+        label: 准确率
+        callout: +37.88 个百分点
+        callout_detail: 相比完整上下文
+        chart_label: 准确率对比，越高越好。
+        direction: 越高越好。
+        rows:
+          - name: PowerContext
+            display: 90.78%
+            scale: 90.78
+          - name: PowerMem
+            display: 87.79%
+            scale: 87.79
+          - name: 完整上下文
+            display: 52.9%
+            scale: 52.9
+      - id: latency
+        label: 搜索 p95
+        callout: 12.4 倍
+        callout_detail: 完整上下文耗时更多
+        chart_label: 搜索 p95 延迟对比，越低越好。
+        direction: 越低越好。
+        rows:
+          - name: PowerContext
+            display: 1.38 秒
+            scale: 8.06
+          - name: PowerMem
+            display: 1.44 秒
+            scale: 8.41
+          - name: 完整上下文
+            display: 17.12 秒
+            scale: 100
+      - id: tokens
+        label: 回答 Token
+        callout: 减少 93.7%
+        callout_detail: 相比完整上下文
+        chart_label: 单个问题的回答 Token 对比，越低越好。
+        direction: 越低越好。
+        rows:
+          - name: PowerContext
+            display: 约 1.65k
+            scale: 6.35
+          - name: PowerMem
+            display: 约 0.9k
+            scale: 3.46
+          - name: 完整上下文
+            display: 26k
+            scale: 100
+    scope_title: 结果覆盖范围
+    scope: 90.78% 来自类别 1-4 的 1,540 个问题，其中答对 1,398 个。该结果不代表 LoCoMo 的事件总结或多模态对话生成任务。
+  swe:
+    title: SWE-bench Pro 检验上下文是否改变补丁结果。
+    lead: 每个任务都从真实代码库与 Issue 开始。Codex 修改仓库，再由任务自带的正式测试判断补丁是否解决问题。
+    method:
+      - title: 相同任务集
+        description: OFF 与 ON 都运行 public v2 的 731 个仓库问题。
+      - title: 相同模型
+        description: Codex 使用 gpt-5.6-sol，推理等级为 medium。
+      - title: 受控开关
+        description: OFF 禁用 Plugin，ON 启用已安装的 PowerContext Plugin。
+    scores:
+      - label: PowerContext OFF
+        count: 602
+        rate: 解决率 82.35%
+        accessible: 关闭 PowerContext 时，731 个任务中解决 602 个
+        kind: "off"
+      - label: PowerContext ON
+        count: 634
+        rate: 解决率 86.73%
+        accessible: 开启 PowerContext 时，731 个任务中解决 634 个
+        kind: "on"
+    delta: "+32"
+    delta_label: 个任务被额外解决
+    delta_accessible: 开启 PowerContext 后多解决 32 个任务
+    caption: 在这次配对运行中，PowerContext ON 将任务解决率提高了 4.38 个百分点。
+    scope_title: 如何理解这组结果
+    scope: 这是 PowerContext 在固定 SWE-bench Pro public v2 数据集上的配对评测，不是官方排行榜提交。Agent 运行存在随机性，因此数字描述的是本次运行，而不是对所有运行的普遍保证。
+  reading:
+    title: 用每项结果回答它真正评测的问题。
+    lead: 两项评测都与上下文有关，但输入、输出与评分方式不同，不能把两个分数直接横向比较。
+    columns:
+      dimension: 评测维度
+    rows:
+      - dimension: 评测内容
+        locomo: 长程对话记忆与推理
+        swe: 仓库级 Issue 修复
+      - dimension: 输入
+        locomo: 多 Session 对话历史与一个问题
+        swe: 代码仓库、Issue 与干净任务环境
+      - dimension: 输出
+        locomo: 有对话依据的自然语言答案
+        swe: 代码补丁
+      - dimension: 主要评分
+        locomo: Judge 判定的答案准确率
+        swe: 正式可执行测试是否通过
+  sources:
+    title: 证据与评测方法
+    lead: 从原始论文、数据集、评测工具与 PowerContext 发布结果核对页面中的结论。
+    items:
+      - type: 论文
+        label: Evaluating Very Long-Term Conversational Memory of LLM Agents
+        href: https://aclanthology.org/2024.acl-long.747/
+        description: 定义 LoCoMo 与长程记忆任务的 ACL 2024 论文。
+      - type: 数据集
+        label: snap-research/locomo
+        href: https://github.com/snap-research/locomo
+        description: 包含十段长对话与标注的公开数据集。
+      - type: Benchmark
+        label: scaleapi/SWE-bench_Pro-os
+        href: https://github.com/scaleapi/SWE-bench_Pro-os
+        description: 公开 Benchmark 仓库与正式评测路径。
+      - type: 评测工具
+        label: PowerContext evaluation console
+        href: https://github.com/oceanbase/powercontext/tree/master/evaluation
+        description: 固定数据集、OFF 与 ON 分组、隔离 Runner 和报告约束。
+      - type: 结果
+        label: PowerContext 已发布的 Benchmark 数据
+        href: https://github.com/oceanbase/powercontext#benchmarks
+        description: 本页面使用的当前项目 README 数据。
+  cta:
+    title: 查看分数背后的系统。
+    lead: PowerContext 完全开源，可直接检查实现、评测工具与核心契约。
+    label: 前往 GitHub
+    href: https://github.com/oceanbase/powercontext
+---

--- a/docs/zh/blog/index.md
+++ b/docs/zh/blog/index.md
@@ -12,10 +12,10 @@ hide:
 <p class="pc-page-lead">由 PowerContext 维护者发布的工程实践与设计解释。</p>
 
 <section class="pc-blog-empty pc-listing-list pc-listing-row">
-  <p class="pc-blog-empty__date pc-listing-meta">尚无文章</p>
+  <p class="pc-blog-empty__date pc-listing-meta">Benchmark</p>
   <div class="pc-listing-content">
-    <h2>工程记录从已经实现的工作开始。</h2>
-    <p>项目目前通过 RFC 记录产品与 API 决策。只有形成具体实现经验或运行结论后，内容才会发布在这里。</p>
-    <p><a href="../rfcs/">阅读当前 RFC <span aria-hidden="true">→</span></a></p>
+    <h2>用结果检验长程记忆与真实仓库工作。</h2>
+    <p>了解 LoCoMo 与 SWE-bench Pro 具体评测什么、PowerContext 如何运行，以及这些结果能证明和不能证明什么。</p>
+    <p><a href="../benchmarks/">查看 Benchmark <span aria-hidden="true">→</span></a></p>
   </div>
 </section>

--- a/theme/powercontext/assets/javascripts/benchmark.js
+++ b/theme/powercontext/assets/javascripts/benchmark.js
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function () {
+  const initialized = new WeakSet();
+
+  function prefersReducedMotion() {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+
+  function animateCounter(element) {
+    if (element.dataset.countAnimated === "true") {
+      return;
+    }
+    element.dataset.countAnimated = "true";
+
+    const target = Number.parseFloat(element.dataset.countTo || "0");
+    const decimals = Number.parseInt(element.dataset.countDecimals || "0", 10);
+    const suffix = element.dataset.countSuffix || "";
+
+    if (!Number.isFinite(target) || prefersReducedMotion()) {
+      element.textContent = `${target.toFixed(decimals)}${suffix}`;
+      return;
+    }
+
+    const formatter = new Intl.NumberFormat(document.documentElement.lang || "en", {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+    const duration = 1050;
+    const startedAt = performance.now();
+    element.textContent = `${formatter.format(0)}${suffix}`;
+
+    function frame(now) {
+      const progress = Math.min((now - startedAt) / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 4);
+      element.textContent = `${formatter.format(target * eased)}${suffix}`;
+      if (progress < 1 && document.documentElement.contains(element)) {
+        window.requestAnimationFrame(frame);
+      }
+    }
+
+    window.requestAnimationFrame(frame);
+  }
+
+  function reveal(element) {
+    element.classList.add("is-visible");
+    element.querySelectorAll("[data-count-to]").forEach(animateCounter);
+    if (element.matches("[data-count-to]")) {
+      animateCounter(element);
+    }
+  }
+
+  function activateMetric(comparison, id, focusTab) {
+    const tabs = Array.from(comparison.querySelectorAll("[data-metric-target]"));
+    const panels = Array.from(comparison.querySelectorAll("[data-metric-panel]"));
+    const activeTab = tabs.find((tab) => tab.dataset.metricTarget === id);
+    const activePanel = panels.find((panel) => panel.dataset.metricPanel === id);
+
+    if (!activeTab || !activePanel) {
+      return;
+    }
+
+    tabs.forEach((tab) => {
+      const selected = tab === activeTab;
+      tab.setAttribute("aria-selected", selected ? "true" : "false");
+      tab.tabIndex = selected ? 0 : -1;
+    });
+    panels.forEach((panel) => {
+      panel.classList.remove("is-active", "is-playing");
+      panel.hidden = panel !== activePanel;
+    });
+
+    activePanel.classList.add("is-active");
+    window.requestAnimationFrame(() => activePanel.classList.add("is-playing"));
+    if (focusTab) {
+      activeTab.focus();
+    }
+  }
+
+  function enhanceMetricComparison(comparison) {
+    comparison.classList.add("is-enhanced");
+    const tabs = Array.from(comparison.querySelectorAll("[data-metric-target]"));
+    const initial = tabs.find((tab) => tab.getAttribute("aria-selected") === "true") || tabs[0];
+    if (!initial) {
+      return;
+    }
+
+    activateMetric(comparison, initial.dataset.metricTarget, false);
+
+    tabs.forEach((tab, index) => {
+      tab.addEventListener("click", () => activateMetric(comparison, tab.dataset.metricTarget, false));
+      tab.addEventListener("keydown", (event) => {
+        let nextIndex = index;
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          nextIndex = (index + 1) % tabs.length;
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          nextIndex = (index - 1 + tabs.length) % tabs.length;
+        } else if (event.key === "Home") {
+          nextIndex = 0;
+        } else if (event.key === "End") {
+          nextIndex = tabs.length - 1;
+        } else {
+          return;
+        }
+        event.preventDefault();
+        activateMetric(comparison, tabs[nextIndex].dataset.metricTarget, true);
+      });
+    });
+  }
+
+  function initBenchmark() {
+    const page = document.querySelector(".pc-benchmark");
+    if (!page || initialized.has(page)) {
+      return;
+    }
+    initialized.add(page);
+
+    page.querySelectorAll("[data-metric-comparison]").forEach(enhanceMetricComparison);
+    const revealTargets = Array.from(page.querySelectorAll("[data-benchmark-reveal]"));
+
+    if (prefersReducedMotion() || !("IntersectionObserver" in window)) {
+      revealTargets.forEach(reveal);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+          reveal(entry.target);
+          observer.unobserve(entry.target);
+        });
+      },
+      { rootMargin: "0px 0px -8%", threshold: 0.16 },
+    );
+    revealTargets.forEach((target) => observer.observe(target));
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initBenchmark);
+  } else {
+    initBenchmark();
+  }
+
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(initBenchmark);
+  }
+})();

--- a/theme/powercontext/assets/stylesheets/powercontext.css
+++ b/theme/powercontext/assets/stylesheets/powercontext.css
@@ -3378,3 +3378,1105 @@ body {
     padding-block: 51px 72px;
   }
 }
+
+/* Benchmark evidence page */
+.md-main__inner:has(.pc-benchmark) {
+  margin-top: 0;
+  max-width: none;
+  padding: 0;
+}
+
+.pc-benchmark {
+  --benchmark-accent: var(--pc-accent);
+  --benchmark-accent-strong: var(--pc-accent-hover);
+  --benchmark-on-ink: #ffffff;
+  box-sizing: border-box;
+  margin: 0;
+  max-width: none;
+  overflow: clip;
+  width: 100%;
+}
+
+[data-md-color-scheme="slate"] .pc-benchmark {
+  --benchmark-on-ink: #07152b;
+}
+
+.pc-benchmark > .md-content__inner {
+  margin: 0;
+  max-width: none;
+  padding: 0;
+}
+
+.pc-benchmark .shell {
+  box-sizing: border-box;
+  margin-inline: auto;
+  width: min(var(--pc-wide), calc(100% - 48px));
+}
+
+.pc-benchmark h1,
+.pc-benchmark h2,
+.pc-benchmark h3,
+.pc-benchmark p,
+.pc-benchmark figure,
+.pc-benchmark dl,
+.pc-benchmark dd {
+  margin: 0;
+}
+
+.pc-benchmark a {
+  color: inherit;
+}
+
+.pc-visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.pc-benchmark-hero {
+  background:
+    radial-gradient(circle at 83% 18%, color-mix(in srgb, var(--benchmark-accent) 15%, transparent), transparent 27%),
+    var(--pc-paper);
+  border-bottom: 1px solid var(--pc-rule);
+  min-height: min(720px, calc(100dvh - 68px));
+  padding: clamp(64px, 8vw, 96px) 0;
+}
+
+.pc-benchmark-hero__grid {
+  align-items: center;
+  display: grid;
+  gap: clamp(48px, 8vw, 104px);
+  grid-template-columns: minmax(0, 1fr) minmax(420px, 0.92fr);
+}
+
+.pc-benchmark-label {
+  color: var(--benchmark-accent-strong);
+  font-family: var(--pc-font-code);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.pc-benchmark-hero h1 {
+  color: var(--pc-ink);
+  font-size: clamp(56px, 7vw, 88px);
+  font-weight: 760;
+  letter-spacing: -0.055em;
+  line-height: 0.96;
+  margin-top: 20px;
+  max-width: 9ch;
+}
+
+html[lang^="zh"] .pc-benchmark-hero h1 {
+  font-size: clamp(56px, 5.3vw, 76px);
+  max-width: none;
+}
+
+.pc-benchmark-hero__lead {
+  color: var(--pc-muted);
+  font-size: clamp(18px, 2vw, 22px);
+  line-height: 1.52;
+  margin-top: 28px !important;
+  max-width: 46ch;
+}
+
+.pc-benchmark-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 34px;
+}
+
+.pc-benchmark-hero__actions a {
+  align-items: center;
+  border: 1px solid var(--pc-rule-strong);
+  border-radius: var(--pc-radius);
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 700;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  text-decoration: none;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.pc-benchmark-hero__actions a:first-child {
+  background: var(--benchmark-accent);
+  border-color: var(--benchmark-accent);
+  color: var(--benchmark-on-ink);
+}
+
+.pc-benchmark-hero__actions a:last-child {
+  background: var(--pc-surface);
+  color: var(--pc-ink);
+}
+
+.pc-benchmark-hero__actions a:hover {
+  border-color: var(--benchmark-accent);
+  text-decoration: none;
+  transform: translateY(-2px);
+}
+
+.pc-benchmark-hero__actions a:active {
+  transform: translateY(1px);
+}
+
+.pc-benchmark-hero__visual {
+  background: var(--pc-surface);
+  border: 1px solid var(--pc-rule-strong);
+  border-radius: var(--pc-radius);
+  box-shadow: 0 28px 80px color-mix(in srgb, var(--pc-header) 13%, transparent);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  min-height: 420px;
+  overflow: hidden;
+  position: relative;
+}
+
+.pc-benchmark-hero__visual::before {
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--benchmark-accent) 12%, transparent), transparent);
+  content: "";
+  height: 1px;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 58%;
+}
+
+.pc-benchmark-hero__result {
+  align-content: end;
+  display: grid;
+  min-width: 0;
+  padding: 36px 30px 72px;
+  position: relative;
+}
+
+.pc-benchmark-hero__result + .pc-benchmark-hero__result {
+  border-left: 1px solid var(--pc-rule);
+  padding-top: 88px;
+}
+
+.pc-benchmark-hero__result-name {
+  color: var(--pc-muted);
+  font-family: var(--pc-font-code);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.pc-benchmark-hero__result strong {
+  color: var(--pc-ink);
+  font-family: var(--pc-font-code);
+  font-size: clamp(42px, 5vw, 68px);
+  letter-spacing: -0.07em;
+  line-height: 1;
+  margin-top: 16px;
+  white-space: nowrap;
+}
+
+.pc-benchmark-hero__result:last-of-type strong {
+  color: var(--benchmark-accent-strong);
+}
+
+.pc-benchmark-hero__result > span:last-child {
+  color: var(--pc-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  margin-top: 12px;
+}
+
+.pc-benchmark-hero__signal {
+  align-items: end;
+  bottom: 28px;
+  display: flex;
+  gap: 5px;
+  height: 34px;
+  left: 30px;
+  position: absolute;
+}
+
+.pc-benchmark-hero__signal span {
+  background: var(--benchmark-accent);
+  display: block;
+  height: 38%;
+  opacity: 0.72;
+  width: 5px;
+}
+
+.pc-benchmark-hero__signal span:nth-child(2) {
+  height: 100%;
+}
+
+.pc-benchmark-hero__signal span:nth-child(3) {
+  height: 66%;
+}
+
+.pc-benchmark-orientation,
+.pc-benchmark-study,
+.pc-benchmark-reading,
+.pc-benchmark-sources {
+  padding-block: clamp(80px, 10vw, 132px);
+}
+
+.pc-benchmark-orientation > header,
+.pc-benchmark-reading > header {
+  max-width: 760px;
+}
+
+.pc-benchmark h2 {
+  color: var(--pc-ink);
+  font-size: clamp(38px, 5vw, 64px);
+  font-weight: 740;
+  letter-spacing: -0.045em;
+  line-height: 1.02;
+}
+
+.pc-benchmark-orientation > header > p,
+.pc-benchmark-reading > header > p {
+  color: var(--pc-muted);
+  font-size: 18px;
+  line-height: 1.65;
+  margin-top: 22px;
+  max-width: 64ch;
+}
+
+.pc-benchmark-orientation__tests {
+  display: grid;
+  gap: clamp(32px, 7vw, 92px);
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+  margin-top: 72px;
+}
+
+.pc-benchmark-orientation__tests article {
+  border-top: 3px solid var(--pc-ink);
+  padding: 28px 0 0;
+}
+
+.pc-benchmark-orientation__tests article:last-child {
+  border-top-color: var(--benchmark-accent);
+  padding-top: 68px;
+}
+
+.pc-benchmark-orientation__tests article > span {
+  color: var(--benchmark-accent-strong);
+  font-family: var(--pc-font-code);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.pc-benchmark-orientation__tests h3 {
+  color: var(--pc-ink);
+  font-size: clamp(25px, 3vw, 36px);
+  letter-spacing: -0.035em;
+  line-height: 1.16;
+  margin-top: 18px;
+  max-width: 19ch;
+}
+
+.pc-benchmark-orientation__tests p {
+  color: var(--pc-muted);
+  font-size: 16px;
+  line-height: 1.65;
+  margin-top: 18px;
+  max-width: 50ch;
+}
+
+.pc-benchmark-orientation__tests a {
+  color: var(--benchmark-accent-strong);
+  display: inline-block;
+  font-size: 14px;
+  font-weight: 700;
+  margin-top: 22px;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 5px;
+}
+
+.pc-benchmark-study {
+  border-top: 1px solid var(--pc-rule-strong);
+}
+
+.pc-benchmark-study__header {
+  max-width: 860px;
+}
+
+.pc-benchmark-study__header > p {
+  color: var(--pc-muted);
+  font-size: 18px;
+  line-height: 1.65;
+  margin-top: 24px;
+  max-width: 68ch;
+}
+
+.pc-benchmark-facts {
+  border-block: 1px solid var(--pc-rule-strong);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 58px !important;
+}
+
+.pc-benchmark-facts > div {
+  display: grid;
+  gap: 12px;
+  padding: 28px 30px;
+}
+
+.pc-benchmark-facts > div + div {
+  border-left: 1px solid var(--pc-rule);
+}
+
+.pc-benchmark-facts dt {
+  color: var(--pc-muted);
+  font-size: 13px;
+}
+
+.pc-benchmark-facts dd {
+  color: var(--pc-ink);
+  font-family: var(--pc-font-code);
+  font-size: clamp(34px, 4vw, 52px);
+  font-weight: 700;
+  letter-spacing: -0.055em;
+}
+
+.pc-locomo-categories {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  margin-top: 72px;
+}
+
+.pc-locomo-categories article {
+  background: var(--pc-surface);
+  border: 1px solid var(--pc-rule);
+  border-radius: var(--pc-radius);
+  grid-column: span 7;
+  min-height: 220px;
+  padding: 28px;
+}
+
+.pc-locomo-categories article:nth-child(2),
+.pc-locomo-categories article:nth-child(3) {
+  background: var(--pc-surface-secondary);
+  grid-column: span 5;
+}
+
+.pc-locomo-categories article:nth-child(4) {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--benchmark-accent) 11%, var(--pc-surface)), var(--pc-surface));
+}
+
+.pc-locomo-categories strong {
+  color: var(--benchmark-accent-strong);
+  font-family: var(--pc-font-code);
+  font-size: 30px;
+  letter-spacing: -0.04em;
+}
+
+.pc-locomo-categories h3 {
+  color: var(--pc-ink);
+  font-size: 23px;
+  letter-spacing: -0.02em;
+  margin-top: 38px;
+}
+
+.pc-locomo-categories p {
+  color: var(--pc-muted);
+  font-size: 15px;
+  line-height: 1.58;
+  margin-top: 10px;
+  max-width: 38ch;
+}
+
+.pc-metric-comparison {
+  background: var(--pc-code);
+  border: 1px solid var(--pc-code-border);
+  border-radius: var(--pc-radius);
+  color: var(--pc-code-text);
+  margin-top: 90px;
+  overflow: hidden;
+  padding: clamp(26px, 5vw, 54px);
+}
+
+.pc-metric-comparison__intro {
+  align-items: end;
+  display: grid;
+  gap: 32px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.pc-metric-comparison h3 {
+  color: var(--pc-code-text);
+  font-size: clamp(28px, 4vw, 46px);
+  letter-spacing: -0.04em;
+  line-height: 1.08;
+}
+
+.pc-metric-comparison__intro p {
+  color: color-mix(in srgb, var(--pc-code-text) 67%, transparent);
+  font-size: 15px;
+  line-height: 1.6;
+  margin-top: 14px;
+  max-width: 58ch;
+}
+
+.pc-metric-tabs {
+  border: 1px solid var(--pc-code-border);
+  border-radius: var(--pc-radius);
+  display: flex;
+  padding: 4px;
+}
+
+.pc-metric-tabs button {
+  background: transparent;
+  border: 0;
+  border-radius: var(--pc-radius-control);
+  color: color-mix(in srgb, var(--pc-code-text) 65%, transparent);
+  cursor: pointer;
+  font: 600 12px/1 var(--pc-font-text);
+  min-height: 36px;
+  padding: 0 13px;
+  white-space: nowrap;
+}
+
+.pc-metric-tabs button[aria-selected="true"] {
+  background: var(--benchmark-accent);
+  color: var(--benchmark-on-ink);
+}
+
+.pc-metric-panels {
+  margin-top: 54px;
+}
+
+.pc-metric-panel[hidden] {
+  display: none;
+}
+
+.pc-metric-panel {
+  display: grid;
+  gap: clamp(34px, 6vw, 74px);
+  grid-template-columns: minmax(200px, 0.72fr) minmax(0, 1.65fr);
+  min-height: 320px;
+  position: relative;
+}
+
+.pc-metric-panel__callout strong {
+  color: var(--pc-code-text);
+  display: block;
+  font-family: var(--pc-font-code);
+  font-size: clamp(44px, 6vw, 78px);
+  letter-spacing: -0.07em;
+  line-height: 0.98;
+}
+
+.pc-metric-panel__callout span {
+  color: color-mix(in srgb, var(--pc-code-text) 68%, transparent);
+  display: block;
+  font-size: 14px;
+  margin-top: 16px;
+}
+
+.pc-metric-panel__lanes {
+  align-self: center;
+  display: grid;
+  gap: 26px;
+}
+
+.pc-metric-lane {
+  min-width: 0;
+}
+
+.pc-metric-lane__meta {
+  align-items: baseline;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+}
+
+.pc-metric-lane__meta span {
+  color: color-mix(in srgb, var(--pc-code-text) 72%, transparent);
+  font-size: 13px;
+}
+
+.pc-metric-lane__meta strong {
+  color: var(--pc-code-text);
+  font-family: var(--pc-font-code);
+  font-size: 15px;
+  white-space: nowrap;
+}
+
+.pc-metric-lane__bar {
+  background: color-mix(in srgb, var(--pc-code-text) 35%, transparent);
+  display: block;
+  height: 26px;
+  margin-top: 8px;
+  min-width: 72px;
+  transform: scaleX(1);
+  transform-origin: left center;
+  width: var(--benchmark-scale);
+}
+
+.pc-metric-lane:first-child .pc-metric-lane__bar {
+  background: var(--benchmark-accent);
+}
+
+.pc-metric-lane:nth-child(2) .pc-metric-lane__bar {
+  background: color-mix(in srgb, var(--benchmark-accent) 38%, var(--pc-code-text));
+}
+
+.pc-metric-comparison.is-enhanced .pc-metric-lane__bar {
+  transform: scaleX(0);
+}
+
+.pc-metric-comparison.is-visible .pc-metric-panel.is-playing .pc-metric-lane__bar {
+  transform: scaleX(1);
+  transition: transform 900ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.pc-metric-comparison.is-visible .pc-metric-lane:nth-child(2) .pc-metric-lane__bar {
+  transition-delay: 100ms;
+}
+
+.pc-metric-comparison.is-visible .pc-metric-lane:nth-child(3) .pc-metric-lane__bar {
+  transition-delay: 200ms;
+}
+
+.pc-metric-panel__direction {
+  bottom: 0;
+  color: color-mix(in srgb, var(--pc-code-text) 58%, transparent);
+  font: 12px/1 var(--pc-font-code);
+  left: 0;
+  position: absolute;
+}
+
+.pc-benchmark-note {
+  border-left: 3px solid var(--benchmark-accent);
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(180px, 0.35fr) minmax(0, 1fr);
+  margin-top: 42px;
+  padding: 8px 0 8px 24px;
+}
+
+.pc-benchmark-note strong {
+  color: var(--pc-ink);
+  font-size: 14px;
+}
+
+.pc-benchmark-note p {
+  color: var(--pc-muted);
+  font-size: 14px;
+  line-height: 1.65;
+  max-width: 76ch;
+}
+
+.pc-benchmark-study--swe {
+  padding-bottom: clamp(88px, 11vw, 144px);
+}
+
+.pc-swe-method {
+  border-block: 1px solid var(--pc-rule-strong);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 58px;
+}
+
+.pc-swe-method > div {
+  display: grid;
+  gap: 9px;
+  padding: 26px 28px;
+}
+
+.pc-swe-method > div + div {
+  border-left: 1px solid var(--pc-rule);
+}
+
+.pc-swe-method strong {
+  color: var(--pc-ink);
+  font-size: 14px;
+}
+
+.pc-swe-method span {
+  color: var(--pc-muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.pc-benchmark .pc-swe-result {
+  display: block;
+  margin-top: 76px !important;
+  max-width: none;
+  width: 100%;
+}
+
+.pc-swe-result__scores {
+  align-items: stretch;
+  display: grid;
+  gap: clamp(18px, 2.4vw, 34px);
+  grid-template-areas: "off delta on";
+  grid-template-columns: minmax(0, 1fr) minmax(148px, 174px) minmax(0, 1fr);
+  min-height: 430px;
+}
+
+.pc-swe-score {
+  align-content: center;
+  border-radius: var(--pc-radius);
+  display: grid;
+  min-width: 0;
+  padding: clamp(28px, 5vw, 58px);
+  transition: opacity 800ms cubic-bezier(0.16, 1, 0.3, 1), transform 800ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.pc-swe-score--off {
+  background: var(--pc-surface-secondary);
+  border: 1px solid var(--pc-rule-strong);
+  grid-area: off;
+  transform: translateX(28px);
+}
+
+.pc-swe-score--on {
+  background: var(--benchmark-accent);
+  color: var(--benchmark-on-ink);
+  grid-area: on;
+  transform: translateX(-28px);
+}
+
+.pc-swe-result.is-visible .pc-swe-score {
+  transform: translateX(0);
+}
+
+.pc-swe-score > span:first-child {
+  font-family: var(--pc-font-code);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.pc-swe-score--off > span:first-child,
+.pc-swe-score--off small {
+  color: var(--pc-muted);
+}
+
+.pc-swe-score strong {
+  font-family: var(--pc-font-code);
+  font-size: clamp(72px, 9vw, 124px);
+  letter-spacing: -0.085em;
+  line-height: 0.9;
+  margin-top: 30px;
+}
+
+.pc-swe-score--off strong {
+  color: var(--pc-ink);
+}
+
+.pc-swe-score small {
+  font-size: 15px;
+  margin-top: 25px;
+}
+
+.pc-swe-result__delta {
+  align-content: center;
+  align-self: center;
+  background: var(--pc-code);
+  border: 4px solid var(--pc-paper);
+  border-radius: var(--pc-radius);
+  color: var(--pc-code-text);
+  display: grid;
+  grid-area: delta;
+  height: 124px;
+  justify-items: center;
+  justify-self: center;
+  opacity: 0;
+  padding: 12px 22px;
+  transform: scale(0.64) rotate(-7deg);
+  transition: opacity 500ms 520ms ease, transform 700ms 420ms cubic-bezier(0.16, 1, 0.3, 1);
+  width: min(100%, 174px);
+}
+
+.pc-swe-result.is-visible .pc-swe-result__delta {
+  opacity: 1;
+  transform: scale(1) rotate(0);
+}
+
+.pc-swe-result__delta strong {
+  font-family: var(--pc-font-code);
+  font-size: 42px;
+  letter-spacing: -0.06em;
+  line-height: 1;
+}
+
+.pc-swe-result__delta span {
+  color: color-mix(in srgb, var(--pc-code-text) 72%, transparent);
+  font-size: 11px;
+  line-height: 1.25;
+  text-align: center;
+}
+
+.pc-swe-result figcaption {
+  color: var(--pc-muted);
+  font-size: 14px;
+  line-height: 1.6;
+  margin: 22px auto 0;
+  max-width: 70ch;
+  text-align: center;
+}
+
+.pc-benchmark-reading {
+  border-top: 1px solid var(--pc-rule-strong);
+}
+
+.pc-benchmark-table-wrap {
+  border: 1px solid var(--pc-rule-strong);
+  border-radius: var(--pc-radius);
+  margin-top: 58px;
+  overflow-x: auto;
+}
+
+.pc-benchmark-table-wrap table {
+  background: var(--pc-surface);
+  border: 0;
+  border-collapse: collapse;
+  font-size: 14px;
+  margin: 0;
+  min-width: 720px;
+  width: 100%;
+}
+
+.pc-benchmark-table-wrap th,
+.pc-benchmark-table-wrap td {
+  border: 0;
+  padding: 22px 24px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.pc-benchmark-table-wrap thead {
+  background: var(--pc-surface-secondary);
+  color: var(--pc-muted);
+}
+
+.pc-benchmark-table-wrap thead th {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.pc-benchmark-table-wrap tbody tr + tr {
+  border-top: 1px solid var(--pc-rule);
+}
+
+.pc-benchmark-table-wrap tbody th {
+  color: var(--pc-ink);
+  font-weight: 700;
+  width: 24%;
+}
+
+.pc-benchmark-table-wrap tbody td {
+  color: var(--pc-muted);
+  line-height: 1.55;
+}
+
+.pc-benchmark-sources {
+  border-top: 1px solid var(--pc-rule-strong);
+  display: grid;
+  gap: clamp(46px, 8vw, 110px);
+  grid-template-columns: minmax(240px, 0.62fr) minmax(0, 1fr);
+}
+
+.pc-benchmark-sources > div > p {
+  color: var(--pc-muted);
+  font-size: 16px;
+  line-height: 1.65;
+  margin-top: 22px;
+}
+
+.pc-benchmark-sources ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pc-benchmark-sources li {
+  border-top: 1px solid var(--pc-rule-strong);
+  display: grid;
+  gap: 10px 22px;
+  grid-template-columns: 86px minmax(0, 1fr);
+  padding: 24px 0;
+}
+
+.pc-benchmark-sources li > span {
+  color: var(--pc-tertiary);
+  font-family: var(--pc-font-code);
+  font-size: 11px;
+}
+
+.pc-benchmark-sources li > a {
+  color: var(--pc-ink);
+  font-size: 15px;
+  font-weight: 700;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.pc-benchmark-sources li > a:hover {
+  color: var(--benchmark-accent-strong);
+}
+
+.pc-benchmark-sources li > p {
+  color: var(--pc-muted);
+  font-size: 13px;
+  grid-column: 2;
+  line-height: 1.55;
+}
+
+.pc-benchmark-cta {
+  align-items: center;
+  border-top: 1px solid var(--pc-rule-strong);
+  display: grid;
+  gap: 40px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding-block: 72px 90px;
+}
+
+.pc-benchmark-cta h2 {
+  font-size: clamp(34px, 4vw, 52px);
+}
+
+.pc-benchmark-cta p {
+  color: var(--pc-muted);
+  font-size: 16px;
+  line-height: 1.6;
+  margin-top: 16px;
+  max-width: 60ch;
+}
+
+.pc-benchmark-cta .primary-button {
+  min-width: 150px;
+  white-space: nowrap;
+}
+
+[data-benchmark-reveal] {
+  opacity: 0.001;
+  transform: translateY(34px);
+  transition: opacity 700ms ease, transform 850ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+[data-benchmark-reveal].is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media screen and (max-width: 1020px) {
+  .pc-benchmark-hero__grid {
+    gap: 48px;
+    grid-template-columns: minmax(0, 0.85fr) minmax(390px, 1fr);
+  }
+
+  .pc-benchmark-hero__result {
+    padding-inline: 22px;
+  }
+
+  .pc-metric-comparison__intro {
+    align-items: start;
+    grid-template-columns: 1fr;
+  }
+
+  .pc-metric-tabs {
+    justify-self: start;
+  }
+}
+
+@media screen and (max-width: 800px) {
+  .pc-benchmark-hero {
+    min-height: 0;
+  }
+
+  .pc-benchmark-hero__grid,
+  .pc-benchmark-orientation__tests,
+  .pc-metric-panel,
+  .pc-benchmark-sources,
+  .pc-benchmark-cta {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-benchmark-hero h1 {
+    max-width: 10ch;
+  }
+
+  .pc-benchmark-hero__visual {
+    min-height: 350px;
+  }
+
+  .pc-benchmark-orientation__tests article:last-child {
+    padding-top: 28px;
+  }
+
+  .pc-metric-panel {
+    min-height: 440px;
+  }
+
+  .pc-metric-panel__direction {
+    position: static;
+  }
+
+  .pc-benchmark-sources {
+    gap: 48px;
+  }
+
+  .pc-benchmark-cta {
+    align-items: start;
+  }
+
+  .pc-benchmark-cta .primary-button {
+    justify-self: start;
+  }
+
+  .pc-swe-result__scores {
+    gap: 18px;
+    grid-template-areas:
+      "off"
+      "delta"
+      "on";
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .pc-swe-score {
+    min-height: 280px;
+  }
+
+  .pc-swe-score--off {
+    transform: translateY(28px);
+  }
+
+  .pc-swe-score--on {
+    transform: translateY(-28px);
+  }
+
+  .pc-swe-result.is-visible .pc-swe-score {
+    transform: translateY(0);
+  }
+}
+
+@media screen and (max-width: 640px) {
+  .pc-benchmark .shell {
+    width: calc(100% - 30px);
+  }
+
+  .pc-benchmark-hero {
+    padding-block: 54px 64px;
+  }
+
+  .pc-benchmark-hero h1 {
+    font-size: clamp(46px, 15vw, 64px);
+  }
+
+  .pc-benchmark-hero__lead {
+    font-size: 17px;
+  }
+
+  .pc-benchmark-hero__actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .pc-benchmark-hero__visual {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .pc-benchmark-hero__visual::before,
+  .pc-benchmark-hero__signal {
+    display: none;
+  }
+
+  .pc-benchmark-hero__result {
+    min-height: 220px;
+    padding: 30px;
+  }
+
+  .pc-benchmark-hero__result + .pc-benchmark-hero__result {
+    border-left: 0;
+    border-top: 1px solid var(--pc-rule);
+    padding-top: 30px;
+  }
+
+  .pc-benchmark h2 {
+    font-size: clamp(36px, 12vw, 48px);
+  }
+
+  .pc-benchmark-facts,
+  .pc-swe-method {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-benchmark-facts > div + div,
+  .pc-swe-method > div + div {
+    border-left: 0;
+    border-top: 1px solid var(--pc-rule);
+  }
+
+  .pc-benchmark-facts > div,
+  .pc-swe-method > div {
+    padding-inline: 0;
+  }
+
+  .pc-locomo-categories {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-locomo-categories article,
+  .pc-locomo-categories article:nth-child(2),
+  .pc-locomo-categories article:nth-child(3) {
+    grid-column: 1;
+  }
+
+  .pc-metric-comparison {
+    margin-inline: -4px;
+  }
+
+  .pc-metric-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    justify-self: stretch;
+  }
+
+  .pc-metric-tabs button {
+    padding-inline: 8px;
+  }
+
+  .pc-metric-panel {
+    min-height: 470px;
+  }
+
+  .pc-metric-panel__callout strong {
+    font-size: 46px;
+  }
+
+  .pc-benchmark-note {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-benchmark-sources li {
+    grid-template-columns: 66px minmax(0, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pc-benchmark *,
+  .pc-benchmark *::before,
+  .pc-benchmark *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  [data-benchmark-reveal],
+  .pc-swe-score,
+  .pc-swe-result__delta,
+  .pc-metric-comparison.is-enhanced .pc-metric-lane__bar {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/theme/powercontext/benchmark.html
+++ b/theme/powercontext/benchmark.html
@@ -1,0 +1,214 @@
+<!--
+  ~ Copyright (c) 2026 OceanBase.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+{% extends "main.html" %}
+
+{% set benchmark = page.meta["benchmark"] %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ 'assets/javascripts/benchmark.js' | url }}"></script>
+{% endblock %}
+
+{% block site_nav %}
+  <div class="md-sidebar md-sidebar--primary pc-mobile-sidebar" data-md-component="sidebar" data-md-type="navigation">
+    <div class="md-sidebar__scrollwrap">
+      <div class="md-sidebar__inner">{% include "partials/nav.html" %}</div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block container %}
+  <div class="md-content pc-benchmark" data-md-component="content">
+    <article class="md-content__inner md-typeset">
+      <section class="pc-benchmark-hero" aria-labelledby="benchmark-title">
+        <div class="shell pc-benchmark-hero__grid">
+          <div class="pc-benchmark-hero__copy">
+            <p class="pc-benchmark-label">{{ benchmark["hero"]["label"] }}</p>
+            <h1 id="benchmark-title">{% for line in benchmark["hero"]["title"] %}{{ line }}{% if not loop.last %}<br>{% endif %}{% endfor %}</h1>
+            <p class="pc-benchmark-hero__lead">{{ benchmark["hero"]["lead"] }}</p>
+            <nav class="pc-benchmark-hero__actions" aria-label="{{ benchmark['hero']['actions_label'] }}">
+              {% for action in benchmark["hero"]["actions"] %}
+                <a href="#{{ action['target'] }}">{{ action["label"] }}</a>
+              {% endfor %}
+            </nav>
+          </div>
+
+          <div class="pc-benchmark-hero__visual" data-benchmark-reveal aria-label="{{ benchmark['hero']['visual_label'] }}">
+            {% for result in benchmark["hero"]["results"] %}
+              <div class="pc-benchmark-hero__result">
+                <span class="pc-benchmark-hero__result-name">{{ result["name"] }}</span>
+                <strong aria-hidden="true" data-count-to="{{ result['value'] }}" data-count-decimals="{{ result['decimals'] }}" data-count-suffix="{{ result['suffix'] }}">{{ result["display"] }}</strong>
+                <span class="pc-visually-hidden">{{ result["accessible"] }}</span>
+                <span>{{ result["metric"] }}</span>
+              </div>
+            {% endfor %}
+            <div class="pc-benchmark-hero__signal" aria-hidden="true"><span></span><span></span><span></span></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="pc-benchmark-orientation shell" aria-labelledby="benchmark-orientation-title">
+        <header>
+          <h2 id="benchmark-orientation-title">{{ benchmark["orientation"]["title"] }}</h2>
+          <p>{{ benchmark["orientation"]["lead"] }}</p>
+        </header>
+        <div class="pc-benchmark-orientation__tests">
+          {% for test in benchmark["orientation"]["tests"] %}
+            <article data-benchmark-reveal>
+              <span>{{ test["name"] }}</span>
+              <h3>{{ test["question"] }}</h3>
+              <p>{{ test["answer"] }}</p>
+              <a href="#{{ test['target'] }}">{{ test["link"] }}</a>
+            </article>
+          {% endfor %}
+        </div>
+      </section>
+
+      <section class="pc-benchmark-study shell" id="locomo" aria-labelledby="locomo-title">
+        <header class="pc-benchmark-study__header">
+          <h2 id="locomo-title">{{ benchmark["locomo"]["title"] }}</h2>
+          <p>{{ benchmark["locomo"]["lead"] }}</p>
+        </header>
+
+        <dl class="pc-benchmark-facts" data-benchmark-reveal>
+          {% for fact in benchmark["locomo"]["facts"] %}
+            <div><dt>{{ fact["label"] }}</dt><dd>{{ fact["value"] }}</dd></div>
+          {% endfor %}
+        </dl>
+
+        <div class="pc-locomo-categories" aria-label="{{ benchmark['locomo']['categories_label'] }}">
+          {% for category in benchmark["locomo"]["categories"] %}
+            <article data-benchmark-reveal>
+              <strong>{{ category["count"] }}</strong>
+              <h3>{{ category["name"] }}</h3>
+              <p>{{ category["description"] }}</p>
+            </article>
+          {% endfor %}
+        </div>
+
+        <div class="pc-metric-comparison" data-metric-comparison data-benchmark-reveal>
+          <div class="pc-metric-comparison__intro">
+            <div>
+              <h3>{{ benchmark["locomo"]["results_title"] }}</h3>
+              <p>{{ benchmark["locomo"]["results_lead"] }}</p>
+            </div>
+            <div class="pc-metric-tabs" role="tablist" aria-label="{{ benchmark['locomo']['tabs_label'] }}">
+              {% for metric in benchmark["locomo"]["metrics"] %}
+                <button id="metric-{{ metric['id'] }}-tab" type="button" role="tab" aria-controls="metric-{{ metric['id'] }}" aria-selected="{{ 'true' if loop.first else 'false' }}" tabindex="{{ '0' if loop.first else '-1' }}" data-metric-target="{{ metric['id'] }}">{{ metric["label"] }}</button>
+              {% endfor %}
+            </div>
+          </div>
+
+          <div class="pc-metric-panels">
+            {% for metric in benchmark["locomo"]["metrics"] %}
+              <section id="metric-{{ metric['id'] }}" class="pc-metric-panel{% if loop.first %} is-active{% endif %}" role="tabpanel" aria-labelledby="metric-{{ metric['id'] }}-tab" data-metric-panel="{{ metric['id'] }}">
+                <div class="pc-metric-panel__callout">
+                  <strong>{{ metric["callout"] }}</strong>
+                  <span>{{ metric["callout_detail"] }}</span>
+                </div>
+                <div class="pc-metric-panel__lanes" aria-label="{{ metric['chart_label'] }}">
+                  {% for row in metric["rows"] %}
+                    <div class="pc-metric-lane" style="--benchmark-scale: {{ row['scale'] }}%;">
+                      <div class="pc-metric-lane__meta"><span>{{ row["name"] }}</span><strong>{{ row["display"] }}</strong></div>
+                      <span class="pc-metric-lane__bar" aria-hidden="true"></span>
+                    </div>
+                  {% endfor %}
+                </div>
+                <p class="pc-metric-panel__direction">{{ metric["direction"] }}</p>
+              </section>
+            {% endfor %}
+          </div>
+        </div>
+
+        <aside class="pc-benchmark-note" data-benchmark-reveal>
+          <strong>{{ benchmark["locomo"]["scope_title"] }}</strong>
+          <p>{{ benchmark["locomo"]["scope"] }}</p>
+        </aside>
+      </section>
+
+      <section class="pc-benchmark-study pc-benchmark-study--swe shell" id="swe-bench" aria-labelledby="swe-bench-title">
+        <header class="pc-benchmark-study__header">
+          <h2 id="swe-bench-title">{{ benchmark["swe"]["title"] }}</h2>
+          <p>{{ benchmark["swe"]["lead"] }}</p>
+        </header>
+
+        <div class="pc-swe-method" data-benchmark-reveal>
+          {% for item in benchmark["swe"]["method"] %}
+            <div><strong>{{ item["title"] }}</strong><span>{{ item["description"] }}</span></div>
+          {% endfor %}
+        </div>
+
+        <figure class="pc-swe-result" data-swe-result data-benchmark-reveal aria-labelledby="swe-result-caption">
+          <div class="pc-swe-result__scores">
+            {% for score in benchmark["swe"]["scores"] %}
+              <div class="pc-swe-score pc-swe-score--{{ score['kind'] }}">
+                <span>{{ score["label"] }}</span>
+                <strong aria-hidden="true" data-count-to="{{ score['count'] }}">{{ score["count"] }}</strong>
+                <span class="pc-visually-hidden">{{ score["accessible"] }}</span>
+                <small>{{ score["rate"] }}</small>
+              </div>
+            {% endfor %}
+            <div class="pc-swe-result__delta" aria-label="{{ benchmark['swe']['delta_accessible'] }}">
+              <strong>{{ benchmark["swe"]["delta"] }}</strong>
+              <span>{{ benchmark["swe"]["delta_label"] }}</span>
+            </div>
+          </div>
+          <figcaption id="swe-result-caption">{{ benchmark["swe"]["caption"] }}</figcaption>
+        </figure>
+
+        <aside class="pc-benchmark-note" data-benchmark-reveal>
+          <strong>{{ benchmark["swe"]["scope_title"] }}</strong>
+          <p>{{ benchmark["swe"]["scope"] }}</p>
+        </aside>
+      </section>
+
+      <section class="pc-benchmark-reading shell" aria-labelledby="reading-title">
+        <header>
+          <h2 id="reading-title">{{ benchmark["reading"]["title"] }}</h2>
+          <p>{{ benchmark["reading"]["lead"] }}</p>
+        </header>
+        <div class="pc-benchmark-table-wrap" data-benchmark-reveal>
+          <table>
+            <thead><tr><th scope="col">{{ benchmark["reading"]["columns"]["dimension"] }}</th><th scope="col">LoCoMo</th><th scope="col">SWE-bench Pro</th></tr></thead>
+            <tbody>
+              {% for row in benchmark["reading"]["rows"] %}
+                <tr><th scope="row">{{ row["dimension"] }}</th><td>{{ row["locomo"] }}</td><td>{{ row["swe"] }}</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="pc-benchmark-sources shell" aria-labelledby="sources-title">
+        <div>
+          <h2 id="sources-title">{{ benchmark["sources"]["title"] }}</h2>
+          <p>{{ benchmark["sources"]["lead"] }}</p>
+        </div>
+        <ol>
+          {% for source in benchmark["sources"]["items"] %}
+            <li data-benchmark-reveal><span>{{ source["type"] }}</span><a href="{{ source['href'] }}">{{ source["label"] }}</a><p>{{ source["description"] }}</p></li>
+          {% endfor %}
+        </ol>
+      </section>
+
+      <section class="pc-benchmark-cta shell" data-benchmark-reveal>
+        <div><h2>{{ benchmark["cta"]["title"] }}</h2><p>{{ benchmark["cta"]["lead"] }}</p></div>
+        <a class="primary-button large" href="{{ benchmark['cta']['href'] }}">{{ benchmark["cta"]["label"] }}</a>
+      </section>
+    </article>
+  </div>
+{% endblock %}

--- a/theme/powercontext/partials/footer.html
+++ b/theme/powercontext/partials/footer.html
@@ -70,6 +70,7 @@
       </a>
       <nav class="pc-footer__nav" aria-label="{{ '页脚导航' if is_zh else 'Footer navigation' }}">
         <a href="{{ ('zh/docs/' if is_zh else 'en/docs/') | url }}">{{ "文档" if is_zh else "Docs" }}</a>
+        <a href="{{ ('zh/benchmarks/' if is_zh else 'en/benchmarks/') | url }}">{{ "Benchmark" if is_zh else "Benchmarks" }}</a>
         <a href="{{ ('zh/blog/' if is_zh else 'en/blog/') | url }}">{{ "博客" if is_zh else "Blog" }}</a>
         <a href="{{ ('zh/changelog/' if is_zh else 'en/changelog/') | url }}">{{ "更新日志" if is_zh else "Changelog" }}</a>
         <a href="{{ ('zh/rfcs/' if is_zh else 'en/rfcs/') | url }}">{{ "RFC 与会议纪要" if is_zh else "RFCs & Meetings" }}</a>

--- a/theme/powercontext/partials/header.html
+++ b/theme/powercontext/partials/header.html
@@ -18,6 +18,7 @@
 {% set is_zh = "/zh/" in canonical %}
 {% set home_url = "zh/" if is_zh else "en/" %}
 {% set docs_active = "/docs/" in canonical or "/development/" in canonical or "/modules/" in canonical %}
+{% set benchmarks_active = "/benchmarks/" in canonical %}
 {% set blog_active = "/blog/" in canonical %}
 {% set changelog_active = "/changelog/" in canonical %}
 {% set records_active = "/rfcs/" in canonical or "/meetings/" in canonical %}
@@ -33,6 +34,7 @@
     </a>
     <div class="pc-header-nav" aria-label="{{ '主导航' if is_zh else 'Primary navigation' }}">
       <a href="{{ ('zh/docs/' if is_zh else 'en/docs/') | url }}"{% if docs_active %} aria-current="page"{% endif %}>{{ "文档" if is_zh else "Docs" }}</a>
+      <a href="{{ ('zh/benchmarks/' if is_zh else 'en/benchmarks/') | url }}"{% if benchmarks_active %} aria-current="page"{% endif %}>{{ "Benchmark" if is_zh else "Benchmarks" }}</a>
       <a href="{{ ('zh/blog/' if is_zh else 'en/blog/') | url }}"{% if blog_active %} aria-current="page"{% endif %}>{{ "博客" if is_zh else "Blog" }}</a>
       <a href="{{ ('zh/changelog/' if is_zh else 'en/changelog/') | url }}"{% if changelog_active %} aria-current="page"{% endif %}>{{ "更新日志" if is_zh else "Changelog" }}</a>
       <a href="{{ ('zh/rfcs/' if is_zh else 'en/rfcs/') | url }}"{% if records_active %} aria-current="page"{% endif %}>{{ "RFC 与会议纪要" if is_zh else "RFCs & Meetings" }}</a>

--- a/zensical.toml
+++ b/zensical.toml
@@ -49,6 +49,7 @@ nav = [
                 { "Configuration" = "en/docs/reference/configuration.md" },
             ] },
         ] },
+        { "Benchmarks" = "en/benchmarks/index.md" },
         { "Development" = [
             { "Core Protocol" = "en/development/core-protocol.md" },
             { "Memory Layer" = "en/development/memory-layer.md" },
@@ -131,6 +132,7 @@ nav = [
                 { "配置" = "zh/docs/reference/configuration.md" },
             ] },
         ] },
+        { "Benchmark" = "zh/benchmarks/index.md" },
         { "开发" = [
             { "Core Protocol" = "zh/development/core-protocol.md" },
             { "Memory Layer" = "zh/development/memory-layer.md" },


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1407.

# Rationale for this change

PowerContext publishes LoCoMo and SWE-bench Pro results in repository assets, but website visitors do not have a dedicated page that explains what each benchmark evaluates, how to interpret the results, and which caveats apply.

# What changes are included in this PR?

- Add localized `/en/benchmarks/` and `/zh/benchmarks/` pages for LoCoMo and SWE-bench Pro.
- Explain each benchmark's evaluation scope, protocol, metrics, result interpretation, and limitations.
- Add accessible animated comparisons, including an overlap-safe SWE-bench result layout and reduced-motion support.
- Add Benchmark entry points to the header, footer, and blog landing pages.
- Keep the published figures traceable to the existing repository benchmark sources.

# Are there any user-facing changes?

Yes. The documentation website gains a new Benchmark navigation item and bilingual benchmark pages. There are no public API, persisted-format, or runtime behavior changes.

# How was this change tested?

- `make check`
- `make docs-test`
- `make test` (`974 passed, 9 skipped`)
- Chromium manual/browser validation at 1536 px, 1024 px, 800 px, and 390 px viewports
- Light mode, dark mode, reduced-motion, keyboard navigation, and both locales verified
- Browser console verified with no errors or warnings

# AI usage statement

OpenAI Codex (GPT-5) was used to inspect the existing site and benchmark sources, implement the bilingual page, template, styles, and interactions, and run validation. The contributor reviewed the resulting content and code.
