### PR TITLE
feat(site): add benchmark leaderboards

### DIFF
--- a/docs/en/benchmarks/index.md
+++ b/docs/en/benchmarks/index.md
@@ -1,0 +1,204 @@
+---
+template: benchmark.html
+page_type: benchmark
+title: Benchmarks
+description: How PowerContext performs on long-term conversational memory and repository-level software engineering evaluations.
+hide:
+  - navigation
+  - toc
+benchmark:
+  hero:
+    label: Benchmark evidence
+    title:
+      - Context,
+      - under pressure.
+    lead: Two public evaluations test long-term recall and repository-level software engineering with measurable outcomes.
+    actions_label: Jump to a benchmark
+    actions:
+      - label: See LoCoMo
+        target: locomo
+      - label: See SWE-bench
+        target: swe-bench
+    visual_label: Key results from the LoCoMo and SWE-bench Pro evaluations
+    results:
+      - name: LoCoMo
+        value: 90.78
+        decimals: 2
+        suffix: "%"
+        display: 90.78%
+        accessible: 90.78 percent accuracy
+        metric: question-answer accuracy
+      - name: SWE-bench Pro
+        value: 86.73
+        decimals: 2
+        suffix: "%"
+        display: 86.73%
+        accessible: 86.73 percent task resolution
+        metric: tasks resolved with PowerContext on
+  orientation:
+    title: Two benchmarks. Two different questions.
+    lead: "Memory quality matters twice: first when an agent must recover what happened, then when it must use context to finish real work."
+    tests:
+      - name: LoCoMo
+        question: Can the system remember a long-running conversation?
+        answer: It measures direct recall, temporal reasoning, multi-step reasoning, and context grounded open-domain answers.
+        target: locomo
+        link: Explore the memory test
+      - name: SWE-bench Pro
+        question: Can an agent turn context into a working patch?
+        answer: It gives Codex a real repository and issue, then grades the resulting patch with executable tests.
+        target: swe-bench
+        link: Explore the coding test
+  locomo:
+    title: LoCoMo tests long-term recall.
+    lead: The public dataset contains long, multi-session conversations. PowerContext is evaluated on the answerable question set, where facts can be separated by many sessions.
+    facts:
+      - label: Conversations
+        value: "10"
+      - label: Scored questions
+        value: 1,540
+      - label: Question types
+        value: "4"
+    categories_label: LoCoMo question categories used in the PowerContext result
+    categories:
+      - name: Single-hop
+        count: "841"
+        description: Recover one fact from the conversation history.
+      - name: Temporal
+        count: "321"
+        description: Reason about dates, order, and duration across sessions.
+      - name: Multi-hop
+        count: "282"
+        description: Connect several facts before producing an answer.
+      - name: Open-domain
+        count: "96"
+        description: Combine conversation evidence with general knowledge.
+    results_title: One run, three ways to carry context.
+    results_lead: Switch metrics to compare PowerContext, PowerMem, and placing the entire conversation in the prompt.
+    tabs_label: LoCoMo result metric
+    metrics:
+      - id: accuracy
+        label: Accuracy
+        callout: +37.88 points
+        callout_detail: above full context
+        chart_label: Accuracy comparison. Higher values are better.
+        direction: Higher is better.
+        rows:
+          - name: PowerContext
+            display: 90.78%
+            scale: 90.78
+          - name: PowerMem
+            display: 87.79%
+            scale: 87.79
+          - name: Full context
+            display: 52.9%
+            scale: 52.9
+      - id: latency
+        label: Search p95
+        callout: 12.4x
+        callout_detail: full context took longer
+        chart_label: Search p95 latency comparison. Lower values are better.
+        direction: Lower is better.
+        rows:
+          - name: PowerContext
+            display: 1.38 s
+            scale: 8.06
+          - name: PowerMem
+            display: 1.44 s
+            scale: 8.41
+          - name: Full context
+            display: 17.12 s
+            scale: 100
+      - id: tokens
+        label: Answer tokens
+        callout: 93.7% fewer
+        callout_detail: than full context
+        chart_label: Answer tokens per question comparison. Lower values are better.
+        direction: Lower is better.
+        rows:
+          - name: PowerContext
+            display: about 1.65k
+            scale: 6.35
+          - name: PowerMem
+            display: about 0.9k
+            scale: 3.46
+          - name: Full context
+            display: 26k
+            scale: 100
+    scope_title: What this result covers
+    scope: The 90.78% result is 1,398 correct answers from 1,540 questions in categories 1-4. It does not claim results for LoCoMo event summarization or multimodal dialogue generation.
+  swe:
+    title: SWE-bench Pro tests whether context changes the patch.
+    lead: Each task starts from a real codebase and issue. Codex edits the repository, and the official task tests decide whether the patch resolves the problem.
+    method:
+      - title: Same task set
+        description: 731 public v2 repository issues in both arms.
+      - title: Same model
+        description: gpt-5.6-sol with medium reasoning in Codex.
+      - title: Controlled switch
+        description: OFF disables plugins. ON enables the installed PowerContext plugin.
+    scores:
+      - label: PowerContext OFF
+        count: 602
+        rate: 82.35% resolved
+        accessible: 602 of 731 tasks resolved with PowerContext off
+        kind: "off"
+      - label: PowerContext ON
+        count: 634
+        rate: 86.73% resolved
+        accessible: 634 of 731 tasks resolved with PowerContext on
+        kind: "on"
+    delta: "+32"
+    delta_label: more tasks resolved
+    delta_accessible: PowerContext on resolved 32 more tasks
+    caption: In the reported paired run, PowerContext ON improved task resolution by 4.38 percentage points.
+    scope_title: How to read this result
+    scope: This is a PowerContext paired evaluation on a pinned SWE-bench Pro public v2 dataset, not an official leaderboard submission. Agent runs are stochastic, so the numbers describe this run rather than a universal guarantee.
+  reading:
+    title: Read each result for the question it answers.
+    lead: The two evaluations share a context theme, but their inputs, outputs, and graders are intentionally different.
+    columns:
+      dimension: Evaluation dimension
+    rows:
+      - dimension: What is tested
+        locomo: Long-term conversational recall and reasoning
+        swe: Repository-level issue resolution
+      - dimension: Input
+        locomo: Multi-session dialogue history and a question
+        swe: A repository, an issue, and a clean task environment
+      - dimension: Output
+        locomo: A grounded natural-language answer
+        swe: A code patch
+      - dimension: Primary score
+        locomo: Judge-rated answer accuracy
+        swe: Official executable tests passed
+  sources:
+    title: Evidence and methodology
+    lead: Follow the dataset, paper, harness, and published PowerContext figures from the original sources.
+    items:
+      - type: Paper
+        label: Evaluating Very Long-Term Conversational Memory of LLM Agents
+        href: https://aclanthology.org/2024.acl-long.747/
+        description: The ACL 2024 paper that defines LoCoMo and its long-term memory tasks.
+      - type: Dataset
+        label: snap-research/locomo
+        href: https://github.com/snap-research/locomo
+        description: The public ten-conversation dataset and annotations.
+      - type: Benchmark
+        label: scaleapi/SWE-bench_Pro-os
+        href: https://github.com/scaleapi/SWE-bench_Pro-os
+        description: The public benchmark repository and official evaluation path.
+      - type: Harness
+        label: PowerContext evaluation console
+        href: https://github.com/oceanbase/powercontext/tree/master/evaluation
+        description: The pinned dataset, OFF and ON arms, isolated runner, and reporting contracts.
+      - type: Results
+        label: Published PowerContext benchmark figures
+        href: https://github.com/oceanbase/powercontext#benchmarks
+        description: The current project README values used on this page.
+  cta:
+    title: Inspect the system behind the scores.
+    lead: PowerContext is open source. Review the implementation, evaluation harness, and contracts directly.
+    label: View on GitHub
+    href: https://github.com/oceanbase/powercontext
+---

--- a/docs/en/benchmarks/index.md
+++ b/docs/en/benchmarks/index.md
@@ -154,6 +154,273 @@ benchmark:
     caption: In the reported paired run, PowerContext ON improved task resolution by 4.38 percentage points.
     scope_title: How to read this result
     scope: This is a PowerContext paired evaluation on a pinned SWE-bench Pro public v2 dataset, not an official leaderboard submission. Agent runs are stochastic, so the numbers describe this run rather than a universal guarantee.
+  leaderboards:
+    title: The public score index.
+    lead: Put the published field next to PowerContext, while keeping the test rig visible.
+    tabs_label: Select a benchmark leaderboard
+    updated: Data checked August 31, 2026
+    source_label: View source
+    locomo:
+      id: locomo-rankings
+      tab: LoCoMo public claims
+      count: 15 systems
+      title: LoCoMo scores on all 1,540 questions
+      lead: Only results that explicitly disclose the complete 1,540-question scope are included. Reader, judge, and answer-policy differences remain visible.
+      table_label: LoCoMo public score index with 15 systems evaluated on 1,540 questions
+      columns:
+        rank: Rank
+        system: System
+        score: Score
+        protocol: Published protocol
+        evidence: Evidence
+      note_title: One dataset scope, visible test rigs
+      note: Every row explicitly reports all 1,540 scored questions. Results with an undisclosed or different question count are excluded. The remaining scores still use different readers, judges, and answer policies, so the rank is a public evidence index rather than an official LoCoMo leaderboard.
+      rows:
+        - rank: 1
+          name: Zep
+          score: 94.70%
+          protocol: 1,540 questions; GPT-5.4 reader and judge
+          evidence: Vendor run
+          source: https://www.getzep.com/research/
+        - rank: 2
+          name: EverMemOS
+          score: 94.50%
+          protocol: 1,540 questions; lenient shared harness; precomputed retrieval
+          evidence: Third-party run
+          source: https://github.com/buildingjoshbetter/TrueMemory/blob/main/benchmarks/locomo/BENCHMARK_RESULTS.md
+        - rank: 3
+          name: XMDB
+          score: 93.20%
+          protocol: 1,540 questions; internally verified
+          evidence: Vendor run
+          source: https://xmdb.ai/memory
+        - rank: 4
+          name: TrueMemory Pro
+          score: 93.00%
+          protocol: 1,540 questions; three-run mean; lenient judge
+          evidence: Open harness
+          source: https://github.com/buildingjoshbetter/TrueMemory/blob/main/benchmarks/locomo/BENCHMARK_RESULTS.md
+        - rank: 5
+          name: Mem0
+          score: 92.50%
+          protocol: 1,540 questions; latest vendor evaluation rig
+          evidence: Vendor run
+          source: https://mem0.ai/research
+        - rank: 6
+          name: PowerContext
+          score: 90.78%
+          protocol: 1,540 questions; 1,398 correct; topical judge
+          evidence: Project run
+          source: https://github.com/oceanbase/powercontext#benchmarks
+          highlight: true
+        - rank: 7
+          name: Honcho
+          score: 89.90%
+          protocol: 1,540 questions; current full-system result
+          evidence: Vendor run
+          source: https://honcho.dev/blog/blog/benchmarking-honcho
+        - rank: 8
+          name: Dakera
+          score: 88.20%
+          protocol: 1,540 questions; single pass; no LLM reranker
+          evidence: Reproducible vendor run
+          source: https://dakera.ai/benchmark/
+        - rank: 9
+          name: PowerMem
+          score: 87.79%
+          protocol: 1,540 questions; historical project run
+          evidence: Project run
+          source: https://github.com/oceanbase/powercontext#benchmarks
+        - rank: 10
+          name: Memvid
+          score: 85.65%
+          protocol: 1,540 questions; GPT-4o reader; lenient judge
+          evidence: Open harness
+          source: https://github.com/memvid/memvidbench
+        - rank: 11
+          name: Genesys
+          score: 85.55%
+          protocol: 1,540 questions; ten-run mean; frozen Mem0 protocol
+          evidence: Certified vendor run
+          source: https://genesys.astrixlabs.ai/developers/methodology
+        - rank: 12
+          name: Engram
+          score: 84.50%
+          protocol: 1,540 questions; shared lenient harness
+          evidence: Third-party run
+          source: https://github.com/buildingjoshbetter/TrueMemory/blob/main/benchmarks/locomo/BENCHMARK_RESULTS.md
+        - rank: 13
+          name: MemHQ
+          score: 83.20%
+          protocol: 1,540 questions; gpt-4o-mini; partial answers accepted
+          evidence: Open harness
+          source: https://memhq.ai/benchmark
+        - rank: 14
+          name: Logica Mind
+          score: 72.50%
+          protocol: 1,540 questions; Mem0 paper protocol
+          evidence: Open harness
+          source: https://huggingface.co/datasets/rovemark/locomo-benchmark-results
+        - rank: 15
+          name: Supermemory
+          score: 65.40%
+          protocol: 1,540 questions; shared lenient harness
+          evidence: Third-party run
+          source: https://github.com/buildingjoshbetter/TrueMemory/blob/main/benchmarks/locomo/BENCHMARK_RESULTS.md
+    swe:
+      id: swe-rankings
+      tab: SWE-bench Pro official
+      count: 25 official entries
+      title: Every official public entry
+      lead: Scale currently publishes 25 model runs, not 30 memory products. Official Rank (UB), resolve rate, confidence interval, and harness marker are preserved below.
+      table_label: SWE-bench Pro official public leaderboard with 25 entries
+      source: https://labs.scale.com/leaderboard/swe_bench_pro_public
+      note_title: Why PowerContext is not ranked here
+      note: Scale defines Rank (UB) as one plus the number of models whose lower confidence bound exceeds that run's upper bound; an asterisk marks mini-swe-agent. PowerContext reports a separate Codex paired A/B on the same 731-task public set. Its 86.73% is not an official submission and cannot be inserted into this ranking.
+      spotlight:
+        label: PowerContext paired run
+        value: 86.73%
+        detail: 634 of 731 resolved with PowerContext ON
+        status: Separate protocol, not officially ranked
+      columns:
+        rank: Official rank
+        system: Model
+        score: Resolve rate
+        provider: Provider
+        harness: Harness
+      harness_default: Scale run
+      harness_star: mini-swe-agent
+      rows:
+        - rank: 1
+          name: Muse Spark 1.1
+          provider: Meta
+          score: 61.50%
+          ci: ±3.10
+          star: true
+        - rank: 1
+          name: gpt-5.4 (xHigh)
+          provider: OpenAI
+          score: 59.10%
+          ci: ±3.56
+          star: true
+        - rank: 3
+          name: Muse Spark
+          provider: Meta
+          score: 55.00%
+          ci: ±3.60
+          star: true
+        - rank: 3
+          name: claude-opus-4-6 (thinking)
+          provider: Anthropic
+          score: 51.90%
+          ci: ±3.61
+          star: true
+        - rank: 5
+          name: gemini-3.1-pro (thinking)
+          provider: Google
+          score: 46.10%
+          ci: ±3.60
+          star: true
+        - rank: 5
+          name: claude-opus-4-5-20251101
+          provider: Anthropic
+          score: 45.89%
+          ci: ±3.60
+        - rank: 5
+          name: claude-4-5-Sonnet
+          provider: Anthropic
+          score: 43.60%
+          ci: ±3.60
+        - rank: 5
+          name: gemini-3-pro-preview
+          provider: Google
+          score: 43.30%
+          ci: ±3.60
+        - rank: 5
+          name: claude-4-Sonnet
+          provider: Anthropic
+          score: 42.70%
+          ci: ±3.59
+        - rank: 10
+          name: gpt-5-2025-08-07 (High)
+          provider: OpenAI
+          score: 41.78%
+          ci: ±3.49
+        - rank: 10
+          name: gpt-5.2-codex
+          provider: OpenAI
+          score: 41.04%
+          ci: ±3.57
+        - rank: 10
+          name: claude-4-5-haiku
+          provider: Anthropic
+          score: 39.45%
+          ci: ±3.55
+        - rank: 10
+          name: qwen3-coder-480b-a35b
+          provider: Alibaba
+          score: 38.70%
+          ci: ±3.55
+        - rank: 14
+          name: minimax-2.1
+          provider: MiniMax
+          score: 36.81%
+          ci: ±3.55
+        - rank: 14
+          name: gemini-3-flash
+          provider: Google
+          score: 34.63%
+          ci: ±3.55
+        - rank: 16
+          name: gpt-5.2
+          provider: OpenAI
+          score: 29.94%
+          ci: ±2.15
+        - rank: 16
+          name: kimi-k2-instruct
+          provider: Moonshot
+          score: 27.67%
+          ci: ±3.25
+        - rank: 18
+          name: qwen3-235b-a22b
+          provider: Alibaba
+          score: 21.41%
+          ci: ±2.25
+        - rank: 19
+          name: gpt-oss-120b
+          provider: OpenAI
+          score: 16.20%
+          ci: ±2.67
+        - rank: 19
+          name: deepseek-v3p2
+          provider: DeepSeek
+          score: 15.56%
+          ci: ±2.63
+        - rank: 21
+          name: gemma-3-27b-it
+          provider: Google
+          score: 11.38%
+          ci: ±2.15
+        - rank: 21
+          name: llama3-1-405b-instruct
+          provider: Meta
+          score: 11.18%
+          ci: ±2.15
+        - rank: 21
+          name: glm-4.6
+          provider: Z.ai
+          score: 9.67%
+          ci: ±2.15
+        - rank: 24
+          name: llama4-maverick-17b-instruct
+          provider: Meta
+          score: 5.24%
+          ci: ±1.24
+        - rank: 25
+          name: codestral-2405
+          provider: Mistral
+          score: 1.51%
+          ci: ±1.51
   reading:
     title: Read each result for the question it answers.
     lead: The two evaluations share a context theme, but their inputs, outputs, and graders are intentionally different.

--- a/docs/en/blog/index.md
+++ b/docs/en/blog/index.md
@@ -12,10 +12,10 @@ hide:
 <p class="pc-page-lead">Engineering notes and design explanations from the PowerContext maintainers.</p>
 
 <section class="pc-blog-empty pc-listing-list pc-listing-row">
-  <p class="pc-blog-empty__date pc-listing-meta">No posts yet</p>
+  <p class="pc-blog-empty__date pc-listing-meta">Benchmarks</p>
   <div class="pc-listing-content">
-    <h2>Engineering notes will start with implemented work.</h2>
-    <p>The project currently records product and API decisions as RFCs. A post belongs here only when there is a concrete implementation or operating lesson to examine.</p>
-    <p><a href="../rfcs/">Read the current RFCs <span aria-hidden="true">→</span></a></p>
+    <h2>Long-term memory and real repository work, measured.</h2>
+    <p>See what LoCoMo and SWE-bench Pro evaluate, how PowerContext was tested, and what the reported results do and do not prove.</p>
+    <p><a href="../benchmarks/">Explore the benchmarks <span aria-hidden="true">→</span></a></p>
   </div>
 </section>

--- a/docs/zh/benchmarks/index.md
+++ b/docs/zh/benchmarks/index.md
@@ -1,17 +1,17 @@
 ---
 template: benchmark.html
 page_type: benchmark
-title: Benchmark
+title: 评估测试
 description: PowerContext 在长程对话记忆与真实仓库软件工程评测中的表现。
 hide:
   - navigation
   - toc
 benchmark:
   hero:
-    label: Benchmark 评测证据
+    label: 评估测试证据
     title:
       - 把上下文能力，
-      - 放进压力测试。
+      - 交给评估测试。
     lead: 两项公开评测，分别检验长程记忆与真实仓库软件工程，并给出可核对的结果。
     actions_label: 跳转到具体评测
     actions:
@@ -36,7 +36,7 @@ benchmark:
         accessible: 任务解决率 86.73%
         metric: 开启 PowerContext 后的任务解决率
   orientation:
-    title: 两个 Benchmark，回答两个不同问题。
+    title: 两项评估测试，回答两个不同问题。
     lead: Agent 先要找回发生过什么，再要把上下文用于真实工作。两项评测分别检验这两层能力。
     tests:
       - name: LoCoMo
@@ -154,6 +154,273 @@ benchmark:
     caption: 在这次配对运行中，PowerContext ON 将任务解决率提高了 4.38 个百分点。
     scope_title: 如何理解这组结果
     scope: 这是 PowerContext 在固定 SWE-bench Pro public v2 数据集上的配对评测，不是官方排行榜提交。Agent 运行存在随机性，因此数字描述的是本次运行，而不是对所有运行的普遍保证。
+  leaderboards:
+    title: 公开分数 PK 榜。
+    lead: 把 PowerContext 放进公开视野，同时把每个分数背后的评测装置讲清楚。
+    tabs_label: 选择评测榜单
+    updated: 数据核验于 2026 年 8 月 31 日
+    source_label: 查看来源
+    locomo:
+      id: locomo-rankings
+      tab: LoCoMo 公开声明
+      count: 15 个系统
+      title: 完整 1,540 题 LoCoMo 分数
+      lead: 只收录明确披露完整 1,540 题范围的结果，同时保留 Reader、Judge 和答案判定策略的差异。
+      table_label: 15 个完成 1,540 题评测的 LoCoMo 公开分数索引
+      columns:
+        rank: 名次
+        system: 系统
+        score: 分数
+        protocol: 公开评测口径
+        evidence: 证据类型
+      note_title: 统一题目范围，保留评测装置差异
+      note: 每一行都明确报告了全部 1,540 道计分题，未披露题目数或题目数不同的结果均已排除。其余结果仍使用不同的 Reader、Judge 和答案判定策略，因此这是公开证据索引，不是 LoCoMo 官方排行榜。
+      rows:
+        - rank: 1
+          name: Zep
+          score: 94.70%
+          protocol: 1,540 题；GPT-5.4 Reader 和 Judge
+          evidence: 供应商实测
+          source: https://www.getzep.com/research/
+        - rank: 2
+          name: EverMemOS
+          score: 94.50%
+          protocol: 1,540 题；宽松共享工具；预计算检索
+          evidence: 第三方实测
+          source: https://github.com/buildingjoshbetter/TrueMemory/blob/main/benchmarks/locomo/BENCHMARK_RESULTS.md
+        - rank: 3
+          name: XMDB
+          score: 93.20%
+          protocol: 1,540 题；内部验证
+          evidence: 供应商实测
+          source: https://xmdb.ai/memory
+        - rank: 4
+          name: TrueMemory Pro
+          score: 93.00%
+          protocol: 1,540 题；三次均值；宽松 Judge
+          evidence: 开放评测工具
+          source: https://github.com/buildingjoshbetter/TrueMemory/blob/main/benchmarks/locomo/BENCHMARK_RESULTS.md
+        - rank: 5
+          name: Mem0
+          score: 92.50%
+          protocol: 1,540 题；最新供应商评测装置
+          evidence: 供应商实测
+          source: https://mem0.ai/research
+        - rank: 6
+          name: PowerContext
+          score: 90.78%
+          protocol: 1,540 题；答对 1,398 题；topical Judge
+          evidence: 项目实测
+          source: https://github.com/oceanbase/powercontext#benchmarks
+          highlight: true
+        - rank: 7
+          name: Honcho
+          score: 89.90%
+          protocol: 1,540 题；当前完整系统结果
+          evidence: 供应商实测
+          source: https://honcho.dev/blog/blog/benchmarking-honcho
+        - rank: 8
+          name: Dakera
+          score: 88.20%
+          protocol: 1,540 题；单次检索；没有 LLM 重排
+          evidence: 可复现供应商实测
+          source: https://dakera.ai/benchmark/
+        - rank: 9
+          name: PowerMem
+          score: 87.79%
+          protocol: 1,540 题；历史项目实测
+          evidence: 项目实测
+          source: https://github.com/oceanbase/powercontext#benchmarks
+        - rank: 10
+          name: Memvid
+          score: 85.65%
+          protocol: 1,540 题；GPT-4o Reader；宽松 Judge
+          evidence: 开放评测工具
+          source: https://github.com/memvid/memvidbench
+        - rank: 11
+          name: Genesys
+          score: 85.55%
+          protocol: 1,540 题；十次均值；固定 Mem0 协议
+          evidence: 认证供应商实测
+          source: https://genesys.astrixlabs.ai/developers/methodology
+        - rank: 12
+          name: Engram
+          score: 84.50%
+          protocol: 1,540 题；共享宽松评测工具
+          evidence: 第三方实测
+          source: https://github.com/buildingjoshbetter/TrueMemory/blob/main/benchmarks/locomo/BENCHMARK_RESULTS.md
+        - rank: 13
+          name: MemHQ
+          score: 83.20%
+          protocol: 1,540 题；gpt-4o-mini；部分正确计入
+          evidence: 开放评测工具
+          source: https://memhq.ai/benchmark
+        - rank: 14
+          name: Logica Mind
+          score: 72.50%
+          protocol: 1,540 题；Mem0 论文协议
+          evidence: 开放评测工具
+          source: https://huggingface.co/datasets/rovemark/locomo-benchmark-results
+        - rank: 15
+          name: Supermemory
+          score: 65.40%
+          protocol: 1,540 题；共享宽松评测工具
+          evidence: 第三方实测
+          source: https://github.com/buildingjoshbetter/TrueMemory/blob/main/benchmarks/locomo/BENCHMARK_RESULTS.md
+    swe:
+      id: swe-rankings
+      tab: SWE-bench Pro 官方榜
+      count: 25 个官方条目
+      title: 官方 Public 榜全部条目
+      lead: Scale 当前只公开 25 个模型实测，不是 30 个记忆产品。下表保留官方 Rank (UB)、解决率、置信区间和工具标记。
+      table_label: 包含 25 个条目的 SWE-bench Pro 官方 Public 排行榜
+      source: https://labs.scale.com/leaderboard/swe_bench_pro_public
+      note_title: 为什么 PowerContext 没有被插入官方名次
+      note: Scale 将 Rank (UB) 定义为：下置信界高于该结果上置信界的模型数量再加 1；星号表示 mini-swe-agent。PowerContext 是在同一 731 题 Public 集上完成的另一组 Codex 配对 A/B。86.73% 不是官方提交，不能直接插入此榜排名。
+      spotlight:
+        label: PowerContext 配对实测
+        value: 86.73%
+        detail: PowerContext ON 解决 634 / 731 题
+        status: 不同协议，未进入官方排名
+      columns:
+        rank: 官方名次
+        system: 模型
+        score: 解决率
+        provider: 提供方
+        harness: 评测工具
+      harness_default: Scale 实测
+      harness_star: mini-swe-agent
+      rows:
+        - rank: 1
+          name: Muse Spark 1.1
+          provider: Meta
+          score: 61.50%
+          ci: ±3.10
+          star: true
+        - rank: 1
+          name: gpt-5.4 (xHigh)
+          provider: OpenAI
+          score: 59.10%
+          ci: ±3.56
+          star: true
+        - rank: 3
+          name: Muse Spark
+          provider: Meta
+          score: 55.00%
+          ci: ±3.60
+          star: true
+        - rank: 3
+          name: claude-opus-4-6 (thinking)
+          provider: Anthropic
+          score: 51.90%
+          ci: ±3.61
+          star: true
+        - rank: 5
+          name: gemini-3.1-pro (thinking)
+          provider: Google
+          score: 46.10%
+          ci: ±3.60
+          star: true
+        - rank: 5
+          name: claude-opus-4-5-20251101
+          provider: Anthropic
+          score: 45.89%
+          ci: ±3.60
+        - rank: 5
+          name: claude-4-5-Sonnet
+          provider: Anthropic
+          score: 43.60%
+          ci: ±3.60
+        - rank: 5
+          name: gemini-3-pro-preview
+          provider: Google
+          score: 43.30%
+          ci: ±3.60
+        - rank: 5
+          name: claude-4-Sonnet
+          provider: Anthropic
+          score: 42.70%
+          ci: ±3.59
+        - rank: 10
+          name: gpt-5-2025-08-07 (High)
+          provider: OpenAI
+          score: 41.78%
+          ci: ±3.49
+        - rank: 10
+          name: gpt-5.2-codex
+          provider: OpenAI
+          score: 41.04%
+          ci: ±3.57
+        - rank: 10
+          name: claude-4-5-haiku
+          provider: Anthropic
+          score: 39.45%
+          ci: ±3.55
+        - rank: 10
+          name: qwen3-coder-480b-a35b
+          provider: Alibaba
+          score: 38.70%
+          ci: ±3.55
+        - rank: 14
+          name: minimax-2.1
+          provider: MiniMax
+          score: 36.81%
+          ci: ±3.55
+        - rank: 14
+          name: gemini-3-flash
+          provider: Google
+          score: 34.63%
+          ci: ±3.55
+        - rank: 16
+          name: gpt-5.2
+          provider: OpenAI
+          score: 29.94%
+          ci: ±2.15
+        - rank: 16
+          name: kimi-k2-instruct
+          provider: Moonshot
+          score: 27.67%
+          ci: ±3.25
+        - rank: 18
+          name: qwen3-235b-a22b
+          provider: Alibaba
+          score: 21.41%
+          ci: ±2.25
+        - rank: 19
+          name: gpt-oss-120b
+          provider: OpenAI
+          score: 16.20%
+          ci: ±2.67
+        - rank: 19
+          name: deepseek-v3p2
+          provider: DeepSeek
+          score: 15.56%
+          ci: ±2.63
+        - rank: 21
+          name: gemma-3-27b-it
+          provider: Google
+          score: 11.38%
+          ci: ±2.15
+        - rank: 21
+          name: llama3-1-405b-instruct
+          provider: Meta
+          score: 11.18%
+          ci: ±2.15
+        - rank: 21
+          name: glm-4.6
+          provider: Z.ai
+          score: 9.67%
+          ci: ±2.15
+        - rank: 24
+          name: llama4-maverick-17b-instruct
+          provider: Meta
+          score: 5.24%
+          ci: ±1.24
+        - rank: 25
+          name: codestral-2405
+          provider: Mistral
+          score: 1.51%
+          ci: ±1.51
   reading:
     title: 用每项结果回答它真正评测的问题。
     lead: 两项评测都与上下文有关，但输入、输出与评分方式不同，不能把两个分数直接横向比较。
@@ -184,16 +451,16 @@ benchmark:
         label: snap-research/locomo
         href: https://github.com/snap-research/locomo
         description: 包含十段长对话与标注的公开数据集。
-      - type: Benchmark
+      - type: 评估测试
         label: scaleapi/SWE-bench_Pro-os
         href: https://github.com/scaleapi/SWE-bench_Pro-os
-        description: 公开 Benchmark 仓库与正式评测路径。
+        description: 公开评估测试仓库与正式评测路径。
       - type: 评测工具
         label: PowerContext evaluation console
         href: https://github.com/oceanbase/powercontext/tree/master/evaluation
         description: 固定数据集、OFF 与 ON 分组、隔离 Runner 和报告约束。
       - type: 结果
-        label: PowerContext 已发布的 Benchmark 数据
+        label: PowerContext 已发布的评估测试数据
         href: https://github.com/oceanbase/powercontext#benchmarks
         description: 本页面使用的当前项目 README 数据。
   cta:

--- a/docs/zh/benchmarks/index.md
+++ b/docs/zh/benchmarks/index.md
@@ -1,0 +1,204 @@
+---
+template: benchmark.html
+page_type: benchmark
+title: Benchmark
+description: PowerContext 在长程对话记忆与真实仓库软件工程评测中的表现。
+hide:
+  - navigation
+  - toc
+benchmark:
+  hero:
+    label: Benchmark 评测证据
+    title:
+      - 把上下文能力，
+      - 放进压力测试。
+    lead: 两项公开评测，分别检验长程记忆与真实仓库软件工程，并给出可核对的结果。
+    actions_label: 跳转到具体评测
+    actions:
+      - label: 查看 LoCoMo
+        target: locomo
+      - label: 查看 SWE-bench
+        target: swe-bench
+    visual_label: LoCoMo 与 SWE-bench Pro 评测的关键结果
+    results:
+      - name: LoCoMo
+        value: 90.78
+        decimals: 2
+        suffix: "%"
+        display: 90.78%
+        accessible: 问答准确率 90.78%
+        metric: 问答准确率
+      - name: SWE-bench Pro
+        value: 86.73
+        decimals: 2
+        suffix: "%"
+        display: 86.73%
+        accessible: 任务解决率 86.73%
+        metric: 开启 PowerContext 后的任务解决率
+  orientation:
+    title: 两个 Benchmark，回答两个不同问题。
+    lead: Agent 先要找回发生过什么，再要把上下文用于真实工作。两项评测分别检验这两层能力。
+    tests:
+      - name: LoCoMo
+        question: 系统能记住一段长期对话吗？
+        answer: 评测直接回忆、时间推理、多步推理，以及结合对话证据的开放域回答。
+        target: locomo
+        link: 查看记忆评测
+      - name: SWE-bench Pro
+        question: Agent 能把上下文变成可用补丁吗？
+        answer: 给 Codex 一个真实仓库和 Issue，再用可执行测试评判最终补丁。
+        target: swe-bench
+        link: 查看编码评测
+  locomo:
+    title: LoCoMo 检验长程记忆。
+    lead: 公开数据集包含跨多个 Session 的长对话。PowerContext 在可回答问题集上接受评测，相关事实可能相隔很多轮对话。
+    facts:
+      - label: 长对话
+        value: "10"
+      - label: 计分问题
+        value: 1,540
+      - label: 问题类型
+        value: "4"
+    categories_label: PowerContext 结果覆盖的 LoCoMo 问题类型
+    categories:
+      - name: 单跳回忆
+        count: "841"
+        description: 从长对话中找回一条明确事实。
+      - name: 时间推理
+        count: "321"
+        description: 推理跨 Session 的日期、顺序与持续时间。
+      - name: 多跳推理
+        count: "282"
+        description: 连接多条事实后生成答案。
+      - name: 开放域问答
+        count: "96"
+        description: 结合对话证据与通用知识回答。
+    results_title: 同一次评测，三种上下文方式。
+    results_lead: 切换指标，对比 PowerContext、PowerMem，以及把完整对话直接放入 Prompt 的方式。
+    tabs_label: LoCoMo 结果指标
+    metrics:
+      - id: accuracy
+        label: 准确率
+        callout: +37.88 个百分点
+        callout_detail: 相比完整上下文
+        chart_label: 准确率对比，越高越好。
+        direction: 越高越好。
+        rows:
+          - name: PowerContext
+            display: 90.78%
+            scale: 90.78
+          - name: PowerMem
+            display: 87.79%
+            scale: 87.79
+          - name: 完整上下文
+            display: 52.9%
+            scale: 52.9
+      - id: latency
+        label: 搜索 p95
+        callout: 12.4 倍
+        callout_detail: 完整上下文耗时更多
+        chart_label: 搜索 p95 延迟对比，越低越好。
+        direction: 越低越好。
+        rows:
+          - name: PowerContext
+            display: 1.38 秒
+            scale: 8.06
+          - name: PowerMem
+            display: 1.44 秒
+            scale: 8.41
+          - name: 完整上下文
+            display: 17.12 秒
+            scale: 100
+      - id: tokens
+        label: 回答 Token
+        callout: 减少 93.7%
+        callout_detail: 相比完整上下文
+        chart_label: 单个问题的回答 Token 对比，越低越好。
+        direction: 越低越好。
+        rows:
+          - name: PowerContext
+            display: 约 1.65k
+            scale: 6.35
+          - name: PowerMem
+            display: 约 0.9k
+            scale: 3.46
+          - name: 完整上下文
+            display: 26k
+            scale: 100
+    scope_title: 结果覆盖范围
+    scope: 90.78% 来自类别 1-4 的 1,540 个问题，其中答对 1,398 个。该结果不代表 LoCoMo 的事件总结或多模态对话生成任务。
+  swe:
+    title: SWE-bench Pro 检验上下文是否改变补丁结果。
+    lead: 每个任务都从真实代码库与 Issue 开始。Codex 修改仓库，再由任务自带的正式测试判断补丁是否解决问题。
+    method:
+      - title: 相同任务集
+        description: OFF 与 ON 都运行 public v2 的 731 个仓库问题。
+      - title: 相同模型
+        description: Codex 使用 gpt-5.6-sol，推理等级为 medium。
+      - title: 受控开关
+        description: OFF 禁用 Plugin，ON 启用已安装的 PowerContext Plugin。
+    scores:
+      - label: PowerContext OFF
+        count: 602
+        rate: 解决率 82.35%
+        accessible: 关闭 PowerContext 时，731 个任务中解决 602 个
+        kind: "off"
+      - label: PowerContext ON
+        count: 634
+        rate: 解决率 86.73%
+        accessible: 开启 PowerContext 时，731 个任务中解决 634 个
+        kind: "on"
+    delta: "+32"
+    delta_label: 个任务被额外解决
+    delta_accessible: 开启 PowerContext 后多解决 32 个任务
+    caption: 在这次配对运行中，PowerContext ON 将任务解决率提高了 4.38 个百分点。
+    scope_title: 如何理解这组结果
+    scope: 这是 PowerContext 在固定 SWE-bench Pro public v2 数据集上的配对评测，不是官方排行榜提交。Agent 运行存在随机性，因此数字描述的是本次运行，而不是对所有运行的普遍保证。
+  reading:
+    title: 用每项结果回答它真正评测的问题。
+    lead: 两项评测都与上下文有关，但输入、输出与评分方式不同，不能把两个分数直接横向比较。
+    columns:
+      dimension: 评测维度
+    rows:
+      - dimension: 评测内容
+        locomo: 长程对话记忆与推理
+        swe: 仓库级 Issue 修复
+      - dimension: 输入
+        locomo: 多 Session 对话历史与一个问题
+        swe: 代码仓库、Issue 与干净任务环境
+      - dimension: 输出
+        locomo: 有对话依据的自然语言答案
+        swe: 代码补丁
+      - dimension: 主要评分
+        locomo: Judge 判定的答案准确率
+        swe: 正式可执行测试是否通过
+  sources:
+    title: 证据与评测方法
+    lead: 从原始论文、数据集、评测工具与 PowerContext 发布结果核对页面中的结论。
+    items:
+      - type: 论文
+        label: Evaluating Very Long-Term Conversational Memory of LLM Agents
+        href: https://aclanthology.org/2024.acl-long.747/
+        description: 定义 LoCoMo 与长程记忆任务的 ACL 2024 论文。
+      - type: 数据集
+        label: snap-research/locomo
+        href: https://github.com/snap-research/locomo
+        description: 包含十段长对话与标注的公开数据集。
+      - type: Benchmark
+        label: scaleapi/SWE-bench_Pro-os
+        href: https://github.com/scaleapi/SWE-bench_Pro-os
+        description: 公开 Benchmark 仓库与正式评测路径。
+      - type: 评测工具
+        label: PowerContext evaluation console
+        href: https://github.com/oceanbase/powercontext/tree/master/evaluation
+        description: 固定数据集、OFF 与 ON 分组、隔离 Runner 和报告约束。
+      - type: 结果
+        label: PowerContext 已发布的 Benchmark 数据
+        href: https://github.com/oceanbase/powercontext#benchmarks
+        description: 本页面使用的当前项目 README 数据。
+  cta:
+    title: 查看分数背后的系统。
+    lead: PowerContext 完全开源，可直接检查实现、评测工具与核心契约。
+    label: 前往 GitHub
+    href: https://github.com/oceanbase/powercontext
+---

--- a/docs/zh/blog/index.md
+++ b/docs/zh/blog/index.md
@@ -12,10 +12,10 @@ hide:
 <p class="pc-page-lead">由 PowerContext 维护者发布的工程实践与设计解释。</p>
 
 <section class="pc-blog-empty pc-listing-list pc-listing-row">
-  <p class="pc-blog-empty__date pc-listing-meta">Benchmark</p>
+  <p class="pc-blog-empty__date pc-listing-meta">评估测试</p>
   <div class="pc-listing-content">
     <h2>用结果检验长程记忆与真实仓库工作。</h2>
     <p>了解 LoCoMo 与 SWE-bench Pro 具体评测什么、PowerContext 如何运行，以及这些结果能证明和不能证明什么。</p>
-    <p><a href="../benchmarks/">查看 Benchmark <span aria-hidden="true">→</span></a></p>
+    <p><a href="../benchmarks/">查看评估测试 <span aria-hidden="true">→</span></a></p>
   </div>
 </section>

--- a/docs/zh/blog/index.md
+++ b/docs/zh/blog/index.md
@@ -12,10 +12,10 @@ hide:
 <p class="pc-page-lead">由 PowerContext 维护者发布的工程实践与设计解释。</p>
 
 <section class="pc-blog-empty pc-listing-list pc-listing-row">
-  <p class="pc-blog-empty__date pc-listing-meta">尚无文章</p>
+  <p class="pc-blog-empty__date pc-listing-meta">Benchmark</p>
   <div class="pc-listing-content">
-    <h2>工程记录从已经实现的工作开始。</h2>
-    <p>项目目前通过 RFC 记录产品与 API 决策。只有形成具体实现经验或运行结论后，内容才会发布在这里。</p>
-    <p><a href="../rfcs/">阅读当前 RFC <span aria-hidden="true">→</span></a></p>
+    <h2>用结果检验长程记忆与真实仓库工作。</h2>
+    <p>了解 LoCoMo 与 SWE-bench Pro 具体评测什么、PowerContext 如何运行，以及这些结果能证明和不能证明什么。</p>
+    <p><a href="../benchmarks/">查看 Benchmark <span aria-hidden="true">→</span></a></p>
   </div>
 </section>

--- a/theme/powercontext/assets/javascripts/benchmark.js
+++ b/theme/powercontext/assets/javascripts/benchmark.js
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function () {
+  const initialized = new WeakSet();
+
+  function prefersReducedMotion() {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+
+  function animateCounter(element) {
+    if (element.dataset.countAnimated === "true") {
+      return;
+    }
+    element.dataset.countAnimated = "true";
+
+    const target = Number.parseFloat(element.dataset.countTo || "0");
+    const decimals = Number.parseInt(element.dataset.countDecimals || "0", 10);
+    const suffix = element.dataset.countSuffix || "";
+
+    if (!Number.isFinite(target) || prefersReducedMotion()) {
+      element.textContent = `${target.toFixed(decimals)}${suffix}`;
+      return;
+    }
+
+    const formatter = new Intl.NumberFormat(document.documentElement.lang || "en", {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+    const duration = 1050;
+    const startedAt = performance.now();
+    element.textContent = `${formatter.format(0)}${suffix}`;
+
+    function frame(now) {
+      const progress = Math.min((now - startedAt) / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 4);
+      element.textContent = `${formatter.format(target * eased)}${suffix}`;
+      if (progress < 1 && document.documentElement.contains(element)) {
+        window.requestAnimationFrame(frame);
+      }
+    }
+
+    window.requestAnimationFrame(frame);
+  }
+
+  function reveal(element) {
+    element.classList.add("is-visible");
+    element.querySelectorAll("[data-count-to]").forEach(animateCounter);
+    if (element.matches("[data-count-to]")) {
+      animateCounter(element);
+    }
+  }
+
+  function activateMetric(comparison, id, focusTab) {
+    const tabs = Array.from(comparison.querySelectorAll("[data-metric-target]"));
+    const panels = Array.from(comparison.querySelectorAll("[data-metric-panel]"));
+    const activeTab = tabs.find((tab) => tab.dataset.metricTarget === id);
+    const activePanel = panels.find((panel) => panel.dataset.metricPanel === id);
+
+    if (!activeTab || !activePanel) {
+      return;
+    }
+
+    tabs.forEach((tab) => {
+      const selected = tab === activeTab;
+      tab.setAttribute("aria-selected", selected ? "true" : "false");
+      tab.tabIndex = selected ? 0 : -1;
+    });
+    panels.forEach((panel) => {
+      panel.classList.remove("is-active", "is-playing");
+      panel.hidden = panel !== activePanel;
+    });
+
+    activePanel.classList.add("is-active");
+    window.requestAnimationFrame(() => activePanel.classList.add("is-playing"));
+    if (focusTab) {
+      activeTab.focus();
+    }
+  }
+
+  function enhanceMetricComparison(comparison) {
+    comparison.classList.add("is-enhanced");
+    const tabs = Array.from(comparison.querySelectorAll("[data-metric-target]"));
+    const initial = tabs.find((tab) => tab.getAttribute("aria-selected") === "true") || tabs[0];
+    if (!initial) {
+      return;
+    }
+
+    activateMetric(comparison, initial.dataset.metricTarget, false);
+
+    tabs.forEach((tab, index) => {
+      tab.addEventListener("click", () => activateMetric(comparison, tab.dataset.metricTarget, false));
+      tab.addEventListener("keydown", (event) => {
+        let nextIndex = index;
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          nextIndex = (index + 1) % tabs.length;
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          nextIndex = (index - 1 + tabs.length) % tabs.length;
+        } else if (event.key === "Home") {
+          nextIndex = 0;
+        } else if (event.key === "End") {
+          nextIndex = tabs.length - 1;
+        } else {
+          return;
+        }
+        event.preventDefault();
+        activateMetric(comparison, tabs[nextIndex].dataset.metricTarget, true);
+      });
+    });
+  }
+
+  function initBenchmark() {
+    const page = document.querySelector(".pc-benchmark");
+    if (!page || initialized.has(page)) {
+      return;
+    }
+    initialized.add(page);
+
+    page.querySelectorAll("[data-metric-comparison]").forEach(enhanceMetricComparison);
+    const revealTargets = Array.from(page.querySelectorAll("[data-benchmark-reveal]"));
+
+    if (prefersReducedMotion() || !("IntersectionObserver" in window)) {
+      revealTargets.forEach(reveal);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+          reveal(entry.target);
+          observer.unobserve(entry.target);
+        });
+      },
+      { rootMargin: "0px 0px -8%", threshold: 0.16 },
+    );
+    revealTargets.forEach((target) => observer.observe(target));
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initBenchmark);
+  } else {
+    initBenchmark();
+  }
+
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(initBenchmark);
+  }
+})();

--- a/theme/powercontext/assets/javascripts/benchmark.js
+++ b/theme/powercontext/assets/javascripts/benchmark.js
@@ -122,6 +122,64 @@
     });
   }
 
+  function activateLeaderboard(leaderboards, id, focusTab) {
+    const tabs = Array.from(leaderboards.querySelectorAll("[data-leaderboard-target]"));
+    const panels = Array.from(leaderboards.querySelectorAll("[data-leaderboard-panel]"));
+    const activeTab = tabs.find((tab) => tab.dataset.leaderboardTarget === id);
+    const activePanel = panels.find((panel) => panel.dataset.leaderboardPanel === id);
+
+    if (!activeTab || !activePanel) {
+      return;
+    }
+
+    tabs.forEach((tab) => {
+      const selected = tab === activeTab;
+      tab.setAttribute("aria-selected", selected ? "true" : "false");
+      tab.tabIndex = selected ? 0 : -1;
+    });
+    panels.forEach((panel) => {
+      panel.classList.remove("is-active", "is-playing");
+      panel.hidden = panel !== activePanel;
+    });
+
+    activePanel.classList.add("is-active");
+    window.requestAnimationFrame(() => activePanel.classList.add("is-playing"));
+    if (focusTab) {
+      activeTab.focus();
+    }
+  }
+
+  function enhanceLeaderboards(leaderboards) {
+    leaderboards.classList.add("is-enhanced");
+    const tabs = Array.from(leaderboards.querySelectorAll("[data-leaderboard-target]"));
+    const initial = tabs.find((tab) => tab.getAttribute("aria-selected") === "true") || tabs[0];
+    if (!initial) {
+      return;
+    }
+
+    activateLeaderboard(leaderboards, initial.dataset.leaderboardTarget, false);
+
+    tabs.forEach((tab, index) => {
+      tab.addEventListener("click", () => activateLeaderboard(leaderboards, tab.dataset.leaderboardTarget, false));
+      tab.addEventListener("keydown", (event) => {
+        let nextIndex = index;
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          nextIndex = (index + 1) % tabs.length;
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          nextIndex = (index - 1 + tabs.length) % tabs.length;
+        } else if (event.key === "Home") {
+          nextIndex = 0;
+        } else if (event.key === "End") {
+          nextIndex = tabs.length - 1;
+        } else {
+          return;
+        }
+        event.preventDefault();
+        activateLeaderboard(leaderboards, tabs[nextIndex].dataset.leaderboardTarget, true);
+      });
+    });
+  }
+
   function initBenchmark() {
     const page = document.querySelector(".pc-benchmark");
     if (!page || initialized.has(page)) {
@@ -130,6 +188,7 @@
     initialized.add(page);
 
     page.querySelectorAll("[data-metric-comparison]").forEach(enhanceMetricComparison);
+    page.querySelectorAll("[data-leaderboards]").forEach(enhanceLeaderboards);
     const revealTargets = Array.from(page.querySelectorAll("[data-benchmark-reveal]"));
 
     if (prefersReducedMotion() || !("IntersectionObserver" in window)) {

--- a/theme/powercontext/assets/stylesheets/powercontext.css
+++ b/theme/powercontext/assets/stylesheets/powercontext.css
@@ -3378,3 +3378,1105 @@ body {
     padding-block: 51px 72px;
   }
 }
+
+/* Benchmark evidence page */
+.md-main__inner:has(.pc-benchmark) {
+  margin-top: 0;
+  max-width: none;
+  padding: 0;
+}
+
+.pc-benchmark {
+  --benchmark-accent: var(--pc-accent);
+  --benchmark-accent-strong: var(--pc-accent-hover);
+  --benchmark-on-ink: #ffffff;
+  box-sizing: border-box;
+  margin: 0;
+  max-width: none;
+  overflow: clip;
+  width: 100%;
+}
+
+[data-md-color-scheme="slate"] .pc-benchmark {
+  --benchmark-on-ink: #07152b;
+}
+
+.pc-benchmark > .md-content__inner {
+  margin: 0;
+  max-width: none;
+  padding: 0;
+}
+
+.pc-benchmark .shell {
+  box-sizing: border-box;
+  margin-inline: auto;
+  width: min(var(--pc-wide), calc(100% - 48px));
+}
+
+.pc-benchmark h1,
+.pc-benchmark h2,
+.pc-benchmark h3,
+.pc-benchmark p,
+.pc-benchmark figure,
+.pc-benchmark dl,
+.pc-benchmark dd {
+  margin: 0;
+}
+
+.pc-benchmark a {
+  color: inherit;
+}
+
+.pc-visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.pc-benchmark-hero {
+  background:
+    radial-gradient(circle at 83% 18%, color-mix(in srgb, var(--benchmark-accent) 15%, transparent), transparent 27%),
+    var(--pc-paper);
+  border-bottom: 1px solid var(--pc-rule);
+  min-height: min(720px, calc(100dvh - 68px));
+  padding: clamp(64px, 8vw, 96px) 0;
+}
+
+.pc-benchmark-hero__grid {
+  align-items: center;
+  display: grid;
+  gap: clamp(48px, 8vw, 104px);
+  grid-template-columns: minmax(0, 1fr) minmax(420px, 0.92fr);
+}
+
+.pc-benchmark-label {
+  color: var(--benchmark-accent-strong);
+  font-family: var(--pc-font-code);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.pc-benchmark-hero h1 {
+  color: var(--pc-ink);
+  font-size: clamp(56px, 7vw, 88px);
+  font-weight: 760;
+  letter-spacing: -0.055em;
+  line-height: 0.96;
+  margin-top: 20px;
+  max-width: 9ch;
+}
+
+html[lang^="zh"] .pc-benchmark-hero h1 {
+  font-size: clamp(56px, 5.3vw, 76px);
+  max-width: none;
+}
+
+.pc-benchmark-hero__lead {
+  color: var(--pc-muted);
+  font-size: clamp(18px, 2vw, 22px);
+  line-height: 1.52;
+  margin-top: 28px !important;
+  max-width: 46ch;
+}
+
+.pc-benchmark-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 34px;
+}
+
+.pc-benchmark-hero__actions a {
+  align-items: center;
+  border: 1px solid var(--pc-rule-strong);
+  border-radius: var(--pc-radius);
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 700;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  text-decoration: none;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.pc-benchmark-hero__actions a:first-child {
+  background: var(--benchmark-accent);
+  border-color: var(--benchmark-accent);
+  color: var(--benchmark-on-ink);
+}
+
+.pc-benchmark-hero__actions a:last-child {
+  background: var(--pc-surface);
+  color: var(--pc-ink);
+}
+
+.pc-benchmark-hero__actions a:hover {
+  border-color: var(--benchmark-accent);
+  text-decoration: none;
+  transform: translateY(-2px);
+}
+
+.pc-benchmark-hero__actions a:active {
+  transform: translateY(1px);
+}
+
+.pc-benchmark-hero__visual {
+  background: var(--pc-surface);
+  border: 1px solid var(--pc-rule-strong);
+  border-radius: var(--pc-radius);
+  box-shadow: 0 28px 80px color-mix(in srgb, var(--pc-header) 13%, transparent);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  min-height: 420px;
+  overflow: hidden;
+  position: relative;
+}
+
+.pc-benchmark-hero__visual::before {
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--benchmark-accent) 12%, transparent), transparent);
+  content: "";
+  height: 1px;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 58%;
+}
+
+.pc-benchmark-hero__result {
+  align-content: end;
+  display: grid;
+  min-width: 0;
+  padding: 36px 30px 72px;
+  position: relative;
+}
+
+.pc-benchmark-hero__result + .pc-benchmark-hero__result {
+  border-left: 1px solid var(--pc-rule);
+  padding-top: 88px;
+}
+
+.pc-benchmark-hero__result-name {
+  color: var(--pc-muted);
+  font-family: var(--pc-font-code);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.pc-benchmark-hero__result strong {
+  color: var(--pc-ink);
+  font-family: var(--pc-font-code);
+  font-size: clamp(42px, 5vw, 68px);
+  letter-spacing: -0.07em;
+  line-height: 1;
+  margin-top: 16px;
+  white-space: nowrap;
+}
+
+.pc-benchmark-hero__result:last-of-type strong {
+  color: var(--benchmark-accent-strong);
+}
+
+.pc-benchmark-hero__result > span:last-child {
+  color: var(--pc-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  margin-top: 12px;
+}
+
+.pc-benchmark-hero__signal {
+  align-items: end;
+  bottom: 28px;
+  display: flex;
+  gap: 5px;
+  height: 34px;
+  left: 30px;
+  position: absolute;
+}
+
+.pc-benchmark-hero__signal span {
+  background: var(--benchmark-accent);
+  display: block;
+  height: 38%;
+  opacity: 0.72;
+  width: 5px;
+}
+
+.pc-benchmark-hero__signal span:nth-child(2) {
+  height: 100%;
+}
+
+.pc-benchmark-hero__signal span:nth-child(3) {
+  height: 66%;
+}
+
+.pc-benchmark-orientation,
+.pc-benchmark-study,
+.pc-benchmark-reading,
+.pc-benchmark-sources {
+  padding-block: clamp(80px, 10vw, 132px);
+}
+
+.pc-benchmark-orientation > header,
+.pc-benchmark-reading > header {
+  max-width: 760px;
+}
+
+.pc-benchmark h2 {
+  color: var(--pc-ink);
+  font-size: clamp(38px, 5vw, 64px);
+  font-weight: 740;
+  letter-spacing: -0.045em;
+  line-height: 1.02;
+}
+
+.pc-benchmark-orientation > header > p,
+.pc-benchmark-reading > header > p {
+  color: var(--pc-muted);
+  font-size: 18px;
+  line-height: 1.65;
+  margin-top: 22px;
+  max-width: 64ch;
+}
+
+.pc-benchmark-orientation__tests {
+  display: grid;
+  gap: clamp(32px, 7vw, 92px);
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+  margin-top: 72px;
+}
+
+.pc-benchmark-orientation__tests article {
+  border-top: 3px solid var(--pc-ink);
+  padding: 28px 0 0;
+}
+
+.pc-benchmark-orientation__tests article:last-child {
+  border-top-color: var(--benchmark-accent);
+  padding-top: 68px;
+}
+
+.pc-benchmark-orientation__tests article > span {
+  color: var(--benchmark-accent-strong);
+  font-family: var(--pc-font-code);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.pc-benchmark-orientation__tests h3 {
+  color: var(--pc-ink);
+  font-size: clamp(25px, 3vw, 36px);
+  letter-spacing: -0.035em;
+  line-height: 1.16;
+  margin-top: 18px;
+  max-width: 19ch;
+}
+
+.pc-benchmark-orientation__tests p {
+  color: var(--pc-muted);
+  font-size: 16px;
+  line-height: 1.65;
+  margin-top: 18px;
+  max-width: 50ch;
+}
+
+.pc-benchmark-orientation__tests a {
+  color: var(--benchmark-accent-strong);
+  display: inline-block;
+  font-size: 14px;
+  font-weight: 700;
+  margin-top: 22px;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 5px;
+}
+
+.pc-benchmark-study {
+  border-top: 1px solid var(--pc-rule-strong);
+}
+
+.pc-benchmark-study__header {
+  max-width: 860px;
+}
+
+.pc-benchmark-study__header > p {
+  color: var(--pc-muted);
+  font-size: 18px;
+  line-height: 1.65;
+  margin-top: 24px;
+  max-width: 68ch;
+}
+
+.pc-benchmark-facts {
+  border-block: 1px solid var(--pc-rule-strong);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 58px !important;
+}
+
+.pc-benchmark-facts > div {
+  display: grid;
+  gap: 12px;
+  padding: 28px 30px;
+}
+
+.pc-benchmark-facts > div + div {
+  border-left: 1px solid var(--pc-rule);
+}
+
+.pc-benchmark-facts dt {
+  color: var(--pc-muted);
+  font-size: 13px;
+}
+
+.pc-benchmark-facts dd {
+  color: var(--pc-ink);
+  font-family: var(--pc-font-code);
+  font-size: clamp(34px, 4vw, 52px);
+  font-weight: 700;
+  letter-spacing: -0.055em;
+}
+
+.pc-locomo-categories {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  margin-top: 72px;
+}
+
+.pc-locomo-categories article {
+  background: var(--pc-surface);
+  border: 1px solid var(--pc-rule);
+  border-radius: var(--pc-radius);
+  grid-column: span 7;
+  min-height: 220px;
+  padding: 28px;
+}
+
+.pc-locomo-categories article:nth-child(2),
+.pc-locomo-categories article:nth-child(3) {
+  background: var(--pc-surface-secondary);
+  grid-column: span 5;
+}
+
+.pc-locomo-categories article:nth-child(4) {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--benchmark-accent) 11%, var(--pc-surface)), var(--pc-surface));
+}
+
+.pc-locomo-categories strong {
+  color: var(--benchmark-accent-strong);
+  font-family: var(--pc-font-code);
+  font-size: 30px;
+  letter-spacing: -0.04em;
+}
+
+.pc-locomo-categories h3 {
+  color: var(--pc-ink);
+  font-size: 23px;
+  letter-spacing: -0.02em;
+  margin-top: 38px;
+}
+
+.pc-locomo-categories p {
+  color: var(--pc-muted);
+  font-size: 15px;
+  line-height: 1.58;
+  margin-top: 10px;
+  max-width: 38ch;
+}
+
+.pc-metric-comparison {
+  background: var(--pc-code);
+  border: 1px solid var(--pc-code-border);
+  border-radius: var(--pc-radius);
+  color: var(--pc-code-text);
+  margin-top: 90px;
+  overflow: hidden;
+  padding: clamp(26px, 5vw, 54px);
+}
+
+.pc-metric-comparison__intro {
+  align-items: end;
+  display: grid;
+  gap: 32px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.pc-metric-comparison h3 {
+  color: var(--pc-code-text);
+  font-size: clamp(28px, 4vw, 46px);
+  letter-spacing: -0.04em;
+  line-height: 1.08;
+}
+
+.pc-metric-comparison__intro p {
+  color: color-mix(in srgb, var(--pc-code-text) 67%, transparent);
+  font-size: 15px;
+  line-height: 1.6;
+  margin-top: 14px;
+  max-width: 58ch;
+}
+
+.pc-metric-tabs {
+  border: 1px solid var(--pc-code-border);
+  border-radius: var(--pc-radius);
+  display: flex;
+  padding: 4px;
+}
+
+.pc-metric-tabs button {
+  background: transparent;
+  border: 0;
+  border-radius: var(--pc-radius-control);
+  color: color-mix(in srgb, var(--pc-code-text) 65%, transparent);
+  cursor: pointer;
+  font: 600 12px/1 var(--pc-font-text);
+  min-height: 36px;
+  padding: 0 13px;
+  white-space: nowrap;
+}
+
+.pc-metric-tabs button[aria-selected="true"] {
+  background: var(--benchmark-accent);
+  color: var(--benchmark-on-ink);
+}
+
+.pc-metric-panels {
+  margin-top: 54px;
+}
+
+.pc-metric-panel[hidden] {
+  display: none;
+}
+
+.pc-metric-panel {
+  display: grid;
+  gap: clamp(34px, 6vw, 74px);
+  grid-template-columns: minmax(200px, 0.72fr) minmax(0, 1.65fr);
+  min-height: 320px;
+  position: relative;
+}
+
+.pc-metric-panel__callout strong {
+  color: var(--pc-code-text);
+  display: block;
+  font-family: var(--pc-font-code);
+  font-size: clamp(44px, 6vw, 78px);
+  letter-spacing: -0.07em;
+  line-height: 0.98;
+}
+
+.pc-metric-panel__callout span {
+  color: color-mix(in srgb, var(--pc-code-text) 68%, transparent);
+  display: block;
+  font-size: 14px;
+  margin-top: 16px;
+}
+
+.pc-metric-panel__lanes {
+  align-self: center;
+  display: grid;
+  gap: 26px;
+}
+
+.pc-metric-lane {
+  min-width: 0;
+}
+
+.pc-metric-lane__meta {
+  align-items: baseline;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+}
+
+.pc-metric-lane__meta span {
+  color: color-mix(in srgb, var(--pc-code-text) 72%, transparent);
+  font-size: 13px;
+}
+
+.pc-metric-lane__meta strong {
+  color: var(--pc-code-text);
+  font-family: var(--pc-font-code);
+  font-size: 15px;
+  white-space: nowrap;
+}
+
+.pc-metric-lane__bar {
+  background: color-mix(in srgb, var(--pc-code-text) 35%, transparent);
+  display: block;
+  height: 26px;
+  margin-top: 8px;
+  min-width: 72px;
+  transform: scaleX(1);
+  transform-origin: left center;
+  width: var(--benchmark-scale);
+}
+
+.pc-metric-lane:first-child .pc-metric-lane__bar {
+  background: var(--benchmark-accent);
+}
+
+.pc-metric-lane:nth-child(2) .pc-metric-lane__bar {
+  background: color-mix(in srgb, var(--benchmark-accent) 38%, var(--pc-code-text));
+}
+
+.pc-metric-comparison.is-enhanced .pc-metric-lane__bar {
+  transform: scaleX(0);
+}
+
+.pc-metric-comparison.is-visible .pc-metric-panel.is-playing .pc-metric-lane__bar {
+  transform: scaleX(1);
+  transition: transform 900ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.pc-metric-comparison.is-visible .pc-metric-lane:nth-child(2) .pc-metric-lane__bar {
+  transition-delay: 100ms;
+}
+
+.pc-metric-comparison.is-visible .pc-metric-lane:nth-child(3) .pc-metric-lane__bar {
+  transition-delay: 200ms;
+}
+
+.pc-metric-panel__direction {
+  bottom: 0;
+  color: color-mix(in srgb, var(--pc-code-text) 58%, transparent);
+  font: 12px/1 var(--pc-font-code);
+  left: 0;
+  position: absolute;
+}
+
+.pc-benchmark-note {
+  border-left: 3px solid var(--benchmark-accent);
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(180px, 0.35fr) minmax(0, 1fr);
+  margin-top: 42px;
+  padding: 8px 0 8px 24px;
+}
+
+.pc-benchmark-note strong {
+  color: var(--pc-ink);
+  font-size: 14px;
+}
+
+.pc-benchmark-note p {
+  color: var(--pc-muted);
+  font-size: 14px;
+  line-height: 1.65;
+  max-width: 76ch;
+}
+
+.pc-benchmark-study--swe {
+  padding-bottom: clamp(88px, 11vw, 144px);
+}
+
+.pc-swe-method {
+  border-block: 1px solid var(--pc-rule-strong);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 58px;
+}
+
+.pc-swe-method > div {
+  display: grid;
+  gap: 9px;
+  padding: 26px 28px;
+}
+
+.pc-swe-method > div + div {
+  border-left: 1px solid var(--pc-rule);
+}
+
+.pc-swe-method strong {
+  color: var(--pc-ink);
+  font-size: 14px;
+}
+
+.pc-swe-method span {
+  color: var(--pc-muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.pc-benchmark .pc-swe-result {
+  display: block;
+  margin-top: 76px !important;
+  max-width: none;
+  width: 100%;
+}
+
+.pc-swe-result__scores {
+  align-items: stretch;
+  display: grid;
+  gap: clamp(18px, 2.4vw, 34px);
+  grid-template-areas: "off delta on";
+  grid-template-columns: minmax(0, 1fr) minmax(148px, 174px) minmax(0, 1fr);
+  min-height: 430px;
+}
+
+.pc-swe-score {
+  align-content: center;
+  border-radius: var(--pc-radius);
+  display: grid;
+  min-width: 0;
+  padding: clamp(28px, 5vw, 58px);
+  transition: opacity 800ms cubic-bezier(0.16, 1, 0.3, 1), transform 800ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.pc-swe-score--off {
+  background: var(--pc-surface-secondary);
+  border: 1px solid var(--pc-rule-strong);
+  grid-area: off;
+  transform: translateX(28px);
+}
+
+.pc-swe-score--on {
+  background: var(--benchmark-accent);
+  color: var(--benchmark-on-ink);
+  grid-area: on;
+  transform: translateX(-28px);
+}
+
+.pc-swe-result.is-visible .pc-swe-score {
+  transform: translateX(0);
+}
+
+.pc-swe-score > span:first-child {
+  font-family: var(--pc-font-code);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.pc-swe-score--off > span:first-child,
+.pc-swe-score--off small {
+  color: var(--pc-muted);
+}
+
+.pc-swe-score strong {
+  font-family: var(--pc-font-code);
+  font-size: clamp(72px, 9vw, 124px);
+  letter-spacing: -0.085em;
+  line-height: 0.9;
+  margin-top: 30px;
+}
+
+.pc-swe-score--off strong {
+  color: var(--pc-ink);
+}
+
+.pc-swe-score small {
+  font-size: 15px;
+  margin-top: 25px;
+}
+
+.pc-swe-result__delta {
+  align-content: center;
+  align-self: center;
+  background: var(--pc-code);
+  border: 4px solid var(--pc-paper);
+  border-radius: var(--pc-radius);
+  color: var(--pc-code-text);
+  display: grid;
+  grid-area: delta;
+  height: 124px;
+  justify-items: center;
+  justify-self: center;
+  opacity: 0;
+  padding: 12px 22px;
+  transform: scale(0.64) rotate(-7deg);
+  transition: opacity 500ms 520ms ease, transform 700ms 420ms cubic-bezier(0.16, 1, 0.3, 1);
+  width: min(100%, 174px);
+}
+
+.pc-swe-result.is-visible .pc-swe-result__delta {
+  opacity: 1;
+  transform: scale(1) rotate(0);
+}
+
+.pc-swe-result__delta strong {
+  font-family: var(--pc-font-code);
+  font-size: 42px;
+  letter-spacing: -0.06em;
+  line-height: 1;
+}
+
+.pc-swe-result__delta span {
+  color: color-mix(in srgb, var(--pc-code-text) 72%, transparent);
+  font-size: 11px;
+  line-height: 1.25;
+  text-align: center;
+}
+
+.pc-swe-result figcaption {
+  color: var(--pc-muted);
+  font-size: 14px;
+  line-height: 1.6;
+  margin: 22px auto 0;
+  max-width: 70ch;
+  text-align: center;
+}
+
+.pc-benchmark-reading {
+  border-top: 1px solid var(--pc-rule-strong);
+}
+
+.pc-benchmark-table-wrap {
+  border: 1px solid var(--pc-rule-strong);
+  border-radius: var(--pc-radius);
+  margin-top: 58px;
+  overflow-x: auto;
+}
+
+.pc-benchmark-table-wrap table {
+  background: var(--pc-surface);
+  border: 0;
+  border-collapse: collapse;
+  font-size: 14px;
+  margin: 0;
+  min-width: 720px;
+  width: 100%;
+}
+
+.pc-benchmark-table-wrap th,
+.pc-benchmark-table-wrap td {
+  border: 0;
+  padding: 22px 24px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.pc-benchmark-table-wrap thead {
+  background: var(--pc-surface-secondary);
+  color: var(--pc-muted);
+}
+
+.pc-benchmark-table-wrap thead th {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.pc-benchmark-table-wrap tbody tr + tr {
+  border-top: 1px solid var(--pc-rule);
+}
+
+.pc-benchmark-table-wrap tbody th {
+  color: var(--pc-ink);
+  font-weight: 700;
+  width: 24%;
+}
+
+.pc-benchmark-table-wrap tbody td {
+  color: var(--pc-muted);
+  line-height: 1.55;
+}
+
+.pc-benchmark-sources {
+  border-top: 1px solid var(--pc-rule-strong);
+  display: grid;
+  gap: clamp(46px, 8vw, 110px);
+  grid-template-columns: minmax(240px, 0.62fr) minmax(0, 1fr);
+}
+
+.pc-benchmark-sources > div > p {
+  color: var(--pc-muted);
+  font-size: 16px;
+  line-height: 1.65;
+  margin-top: 22px;
+}
+
+.pc-benchmark-sources ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pc-benchmark-sources li {
+  border-top: 1px solid var(--pc-rule-strong);
+  display: grid;
+  gap: 10px 22px;
+  grid-template-columns: 86px minmax(0, 1fr);
+  padding: 24px 0;
+}
+
+.pc-benchmark-sources li > span {
+  color: var(--pc-tertiary);
+  font-family: var(--pc-font-code);
+  font-size: 11px;
+}
+
+.pc-benchmark-sources li > a {
+  color: var(--pc-ink);
+  font-size: 15px;
+  font-weight: 700;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.pc-benchmark-sources li > a:hover {
+  color: var(--benchmark-accent-strong);
+}
+
+.pc-benchmark-sources li > p {
+  color: var(--pc-muted);
+  font-size: 13px;
+  grid-column: 2;
+  line-height: 1.55;
+}
+
+.pc-benchmark-cta {
+  align-items: center;
+  border-top: 1px solid var(--pc-rule-strong);
+  display: grid;
+  gap: 40px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding-block: 72px 90px;
+}
+
+.pc-benchmark-cta h2 {
+  font-size: clamp(34px, 4vw, 52px);
+}
+
+.pc-benchmark-cta p {
+  color: var(--pc-muted);
+  font-size: 16px;
+  line-height: 1.6;
+  margin-top: 16px;
+  max-width: 60ch;
+}
+
+.pc-benchmark-cta .primary-button {
+  min-width: 150px;
+  white-space: nowrap;
+}
+
+[data-benchmark-reveal] {
+  opacity: 0.001;
+  transform: translateY(34px);
+  transition: opacity 700ms ease, transform 850ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+[data-benchmark-reveal].is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media screen and (max-width: 1020px) {
+  .pc-benchmark-hero__grid {
+    gap: 48px;
+    grid-template-columns: minmax(0, 0.85fr) minmax(390px, 1fr);
+  }
+
+  .pc-benchmark-hero__result {
+    padding-inline: 22px;
+  }
+
+  .pc-metric-comparison__intro {
+    align-items: start;
+    grid-template-columns: 1fr;
+  }
+
+  .pc-metric-tabs {
+    justify-self: start;
+  }
+}
+
+@media screen and (max-width: 800px) {
+  .pc-benchmark-hero {
+    min-height: 0;
+  }
+
+  .pc-benchmark-hero__grid,
+  .pc-benchmark-orientation__tests,
+  .pc-metric-panel,
+  .pc-benchmark-sources,
+  .pc-benchmark-cta {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-benchmark-hero h1 {
+    max-width: 10ch;
+  }
+
+  .pc-benchmark-hero__visual {
+    min-height: 350px;
+  }
+
+  .pc-benchmark-orientation__tests article:last-child {
+    padding-top: 28px;
+  }
+
+  .pc-metric-panel {
+    min-height: 440px;
+  }
+
+  .pc-metric-panel__direction {
+    position: static;
+  }
+
+  .pc-benchmark-sources {
+    gap: 48px;
+  }
+
+  .pc-benchmark-cta {
+    align-items: start;
+  }
+
+  .pc-benchmark-cta .primary-button {
+    justify-self: start;
+  }
+
+  .pc-swe-result__scores {
+    gap: 18px;
+    grid-template-areas:
+      "off"
+      "delta"
+      "on";
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .pc-swe-score {
+    min-height: 280px;
+  }
+
+  .pc-swe-score--off {
+    transform: translateY(28px);
+  }
+
+  .pc-swe-score--on {
+    transform: translateY(-28px);
+  }
+
+  .pc-swe-result.is-visible .pc-swe-score {
+    transform: translateY(0);
+  }
+}
+
+@media screen and (max-width: 640px) {
+  .pc-benchmark .shell {
+    width: calc(100% - 30px);
+  }
+
+  .pc-benchmark-hero {
+    padding-block: 54px 64px;
+  }
+
+  .pc-benchmark-hero h1 {
+    font-size: clamp(46px, 15vw, 64px);
+  }
+
+  .pc-benchmark-hero__lead {
+    font-size: 17px;
+  }
+
+  .pc-benchmark-hero__actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .pc-benchmark-hero__visual {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .pc-benchmark-hero__visual::before,
+  .pc-benchmark-hero__signal {
+    display: none;
+  }
+
+  .pc-benchmark-hero__result {
+    min-height: 220px;
+    padding: 30px;
+  }
+
+  .pc-benchmark-hero__result + .pc-benchmark-hero__result {
+    border-left: 0;
+    border-top: 1px solid var(--pc-rule);
+    padding-top: 30px;
+  }
+
+  .pc-benchmark h2 {
+    font-size: clamp(36px, 12vw, 48px);
+  }
+
+  .pc-benchmark-facts,
+  .pc-swe-method {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-benchmark-facts > div + div,
+  .pc-swe-method > div + div {
+    border-left: 0;
+    border-top: 1px solid var(--pc-rule);
+  }
+
+  .pc-benchmark-facts > div,
+  .pc-swe-method > div {
+    padding-inline: 0;
+  }
+
+  .pc-locomo-categories {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-locomo-categories article,
+  .pc-locomo-categories article:nth-child(2),
+  .pc-locomo-categories article:nth-child(3) {
+    grid-column: 1;
+  }
+
+  .pc-metric-comparison {
+    margin-inline: -4px;
+  }
+
+  .pc-metric-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    justify-self: stretch;
+  }
+
+  .pc-metric-tabs button {
+    padding-inline: 8px;
+  }
+
+  .pc-metric-panel {
+    min-height: 470px;
+  }
+
+  .pc-metric-panel__callout strong {
+    font-size: 46px;
+  }
+
+  .pc-benchmark-note {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-benchmark-sources li {
+    grid-template-columns: 66px minmax(0, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pc-benchmark *,
+  .pc-benchmark *::before,
+  .pc-benchmark *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  [data-benchmark-reveal],
+  .pc-swe-score,
+  .pc-swe-result__delta,
+  .pc-metric-comparison.is-enhanced .pc-metric-lane__bar {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/theme/powercontext/assets/stylesheets/powercontext.css
+++ b/theme/powercontext/assets/stylesheets/powercontext.css
@@ -3442,15 +3442,15 @@ body {
     radial-gradient(circle at 83% 18%, color-mix(in srgb, var(--benchmark-accent) 15%, transparent), transparent 27%),
     var(--pc-paper);
   border-bottom: 1px solid var(--pc-rule);
-  min-height: min(720px, calc(100dvh - 68px));
-  padding: clamp(64px, 8vw, 96px) 0;
+  min-height: min(640px, calc(100dvh - 68px));
+  padding: clamp(52px, 6vw, 76px) 0;
 }
 
 .pc-benchmark-hero__grid {
   align-items: center;
   display: grid;
-  gap: clamp(48px, 8vw, 104px);
-  grid-template-columns: minmax(0, 1fr) minmax(420px, 0.92fr);
+  gap: clamp(42px, 6vw, 76px);
+  grid-template-columns: minmax(0, 1fr) minmax(400px, 0.88fr);
 }
 
 .pc-benchmark-label {
@@ -3464,7 +3464,7 @@ body {
 
 .pc-benchmark-hero h1 {
   color: var(--pc-ink);
-  font-size: clamp(56px, 7vw, 88px);
+  font-size: clamp(52px, 6vw, 76px);
   font-weight: 760;
   letter-spacing: -0.055em;
   line-height: 0.96;
@@ -3473,13 +3473,13 @@ body {
 }
 
 html[lang^="zh"] .pc-benchmark-hero h1 {
-  font-size: clamp(56px, 5.3vw, 76px);
+  font-size: clamp(52px, 4.8vw, 68px);
   max-width: none;
 }
 
 .pc-benchmark-hero__lead {
   color: var(--pc-muted);
-  font-size: clamp(18px, 2vw, 22px);
+  font-size: clamp(17px, 1.6vw, 20px);
   line-height: 1.52;
   margin-top: 28px !important;
   max-width: 46ch;
@@ -3534,7 +3534,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   box-shadow: 0 28px 80px color-mix(in srgb, var(--pc-header) 13%, transparent);
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  min-height: 420px;
+  min-height: 350px;
   overflow: hidden;
   position: relative;
 }
@@ -3553,13 +3553,13 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   align-content: end;
   display: grid;
   min-width: 0;
-  padding: 36px 30px 72px;
+  padding: 30px 26px 60px;
   position: relative;
 }
 
 .pc-benchmark-hero__result + .pc-benchmark-hero__result {
   border-left: 1px solid var(--pc-rule);
-  padding-top: 88px;
+  padding-top: 70px;
 }
 
 .pc-benchmark-hero__result-name {
@@ -3572,7 +3572,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 .pc-benchmark-hero__result strong {
   color: var(--pc-ink);
   font-family: var(--pc-font-code);
-  font-size: clamp(42px, 5vw, 68px);
+  font-size: clamp(38px, 4vw, 56px);
   letter-spacing: -0.07em;
   line-height: 1;
   margin-top: 16px;
@@ -3618,9 +3618,10 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 
 .pc-benchmark-orientation,
 .pc-benchmark-study,
+.pc-benchmark-leaderboards,
 .pc-benchmark-reading,
 .pc-benchmark-sources {
-  padding-block: clamp(80px, 10vw, 132px);
+  padding-block: clamp(64px, 7vw, 96px);
 }
 
 .pc-benchmark-orientation > header,
@@ -3630,7 +3631,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 
 .pc-benchmark h2 {
   color: var(--pc-ink);
-  font-size: clamp(38px, 5vw, 64px);
+  font-size: clamp(34px, 4vw, 52px);
   font-weight: 740;
   letter-spacing: -0.045em;
   line-height: 1.02;
@@ -3647,9 +3648,9 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 
 .pc-benchmark-orientation__tests {
   display: grid;
-  gap: clamp(32px, 7vw, 92px);
+  gap: clamp(32px, 5vw, 68px);
   grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
-  margin-top: 72px;
+  margin-top: 52px;
 }
 
 .pc-benchmark-orientation__tests article {
@@ -3659,7 +3660,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 
 .pc-benchmark-orientation__tests article:last-child {
   border-top-color: var(--benchmark-accent);
-  padding-top: 68px;
+  padding-top: 44px;
 }
 
 .pc-benchmark-orientation__tests article > span {
@@ -3716,13 +3717,13 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   border-block: 1px solid var(--pc-rule-strong);
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: 58px !important;
+  margin-top: 44px !important;
 }
 
 .pc-benchmark-facts > div {
   display: grid;
   gap: 12px;
-  padding: 28px 30px;
+  padding: 24px 26px;
 }
 
 .pc-benchmark-facts > div + div {
@@ -3737,7 +3738,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 .pc-benchmark-facts dd {
   color: var(--pc-ink);
   font-family: var(--pc-font-code);
-  font-size: clamp(34px, 4vw, 52px);
+  font-size: clamp(30px, 3vw, 42px);
   font-weight: 700;
   letter-spacing: -0.055em;
 }
@@ -3746,7 +3747,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   display: grid;
   gap: 14px;
   grid-template-columns: repeat(12, minmax(0, 1fr));
-  margin-top: 72px;
+  margin-top: 52px;
 }
 
 .pc-locomo-categories article {
@@ -3754,8 +3755,8 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   border: 1px solid var(--pc-rule);
   border-radius: var(--pc-radius);
   grid-column: span 7;
-  min-height: 220px;
-  padding: 28px;
+  min-height: 180px;
+  padding: 24px;
 }
 
 .pc-locomo-categories article:nth-child(2),
@@ -3771,7 +3772,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 .pc-locomo-categories strong {
   color: var(--benchmark-accent-strong);
   font-family: var(--pc-font-code);
-  font-size: 30px;
+  font-size: 26px;
   letter-spacing: -0.04em;
 }
 
@@ -3779,7 +3780,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   color: var(--pc-ink);
   font-size: 23px;
   letter-spacing: -0.02em;
-  margin-top: 38px;
+  margin-top: 24px;
 }
 
 .pc-locomo-categories p {
@@ -3795,9 +3796,9 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   border: 1px solid var(--pc-code-border);
   border-radius: var(--pc-radius);
   color: var(--pc-code-text);
-  margin-top: 90px;
+  margin-top: 64px;
   overflow: hidden;
-  padding: clamp(26px, 5vw, 54px);
+  padding: clamp(26px, 4vw, 44px);
 }
 
 .pc-metric-comparison__intro {
@@ -3847,7 +3848,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 }
 
 .pc-metric-panels {
-  margin-top: 54px;
+  margin-top: 42px;
 }
 
 .pc-metric-panel[hidden] {
@@ -3856,9 +3857,9 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 
 .pc-metric-panel {
   display: grid;
-  gap: clamp(34px, 6vw, 74px);
+  gap: clamp(32px, 5vw, 58px);
   grid-template-columns: minmax(200px, 0.72fr) minmax(0, 1.65fr);
-  min-height: 320px;
+  min-height: 260px;
   position: relative;
 }
 
@@ -3866,7 +3867,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   color: var(--pc-code-text);
   display: block;
   font-family: var(--pc-font-code);
-  font-size: clamp(44px, 6vw, 78px);
+  font-size: clamp(38px, 4.8vw, 60px);
   letter-spacing: -0.07em;
   line-height: 0.98;
 }
@@ -3973,14 +3974,14 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 }
 
 .pc-benchmark-study--swe {
-  padding-bottom: clamp(88px, 11vw, 144px);
+  padding-bottom: clamp(72px, 8vw, 108px);
 }
 
 .pc-swe-method {
   border-block: 1px solid var(--pc-rule-strong);
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: 58px;
+  margin-top: 44px;
 }
 
 .pc-swe-method > div {
@@ -4006,7 +4007,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 
 .pc-benchmark .pc-swe-result {
   display: block;
-  margin-top: 76px !important;
+  margin-top: 56px !important;
   max-width: none;
   width: 100%;
 }
@@ -4017,7 +4018,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   gap: clamp(18px, 2.4vw, 34px);
   grid-template-areas: "off delta on";
   grid-template-columns: minmax(0, 1fr) minmax(148px, 174px) minmax(0, 1fr);
-  min-height: 430px;
+  min-height: 340px;
 }
 
 .pc-swe-score {
@@ -4025,7 +4026,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   border-radius: var(--pc-radius);
   display: grid;
   min-width: 0;
-  padding: clamp(28px, 5vw, 58px);
+  padding: clamp(28px, 4vw, 44px);
   transition: opacity 800ms cubic-bezier(0.16, 1, 0.3, 1), transform 800ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -4060,7 +4061,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 
 .pc-swe-score strong {
   font-family: var(--pc-font-code);
-  font-size: clamp(72px, 9vw, 124px);
+  font-size: clamp(64px, 7vw, 94px);
   letter-spacing: -0.085em;
   line-height: 0.9;
   margin-top: 30px;
@@ -4084,7 +4085,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   color: var(--pc-code-text);
   display: grid;
   grid-area: delta;
-  height: 124px;
+  height: 108px;
   justify-items: center;
   justify-self: center;
   opacity: 0;
@@ -4101,7 +4102,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 
 .pc-swe-result__delta strong {
   font-family: var(--pc-font-code);
-  font-size: 42px;
+  font-size: 36px;
   letter-spacing: -0.06em;
   line-height: 1;
 }
@@ -4122,6 +4123,329 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   text-align: center;
 }
 
+.pc-benchmark-leaderboards {
+  border-top: 1px solid var(--pc-rule-strong);
+}
+
+.pc-benchmark-leaderboards__header {
+  max-width: 780px;
+}
+
+.pc-benchmark-leaderboards__header > p {
+  color: var(--pc-muted);
+  font-size: 18px;
+  line-height: 1.65;
+  margin-top: 22px;
+  max-width: 62ch;
+}
+
+.pc-benchmark-leaderboards__header > small {
+  color: var(--pc-tertiary);
+  display: block;
+  font: 12px/1.4 var(--pc-font-code);
+  margin-top: 18px;
+}
+
+.pc-leaderboard-tabs {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 40px;
+}
+
+.pc-leaderboard-tabs button {
+  align-items: center;
+  background: var(--pc-surface);
+  border: 1px solid var(--pc-rule-strong);
+  border-radius: var(--pc-radius);
+  color: var(--pc-ink);
+  cursor: pointer;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  min-height: 64px;
+  padding: 0 22px;
+  text-align: left;
+  transition: background-color 180ms ease, border-color 180ms ease, color 180ms ease, transform 180ms ease;
+}
+
+.pc-leaderboard-tabs button:hover {
+  border-color: var(--benchmark-accent);
+  transform: translateY(-2px);
+}
+
+.pc-leaderboard-tabs button:active {
+  transform: translateY(1px);
+}
+
+.pc-leaderboard-tabs button[aria-selected="true"] {
+  background: var(--pc-code);
+  border-color: var(--pc-code);
+  color: var(--pc-code-text);
+}
+
+.pc-leaderboard-tabs button span {
+  font-size: 15px;
+  font-weight: 750;
+}
+
+.pc-leaderboard-tabs button strong {
+  color: var(--pc-muted);
+  font: 12px/1 var(--pc-font-code);
+  white-space: nowrap;
+}
+
+.pc-leaderboard-tabs button[aria-selected="true"] strong {
+  color: color-mix(in srgb, var(--pc-code-text) 68%, transparent);
+}
+
+.pc-leaderboard-panels {
+  margin-top: 14px;
+}
+
+.pc-leaderboard-panel[hidden] {
+  display: none;
+}
+
+.pc-leaderboard-panel {
+  background: var(--pc-surface);
+  border: 1px solid var(--pc-rule-strong);
+  border-radius: var(--pc-radius);
+  overflow: hidden;
+}
+
+.pc-leaderboard-panel__header {
+  padding: clamp(26px, 4vw, 40px);
+}
+
+.pc-leaderboard-panel__header h3 {
+  color: var(--pc-ink);
+  font-size: clamp(26px, 3vw, 38px);
+  letter-spacing: -0.04em;
+  line-height: 1.06;
+}
+
+.pc-leaderboard-panel__header p {
+  color: var(--pc-muted);
+  font-size: 15px;
+  line-height: 1.65;
+  margin-top: 16px;
+  max-width: 74ch;
+}
+
+.pc-leaderboard-spotlight {
+  align-items: center;
+  background: var(--pc-code);
+  color: var(--pc-code-text);
+  display: grid;
+  gap: 26px;
+  grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1fr) minmax(160px, 0.55fr);
+  margin: 0 clamp(28px, 5vw, 52px) 20px;
+  min-height: 140px;
+  opacity: 0;
+  padding: 24px 28px;
+  transform: scale(0.98);
+  transition: opacity 500ms ease, transform 650ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.pc-leaderboard-panels.is-visible .pc-leaderboard-panel.is-playing .pc-leaderboard-spotlight {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.pc-leaderboard-spotlight > div {
+  display: grid;
+  gap: 12px;
+}
+
+.pc-leaderboard-spotlight span,
+.pc-leaderboard-spotlight small {
+  color: color-mix(in srgb, var(--pc-code-text) 68%, transparent);
+  font: 12px/1.45 var(--pc-font-code);
+}
+
+.pc-leaderboard-spotlight strong {
+  color: var(--benchmark-accent);
+  font: 750 clamp(42px, 5vw, 60px)/0.92 var(--pc-font-code);
+  letter-spacing: -0.07em;
+}
+
+.pc-leaderboard-spotlight p {
+  color: var(--pc-code-text);
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+.pc-leaderboard-spotlight small {
+  border-left: 2px solid var(--benchmark-accent);
+  padding-left: 16px;
+}
+
+.pc-leaderboard-table-wrap {
+  border-top: 1px solid var(--pc-rule-strong);
+  max-height: 820px;
+  overflow: auto;
+}
+
+.pc-leaderboard-table-wrap table {
+  background: var(--pc-surface);
+  border: 0;
+  border-collapse: collapse;
+  display: table !important;
+  font-size: 13px;
+  margin: 0;
+  min-width: 980px;
+  max-width: none;
+  width: 100% !important;
+}
+
+.pc-leaderboard-table-wrap th,
+.pc-leaderboard-table-wrap td {
+  border: 0;
+  padding: 18px 20px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.pc-leaderboard-table-wrap thead {
+  background: var(--pc-surface-secondary);
+  color: var(--pc-muted);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.pc-leaderboard-table-wrap thead th {
+  font-size: 11px;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.pc-leaderboard-table-wrap tbody tr {
+  border-top: 1px solid var(--pc-rule);
+}
+
+.pc-leaderboard-table-wrap tbody tr:first-child {
+  border-top: 0;
+}
+
+.pc-leaderboard-panel.is-active .pc-leaderboard-table-wrap tbody tr {
+  opacity: 0;
+  transform: translateX(24px);
+  transition: background-color 160ms ease, opacity 420ms ease, transform 560ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition-delay: calc(var(--rank-index) * 18ms);
+}
+
+.pc-leaderboard-panels.is-visible .pc-leaderboard-panel.is-playing .pc-leaderboard-table-wrap tbody tr {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.pc-leaderboard-table-wrap tbody tr:hover {
+  background: color-mix(in srgb, var(--benchmark-accent) 7%, var(--pc-surface));
+}
+
+.pc-leaderboard-table-wrap tbody tr.is-powercontext {
+  background: color-mix(in srgb, var(--benchmark-accent) 14%, var(--pc-surface));
+  box-shadow: inset 4px 0 0 var(--benchmark-accent);
+}
+
+.pc-leaderboard-rank {
+  color: var(--pc-tertiary);
+  font: 13px/1 var(--pc-font-code);
+  width: 72px;
+}
+
+.pc-leaderboard-table-wrap tbody th {
+  color: var(--pc-ink);
+  font-size: 14px;
+  font-weight: 750;
+  width: 22%;
+}
+
+.pc-leaderboard-table-wrap tbody th a {
+  color: var(--pc-ink);
+  text-decoration-color: color-mix(in srgb, var(--benchmark-accent) 45%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.pc-leaderboard-table-wrap tbody th a:hover {
+  color: var(--benchmark-accent-strong);
+}
+
+.pc-leaderboard-table-wrap sup {
+  color: var(--benchmark-accent-strong);
+  font-size: 10px;
+}
+
+.pc-leaderboard-score {
+  color: var(--pc-ink);
+  font: 750 16px/1 var(--pc-font-code);
+  white-space: nowrap;
+  width: 132px;
+}
+
+.pc-leaderboard-score small {
+  color: var(--pc-tertiary);
+  display: block;
+  font: 10px/1.2 var(--pc-font-code);
+  margin-top: 7px;
+}
+
+.pc-leaderboard-protocol {
+  color: var(--pc-muted);
+  line-height: 1.5;
+  width: 36%;
+}
+
+.pc-leaderboard-evidence {
+  background: var(--pc-surface-secondary);
+  border-radius: var(--pc-radius-control);
+  color: var(--pc-muted);
+  display: inline-flex;
+  font: 10px/1.25 var(--pc-font-code);
+  max-width: 180px;
+  min-height: 28px;
+  align-items: center;
+  padding: 6px 10px;
+}
+
+.is-powercontext .pc-leaderboard-evidence {
+  background: var(--benchmark-accent);
+  color: var(--benchmark-on-ink);
+}
+
+.pc-leaderboard-panel__footer {
+  align-items: start;
+  background: var(--pc-surface-secondary);
+  border-top: 1px solid var(--pc-rule-strong);
+  display: grid;
+  gap: 36px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 28px clamp(28px, 5vw, 52px);
+}
+
+.pc-leaderboard-panel__footer strong {
+  color: var(--pc-ink);
+  font-size: 13px;
+}
+
+.pc-leaderboard-panel__footer p {
+  color: var(--pc-muted);
+  font-size: 12px;
+  line-height: 1.6;
+  margin-top: 8px;
+  max-width: 86ch;
+}
+
+.pc-leaderboard-panel__footer > a {
+  color: var(--benchmark-accent-strong);
+  font-size: 13px;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
 .pc-benchmark-reading {
   border-top: 1px solid var(--pc-rule-strong);
 }
@@ -4137,10 +4461,12 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   background: var(--pc-surface);
   border: 0;
   border-collapse: collapse;
+  display: table !important;
   font-size: 14px;
   margin: 0;
   min-width: 720px;
-  width: 100%;
+  max-width: none;
+  width: 100% !important;
 }
 
 .pc-benchmark-table-wrap th,
@@ -4269,7 +4595,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
 @media screen and (max-width: 1020px) {
   .pc-benchmark-hero__grid {
     gap: 48px;
-    grid-template-columns: minmax(0, 0.85fr) minmax(390px, 1fr);
+    grid-template-columns: minmax(0, 0.85fr) minmax(360px, 1fr);
   }
 
   .pc-benchmark-hero__result {
@@ -4294,6 +4620,8 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   .pc-benchmark-hero__grid,
   .pc-benchmark-orientation__tests,
   .pc-metric-panel,
+  .pc-leaderboard-spotlight,
+  .pc-leaderboard-panel__footer,
   .pc-benchmark-sources,
   .pc-benchmark-cta {
     grid-template-columns: 1fr;
@@ -4304,7 +4632,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   }
 
   .pc-benchmark-hero__visual {
-    min-height: 350px;
+    min-height: 320px;
   }
 
   .pc-benchmark-orientation__tests article:last-child {
@@ -4312,7 +4640,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   }
 
   .pc-metric-panel {
-    min-height: 440px;
+    min-height: 360px;
   }
 
   .pc-metric-panel__direction {
@@ -4342,7 +4670,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   }
 
   .pc-swe-score {
-    min-height: 280px;
+    min-height: 240px;
   }
 
   .pc-swe-score--off {
@@ -4356,6 +4684,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   .pc-swe-result.is-visible .pc-swe-score {
     transform: translateY(0);
   }
+
 }
 
 @media screen and (max-width: 640px) {
@@ -4364,11 +4693,12 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   }
 
   .pc-benchmark-hero {
-    padding-block: 54px 64px;
+    padding-block: 44px 52px;
   }
 
-  .pc-benchmark-hero h1 {
-    font-size: clamp(46px, 15vw, 64px);
+  .pc-benchmark-hero h1,
+  html[lang^="zh"] .pc-benchmark-hero h1 {
+    font-size: clamp(40px, 11vw, 50px);
   }
 
   .pc-benchmark-hero__lead {
@@ -4391,8 +4721,8 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   }
 
   .pc-benchmark-hero__result {
-    min-height: 220px;
-    padding: 30px;
+    min-height: 180px;
+    padding: 24px;
   }
 
   .pc-benchmark-hero__result + .pc-benchmark-hero__result {
@@ -4402,7 +4732,7 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   }
 
   .pc-benchmark h2 {
-    font-size: clamp(36px, 12vw, 48px);
+    font-size: clamp(32px, 10vw, 42px);
   }
 
   .pc-benchmark-facts,
@@ -4446,14 +4776,30 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   }
 
   .pc-metric-panel {
-    min-height: 470px;
+    min-height: 410px;
   }
 
   .pc-metric-panel__callout strong {
-    font-size: 46px;
+    font-size: 40px;
   }
 
   .pc-benchmark-note {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-leaderboard-tabs {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-leaderboard-tabs button {
+    min-height: 64px;
+  }
+
+  .pc-leaderboard-spotlight {
+    margin-inline: 20px;
+  }
+
+  .pc-leaderboard-panel__footer {
     grid-template-columns: 1fr;
   }
 
@@ -4475,6 +4821,8 @@ html[lang^="zh"] .pc-benchmark-hero h1 {
   [data-benchmark-reveal],
   .pc-swe-score,
   .pc-swe-result__delta,
+  .pc-leaderboard-spotlight,
+  .pc-leaderboard-panel.is-active .pc-leaderboard-table-wrap tbody tr,
   .pc-metric-comparison.is-enhanced .pc-metric-lane__bar {
     opacity: 1;
     transform: none;

--- a/theme/powercontext/benchmark.html
+++ b/theme/powercontext/benchmark.html
@@ -1,0 +1,214 @@
+<!--
+  ~ Copyright (c) 2026 OceanBase.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+{% extends "main.html" %}
+
+{% set benchmark = page.meta["benchmark"] %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ 'assets/javascripts/benchmark.js' | url }}"></script>
+{% endblock %}
+
+{% block site_nav %}
+  <div class="md-sidebar md-sidebar--primary pc-mobile-sidebar" data-md-component="sidebar" data-md-type="navigation">
+    <div class="md-sidebar__scrollwrap">
+      <div class="md-sidebar__inner">{% include "partials/nav.html" %}</div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block container %}
+  <div class="md-content pc-benchmark" data-md-component="content">
+    <article class="md-content__inner md-typeset">
+      <section class="pc-benchmark-hero" aria-labelledby="benchmark-title">
+        <div class="shell pc-benchmark-hero__grid">
+          <div class="pc-benchmark-hero__copy">
+            <p class="pc-benchmark-label">{{ benchmark["hero"]["label"] }}</p>
+            <h1 id="benchmark-title">{% for line in benchmark["hero"]["title"] %}{{ line }}{% if not loop.last %}<br>{% endif %}{% endfor %}</h1>
+            <p class="pc-benchmark-hero__lead">{{ benchmark["hero"]["lead"] }}</p>
+            <nav class="pc-benchmark-hero__actions" aria-label="{{ benchmark['hero']['actions_label'] }}">
+              {% for action in benchmark["hero"]["actions"] %}
+                <a href="#{{ action['target'] }}">{{ action["label"] }}</a>
+              {% endfor %}
+            </nav>
+          </div>
+
+          <div class="pc-benchmark-hero__visual" data-benchmark-reveal aria-label="{{ benchmark['hero']['visual_label'] }}">
+            {% for result in benchmark["hero"]["results"] %}
+              <div class="pc-benchmark-hero__result">
+                <span class="pc-benchmark-hero__result-name">{{ result["name"] }}</span>
+                <strong aria-hidden="true" data-count-to="{{ result['value'] }}" data-count-decimals="{{ result['decimals'] }}" data-count-suffix="{{ result['suffix'] }}">{{ result["display"] }}</strong>
+                <span class="pc-visually-hidden">{{ result["accessible"] }}</span>
+                <span>{{ result["metric"] }}</span>
+              </div>
+            {% endfor %}
+            <div class="pc-benchmark-hero__signal" aria-hidden="true"><span></span><span></span><span></span></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="pc-benchmark-orientation shell" aria-labelledby="benchmark-orientation-title">
+        <header>
+          <h2 id="benchmark-orientation-title">{{ benchmark["orientation"]["title"] }}</h2>
+          <p>{{ benchmark["orientation"]["lead"] }}</p>
+        </header>
+        <div class="pc-benchmark-orientation__tests">
+          {% for test in benchmark["orientation"]["tests"] %}
+            <article data-benchmark-reveal>
+              <span>{{ test["name"] }}</span>
+              <h3>{{ test["question"] }}</h3>
+              <p>{{ test["answer"] }}</p>
+              <a href="#{{ test['target'] }}">{{ test["link"] }}</a>
+            </article>
+          {% endfor %}
+        </div>
+      </section>
+
+      <section class="pc-benchmark-study shell" id="locomo" aria-labelledby="locomo-title">
+        <header class="pc-benchmark-study__header">
+          <h2 id="locomo-title">{{ benchmark["locomo"]["title"] }}</h2>
+          <p>{{ benchmark["locomo"]["lead"] }}</p>
+        </header>
+
+        <dl class="pc-benchmark-facts" data-benchmark-reveal>
+          {% for fact in benchmark["locomo"]["facts"] %}
+            <div><dt>{{ fact["label"] }}</dt><dd>{{ fact["value"] }}</dd></div>
+          {% endfor %}
+        </dl>
+
+        <div class="pc-locomo-categories" aria-label="{{ benchmark['locomo']['categories_label'] }}">
+          {% for category in benchmark["locomo"]["categories"] %}
+            <article data-benchmark-reveal>
+              <strong>{{ category["count"] }}</strong>
+              <h3>{{ category["name"] }}</h3>
+              <p>{{ category["description"] }}</p>
+            </article>
+          {% endfor %}
+        </div>
+
+        <div class="pc-metric-comparison" data-metric-comparison data-benchmark-reveal>
+          <div class="pc-metric-comparison__intro">
+            <div>
+              <h3>{{ benchmark["locomo"]["results_title"] }}</h3>
+              <p>{{ benchmark["locomo"]["results_lead"] }}</p>
+            </div>
+            <div class="pc-metric-tabs" role="tablist" aria-label="{{ benchmark['locomo']['tabs_label'] }}">
+              {% for metric in benchmark["locomo"]["metrics"] %}
+                <button id="metric-{{ metric['id'] }}-tab" type="button" role="tab" aria-controls="metric-{{ metric['id'] }}" aria-selected="{{ 'true' if loop.first else 'false' }}" tabindex="{{ '0' if loop.first else '-1' }}" data-metric-target="{{ metric['id'] }}">{{ metric["label"] }}</button>
+              {% endfor %}
+            </div>
+          </div>
+
+          <div class="pc-metric-panels">
+            {% for metric in benchmark["locomo"]["metrics"] %}
+              <section id="metric-{{ metric['id'] }}" class="pc-metric-panel{% if loop.first %} is-active{% endif %}" role="tabpanel" aria-labelledby="metric-{{ metric['id'] }}-tab" data-metric-panel="{{ metric['id'] }}">
+                <div class="pc-metric-panel__callout">
+                  <strong>{{ metric["callout"] }}</strong>
+                  <span>{{ metric["callout_detail"] }}</span>
+                </div>
+                <div class="pc-metric-panel__lanes" aria-label="{{ metric['chart_label'] }}">
+                  {% for row in metric["rows"] %}
+                    <div class="pc-metric-lane" style="--benchmark-scale: {{ row['scale'] }}%;">
+                      <div class="pc-metric-lane__meta"><span>{{ row["name"] }}</span><strong>{{ row["display"] }}</strong></div>
+                      <span class="pc-metric-lane__bar" aria-hidden="true"></span>
+                    </div>
+                  {% endfor %}
+                </div>
+                <p class="pc-metric-panel__direction">{{ metric["direction"] }}</p>
+              </section>
+            {% endfor %}
+          </div>
+        </div>
+
+        <aside class="pc-benchmark-note" data-benchmark-reveal>
+          <strong>{{ benchmark["locomo"]["scope_title"] }}</strong>
+          <p>{{ benchmark["locomo"]["scope"] }}</p>
+        </aside>
+      </section>
+
+      <section class="pc-benchmark-study pc-benchmark-study--swe shell" id="swe-bench" aria-labelledby="swe-bench-title">
+        <header class="pc-benchmark-study__header">
+          <h2 id="swe-bench-title">{{ benchmark["swe"]["title"] }}</h2>
+          <p>{{ benchmark["swe"]["lead"] }}</p>
+        </header>
+
+        <div class="pc-swe-method" data-benchmark-reveal>
+          {% for item in benchmark["swe"]["method"] %}
+            <div><strong>{{ item["title"] }}</strong><span>{{ item["description"] }}</span></div>
+          {% endfor %}
+        </div>
+
+        <figure class="pc-swe-result" data-swe-result data-benchmark-reveal aria-labelledby="swe-result-caption">
+          <div class="pc-swe-result__scores">
+            {% for score in benchmark["swe"]["scores"] %}
+              <div class="pc-swe-score pc-swe-score--{{ score['kind'] }}">
+                <span>{{ score["label"] }}</span>
+                <strong aria-hidden="true" data-count-to="{{ score['count'] }}">{{ score["count"] }}</strong>
+                <span class="pc-visually-hidden">{{ score["accessible"] }}</span>
+                <small>{{ score["rate"] }}</small>
+              </div>
+            {% endfor %}
+            <div class="pc-swe-result__delta" aria-label="{{ benchmark['swe']['delta_accessible'] }}">
+              <strong>{{ benchmark["swe"]["delta"] }}</strong>
+              <span>{{ benchmark["swe"]["delta_label"] }}</span>
+            </div>
+          </div>
+          <figcaption id="swe-result-caption">{{ benchmark["swe"]["caption"] }}</figcaption>
+        </figure>
+
+        <aside class="pc-benchmark-note" data-benchmark-reveal>
+          <strong>{{ benchmark["swe"]["scope_title"] }}</strong>
+          <p>{{ benchmark["swe"]["scope"] }}</p>
+        </aside>
+      </section>
+
+      <section class="pc-benchmark-reading shell" aria-labelledby="reading-title">
+        <header>
+          <h2 id="reading-title">{{ benchmark["reading"]["title"] }}</h2>
+          <p>{{ benchmark["reading"]["lead"] }}</p>
+        </header>
+        <div class="pc-benchmark-table-wrap" data-benchmark-reveal>
+          <table>
+            <thead><tr><th scope="col">{{ benchmark["reading"]["columns"]["dimension"] }}</th><th scope="col">LoCoMo</th><th scope="col">SWE-bench Pro</th></tr></thead>
+            <tbody>
+              {% for row in benchmark["reading"]["rows"] %}
+                <tr><th scope="row">{{ row["dimension"] }}</th><td>{{ row["locomo"] }}</td><td>{{ row["swe"] }}</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="pc-benchmark-sources shell" aria-labelledby="sources-title">
+        <div>
+          <h2 id="sources-title">{{ benchmark["sources"]["title"] }}</h2>
+          <p>{{ benchmark["sources"]["lead"] }}</p>
+        </div>
+        <ol>
+          {% for source in benchmark["sources"]["items"] %}
+            <li data-benchmark-reveal><span>{{ source["type"] }}</span><a href="{{ source['href'] }}">{{ source["label"] }}</a><p>{{ source["description"] }}</p></li>
+          {% endfor %}
+        </ol>
+      </section>
+
+      <section class="pc-benchmark-cta shell" data-benchmark-reveal>
+        <div><h2>{{ benchmark["cta"]["title"] }}</h2><p>{{ benchmark["cta"]["lead"] }}</p></div>
+        <a class="primary-button large" href="{{ benchmark['cta']['href'] }}">{{ benchmark["cta"]["label"] }}</a>
+      </section>
+    </article>
+  </div>
+{% endblock %}

--- a/theme/powercontext/benchmark.html
+++ b/theme/powercontext/benchmark.html
@@ -176,13 +176,93 @@
         </aside>
       </section>
 
+      <section class="pc-benchmark-leaderboards shell" id="leaderboards" aria-labelledby="leaderboards-title" data-leaderboards>
+        <header class="pc-benchmark-leaderboards__header">
+          <h2 id="leaderboards-title">{{ benchmark["leaderboards"]["title"] }}</h2>
+          <p>{{ benchmark["leaderboards"]["lead"] }}</p>
+          <small>{{ benchmark["leaderboards"]["updated"] }}</small>
+        </header>
+
+        <div class="pc-leaderboard-tabs" role="tablist" aria-label="{{ benchmark['leaderboards']['tabs_label'] }}" data-benchmark-reveal>
+          {% for board_key in ["locomo", "swe"] %}
+            {% set board = benchmark["leaderboards"][board_key] %}
+            <button id="{{ board['id'] }}-tab" type="button" role="tab" aria-controls="{{ board['id'] }}" aria-selected="{{ 'true' if loop.first else 'false' }}" tabindex="{{ '0' if loop.first else '-1' }}" data-leaderboard-target="{{ board_key }}">
+              <span>{{ board["tab"] }}</span>
+              <strong>{{ board["count"] }}</strong>
+            </button>
+          {% endfor %}
+        </div>
+
+        <div class="pc-leaderboard-panels" data-benchmark-reveal>
+          {% for board_key in ["locomo", "swe"] %}
+            {% set board = benchmark["leaderboards"][board_key] %}
+            <section id="{{ board['id'] }}" class="pc-leaderboard-panel{% if loop.first %} is-active{% endif %}" role="tabpanel" aria-labelledby="{{ board['id'] }}-tab" data-leaderboard-panel="{{ board_key }}"{% if not loop.first %} hidden{% endif %}>
+              <header class="pc-leaderboard-panel__header">
+                <h3>{{ board["title"] }}</h3>
+                <p>{{ board["lead"] }}</p>
+              </header>
+
+              {% if board_key == "swe" %}
+                <aside class="pc-leaderboard-spotlight" aria-label="{{ board['spotlight']['label'] }}">
+                  <div>
+                    <span>{{ board["spotlight"]["label"] }}</span>
+                    <strong>{{ board["spotlight"]["value"] }}</strong>
+                  </div>
+                  <p>{{ board["spotlight"]["detail"] }}</p>
+                  <small>{{ board["spotlight"]["status"] }}</small>
+                </aside>
+              {% endif %}
+
+              <div class="pc-leaderboard-table-wrap">
+                <table class="pc-leaderboard-table" aria-label="{{ board['table_label'] }}">
+                  <thead>
+                    {% if board_key == "locomo" %}
+                      <tr><th scope="col">{{ board["columns"]["rank"] }}</th><th scope="col">{{ board["columns"]["system"] }}</th><th scope="col">{{ board["columns"]["score"] }}</th><th scope="col">{{ board["columns"]["protocol"] }}</th><th scope="col">{{ board["columns"]["evidence"] }}</th></tr>
+                    {% else %}
+                      <tr><th scope="col">{{ board["columns"]["rank"] }}</th><th scope="col">{{ board["columns"]["system"] }}</th><th scope="col">{{ board["columns"]["score"] }}</th><th scope="col">{{ board["columns"]["provider"] }}</th><th scope="col">{{ board["columns"]["harness"] }}</th></tr>
+                    {% endif %}
+                  </thead>
+                  <tbody>
+                    {% for row in board["rows"] %}
+                      <tr{% if row["highlight"] %} class="is-powercontext"{% endif %} style="--rank-index: {{ loop.index0 }};">
+                        <td class="pc-leaderboard-rank">{{ row["rank"] }}</td>
+                        <th scope="row">
+                          {% if board_key == "locomo" %}
+                            <a href="{{ row['source'] }}">{{ row["name"] }}</a>
+                          {% else %}
+                            {{ row["name"] }}{% if row["star"] %}<sup>*</sup>{% endif %}
+                          {% endif %}
+                        </th>
+                        <td class="pc-leaderboard-score">{{ row["score"] }}{% if board_key == "swe" %}<small>{{ row["ci"] }}</small>{% endif %}</td>
+                        {% if board_key == "locomo" %}
+                          <td class="pc-leaderboard-protocol">{{ row["protocol"] }}</td>
+                          <td><span class="pc-leaderboard-evidence">{{ row["evidence"] }}</span></td>
+                        {% else %}
+                          <td>{{ row["provider"] }}</td>
+                          <td><span class="pc-leaderboard-evidence">{{ board["harness_star"] if row["star"] else board["harness_default"] }}</span></td>
+                        {% endif %}
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+
+              <footer class="pc-leaderboard-panel__footer">
+                <div><strong>{{ board["note_title"] }}</strong><p>{{ board["note"] }}</p></div>
+                {% if board_key == "swe" %}<a href="{{ board['source'] }}">{{ benchmark["leaderboards"]["source_label"] }}</a>{% endif %}
+              </footer>
+            </section>
+          {% endfor %}
+        </div>
+      </section>
+
       <section class="pc-benchmark-reading shell" aria-labelledby="reading-title">
         <header>
           <h2 id="reading-title">{{ benchmark["reading"]["title"] }}</h2>
           <p>{{ benchmark["reading"]["lead"] }}</p>
         </header>
         <div class="pc-benchmark-table-wrap" data-benchmark-reveal>
-          <table>
+          <table class="pc-benchmark-table">
             <thead><tr><th scope="col">{{ benchmark["reading"]["columns"]["dimension"] }}</th><th scope="col">LoCoMo</th><th scope="col">SWE-bench Pro</th></tr></thead>
             <tbody>
               {% for row in benchmark["reading"]["rows"] %}

--- a/theme/powercontext/partials/footer.html
+++ b/theme/powercontext/partials/footer.html
@@ -70,6 +70,7 @@
       </a>
       <nav class="pc-footer__nav" aria-label="{{ '页脚导航' if is_zh else 'Footer navigation' }}">
         <a href="{{ ('zh/docs/' if is_zh else 'en/docs/') | url }}">{{ "文档" if is_zh else "Docs" }}</a>
+        <a href="{{ ('zh/benchmarks/' if is_zh else 'en/benchmarks/') | url }}">{{ "Benchmark" if is_zh else "Benchmarks" }}</a>
         <a href="{{ ('zh/blog/' if is_zh else 'en/blog/') | url }}">{{ "博客" if is_zh else "Blog" }}</a>
         <a href="{{ ('zh/changelog/' if is_zh else 'en/changelog/') | url }}">{{ "更新日志" if is_zh else "Changelog" }}</a>
         <a href="{{ ('zh/rfcs/' if is_zh else 'en/rfcs/') | url }}">{{ "RFC 与会议纪要" if is_zh else "RFCs & Meetings" }}</a>

--- a/theme/powercontext/partials/footer.html
+++ b/theme/powercontext/partials/footer.html
@@ -70,7 +70,7 @@
       </a>
       <nav class="pc-footer__nav" aria-label="{{ '页脚导航' if is_zh else 'Footer navigation' }}">
         <a href="{{ ('zh/docs/' if is_zh else 'en/docs/') | url }}">{{ "文档" if is_zh else "Docs" }}</a>
-        <a href="{{ ('zh/benchmarks/' if is_zh else 'en/benchmarks/') | url }}">{{ "Benchmark" if is_zh else "Benchmarks" }}</a>
+        <a href="{{ ('zh/benchmarks/' if is_zh else 'en/benchmarks/') | url }}">{{ "评估测试" if is_zh else "Benchmarks" }}</a>
         <a href="{{ ('zh/blog/' if is_zh else 'en/blog/') | url }}">{{ "博客" if is_zh else "Blog" }}</a>
         <a href="{{ ('zh/changelog/' if is_zh else 'en/changelog/') | url }}">{{ "更新日志" if is_zh else "Changelog" }}</a>
         <a href="{{ ('zh/rfcs/' if is_zh else 'en/rfcs/') | url }}">{{ "RFC 与会议纪要" if is_zh else "RFCs & Meetings" }}</a>

--- a/theme/powercontext/partials/header.html
+++ b/theme/powercontext/partials/header.html
@@ -18,6 +18,7 @@
 {% set is_zh = "/zh/" in canonical %}
 {% set home_url = "zh/" if is_zh else "en/" %}
 {% set docs_active = "/docs/" in canonical or "/development/" in canonical or "/modules/" in canonical %}
+{% set benchmarks_active = "/benchmarks/" in canonical %}
 {% set blog_active = "/blog/" in canonical %}
 {% set changelog_active = "/changelog/" in canonical %}
 {% set records_active = "/rfcs/" in canonical or "/meetings/" in canonical %}
@@ -33,6 +34,7 @@
     </a>
     <div class="pc-header-nav" aria-label="{{ '主导航' if is_zh else 'Primary navigation' }}">
       <a href="{{ ('zh/docs/' if is_zh else 'en/docs/') | url }}"{% if docs_active %} aria-current="page"{% endif %}>{{ "文档" if is_zh else "Docs" }}</a>
+      <a href="{{ ('zh/benchmarks/' if is_zh else 'en/benchmarks/') | url }}"{% if benchmarks_active %} aria-current="page"{% endif %}>{{ "Benchmark" if is_zh else "Benchmarks" }}</a>
       <a href="{{ ('zh/blog/' if is_zh else 'en/blog/') | url }}"{% if blog_active %} aria-current="page"{% endif %}>{{ "博客" if is_zh else "Blog" }}</a>
       <a href="{{ ('zh/changelog/' if is_zh else 'en/changelog/') | url }}"{% if changelog_active %} aria-current="page"{% endif %}>{{ "更新日志" if is_zh else "Changelog" }}</a>
       <a href="{{ ('zh/rfcs/' if is_zh else 'en/rfcs/') | url }}"{% if records_active %} aria-current="page"{% endif %}>{{ "RFC 与会议纪要" if is_zh else "RFCs & Meetings" }}</a>

--- a/theme/powercontext/partials/header.html
+++ b/theme/powercontext/partials/header.html
@@ -34,7 +34,7 @@
     </a>
     <div class="pc-header-nav" aria-label="{{ '主导航' if is_zh else 'Primary navigation' }}">
       <a href="{{ ('zh/docs/' if is_zh else 'en/docs/') | url }}"{% if docs_active %} aria-current="page"{% endif %}>{{ "文档" if is_zh else "Docs" }}</a>
-      <a href="{{ ('zh/benchmarks/' if is_zh else 'en/benchmarks/') | url }}"{% if benchmarks_active %} aria-current="page"{% endif %}>{{ "Benchmark" if is_zh else "Benchmarks" }}</a>
+      <a href="{{ ('zh/benchmarks/' if is_zh else 'en/benchmarks/') | url }}"{% if benchmarks_active %} aria-current="page"{% endif %}>{{ "评估测试" if is_zh else "Benchmarks" }}</a>
       <a href="{{ ('zh/blog/' if is_zh else 'en/blog/') | url }}"{% if blog_active %} aria-current="page"{% endif %}>{{ "博客" if is_zh else "Blog" }}</a>
       <a href="{{ ('zh/changelog/' if is_zh else 'en/changelog/') | url }}"{% if changelog_active %} aria-current="page"{% endif %}>{{ "更新日志" if is_zh else "Changelog" }}</a>
       <a href="{{ ('zh/rfcs/' if is_zh else 'en/rfcs/') | url }}"{% if records_active %} aria-current="page"{% endif %}>{{ "RFC 与会议纪要" if is_zh else "RFCs & Meetings" }}</a>

--- a/theme/powercontext/partials/header.html
+++ b/theme/powercontext/partials/header.html
@@ -34,7 +34,7 @@
     </a>
     <div class="pc-header-nav" aria-label="{{ '主导航' if is_zh else 'Primary navigation' }}">
       <a href="{{ ('zh/docs/' if is_zh else 'en/docs/') | url }}"{% if docs_active %} aria-current="page"{% endif %}>{{ "文档" if is_zh else "Docs" }}</a>
-      <a href="{{ ('zh/benchmarks/' if is_zh else 'en/benchmarks/') | url }}"{% if benchmarks_active %} aria-current="page"{% endif %}>{{ "评估测试" if is_zh else "Benchmarks" }}</a>
+      <a href="{{ ('zh/benchmarks/' if is_zh else 'en/benchmarks/') | url }}"{% if benchmarks_active %} aria-current="page"{% endif %}>{{ "评测" if is_zh else "Benchmarks" }}</a>
       <a href="{{ ('zh/blog/' if is_zh else 'en/blog/') | url }}"{% if blog_active %} aria-current="page"{% endif %}>{{ "博客" if is_zh else "Blog" }}</a>
       <a href="{{ ('zh/changelog/' if is_zh else 'en/changelog/') | url }}"{% if changelog_active %} aria-current="page"{% endif %}>{{ "更新日志" if is_zh else "Changelog" }}</a>
       <a href="{{ ('zh/rfcs/' if is_zh else 'en/rfcs/') | url }}"{% if records_active %} aria-current="page"{% endif %}>{{ "RFC 与会议纪要" if is_zh else "RFCs & Meetings" }}</a>

--- a/zensical.toml
+++ b/zensical.toml
@@ -135,7 +135,7 @@ nav = [
                 { "HTTP API 参考" = "api/index.html" },
             ] },
         ] },
-        { "Benchmark" = "zh/benchmarks/index.md" },
+        { "评估测试" = "zh/benchmarks/index.md" },
         { "开发" = [
             { "Core Protocol" = "zh/development/core-protocol.md" },
             { "Memory Layer" = "zh/development/memory-layer.md" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -49,6 +49,7 @@ nav = [
                 { "Configuration" = "en/docs/reference/configuration.md" },
             ] },
         ] },
+        { "Benchmarks" = "en/benchmarks/index.md" },
         { "Development" = [
             { "Core Protocol" = "en/development/core-protocol.md" },
             { "Memory Layer" = "en/development/memory-layer.md" },
@@ -131,6 +132,7 @@ nav = [
                 { "配置" = "zh/docs/reference/configuration.md" },
             ] },
         ] },
+        { "Benchmark" = "zh/benchmarks/index.md" },
         { "开发" = [
             { "Core Protocol" = "zh/development/core-protocol.md" },
             { "Memory Layer" = "zh/development/memory-layer.md" },


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Follow-up to #1409.

# Rationale for this change

The benchmark page explains the two evaluation protocols, but readers also need a sourced view of the public field and a clearer visual hierarchy. The comparison must preserve protocol differences so that unlike runs are not presented as directly equivalent.

# What changes are included in this PR?

- Add a sourced LoCoMo public score index containing only systems that explicitly disclose all 1,540 scored questions.
- Add all 25 entries from the official SWE-bench Pro public leaderboard while keeping the separate PowerContext paired run clearly labeled as unofficial.
- Add accessible leaderboard tabs, staggered row reveals, responsive tables, and reduced-motion support.
- Refine benchmark result sizing and responsive layout to prevent overlap and improve visual balance.
- Remove oversized top-three cards and use compact comparison tables instead.
- Standardize the Chinese navigation and page terminology on 评估测试.

No runtime API or persisted-data behavior changes.

# Are there any user-facing changes?

Yes. The English and Chinese benchmark pages gain public comparison tables, source links, protocol notes, and revised responsive presentation. Chinese site navigation now labels Benchmarks as 评估测试.

# How was this change tested?

- make check
- make docs-test
- make test: 974 passed and 9 skipped; two OpenCode child-process timing cases failed during the full run and both passed when rerun individually.
- uv run pytest tests/test_opencode_cli.py::test_run_opencode_probe_times_out_and_stops_process -q
- uv run pytest tests/e2e/test_opencode_plugin_host.py::test_opencode_run_normalizes_prompt_before_recall_and_capture -q

# AI usage statement

OpenAI Codex was used for research, implementation, review, and validation.