### PR TITLE
feat(e2e): support forbidden recall context

### DIFF
--- a/docs/en/rfcs/1229_unified_workloads_and_long_horizon_memory_evaluation.md
+++ b/docs/en/rfcs/1229_unified_workloads_and_long_horizon_memory_evaluation.md
@@ -82,10 +82,16 @@ evaluation:
       query: Which project decision selected multi-node persistent storage?
       expected_context:
         - OceanBase
+      forbidden_context:
+        - SQLite
 ```
 
 `dataset` may identify a repository-maintained Harbor task or a versioned registry task. Repository tasks and
 registry tasks use the same execution and evidence path.
+
+Recall probe matching is case-insensitive and Unicode-normalized. A prepared context supports a probe only when it
+contains every `expected_context` fragment and none of the `forbidden_context` fragments. Any forbidden match fails
+acceptance independently of the `probe_coverage` threshold.
 
 `execution.type` selects the adapter. The current contract implements `bub`. `execution.model` only declares whether
 the workload needs a model:
@@ -178,7 +184,7 @@ Memory acceptance uses observable evidence:
 - eligible events were captured when capture is required;
 - the run created Memory and completed required checkpoints or flushes;
 - new Memory cites Sources captured during execution; and
-- declared recall probes receive usable prepared context.
+- declared recall probes receive prepared context that satisfies their required and forbidden fragment contracts.
 
 A deterministic workload may require fixed Memory fragments. A long-horizon task normally measures capture
 coverage, grounding, and recall instead of requiring a fixed task answer.
@@ -221,6 +227,9 @@ The replay records the dataset checksum, the workload's single `execution.type`,
 database identity, resolved instructions, and PowerContext scope state. The common envelope supports offline rescoring. Adapter-native
 evidence remains typed within that envelope; the current Bub adapter records ACP summaries, captured events,
 checkpoints, tool observations, and trajectory artifacts.
+
+For negative recall contracts, the replay stores the pre-redaction match verdict rather than the matched text. This
+keeps offline rescoring consistent with the live result without exposing a configured secret through the replay.
 
 Final artifact sinks remove configured secrets. Native task artifacts may contain task content and require review
 before publication.

--- a/docs/en/rfcs/1229_unified_workloads_and_long_horizon_memory_evaluation.md
+++ b/docs/en/rfcs/1229_unified_workloads_and_long_horizon_memory_evaluation.md
@@ -89,9 +89,11 @@ evaluation:
 `dataset` may identify a repository-maintained Harbor task or a versioned registry task. Repository tasks and
 registry tasks use the same execution and evidence path.
 
-Recall probe matching is case-insensitive and Unicode-normalized. A prepared context supports a probe only when it
-contains every `expected_context` fragment and none of the `forbidden_context` fragments. Any forbidden match fails
-acceptance independently of the `probe_coverage` threshold.
+Recall probe matching is case-insensitive and Unicode-normalized. Probes with `expected_context` contribute to
+`probe_coverage` and require every expected fragment. Probes with only `forbidden_context` express abstention and do
+not contribute to that coverage. If there are no positive probes, `probe_coverage` is `1`. Every probe rejects
+prepared context containing a forbidden fragment, and any forbidden match fails acceptance independently of the
+`probe_coverage` threshold.
 
 `execution.type` selects the adapter. The current contract implements `bub`. `execution.model` only declares whether
 the workload needs a model:

--- a/docs/zh/rfcs/1229_unified_workloads_and_long_horizon_memory_evaluation.md
+++ b/docs/zh/rfcs/1229_unified_workloads_and_long_horizon_memory_evaluation.md
@@ -83,9 +83,11 @@ evaluation:
 `dataset` 可以指向仓库自行维护的 Harbor task，也可以指向带版本的 registry task。两者使用相同的 execution 与 evidence
 路径。
 
-Recall probe 的匹配不区分大小写，并进行 Unicode 归一化。Prepared context 只有在包含全部 `expected_context`
-片段，且不包含任何 `forbidden_context` 片段时，才支持该 probe。任何 forbidden match 都会直接令 acceptance
-失败，不受 `probe_coverage` 阈值影响。
+Recall probe 的匹配不区分大小写，并进行 Unicode 归一化。包含 `expected_context` 的正向 probe 参与
+`probe_coverage` 计算，并要求 prepared context 包含全部 expected fragment。仅包含 `forbidden_context` 的纯负向
+probe 表达 abstention，不参与 coverage；没有正向 probe 时，`probe_coverage` 为 `1`。每个 probe 都会拒绝包含
+forbidden fragment 的 prepared context；任何 forbidden match 都会直接令 acceptance 失败，不受
+`probe_coverage` 阈值影响。
 
 `execution.type` 选择 adapter，当前 contract 实现 `bub`。`execution.model` 只声明 workload 是否需要 model：
 

--- a/docs/zh/rfcs/1229_unified_workloads_and_long_horizon_memory_evaluation.md
+++ b/docs/zh/rfcs/1229_unified_workloads_and_long_horizon_memory_evaluation.md
@@ -76,10 +76,16 @@ evaluation:
       query: Which project decision selected multi-node persistent storage?
       expected_context:
         - OceanBase
+      forbidden_context:
+        - SQLite
 ```
 
 `dataset` 可以指向仓库自行维护的 Harbor task，也可以指向带版本的 registry task。两者使用相同的 execution 与 evidence
 路径。
+
+Recall probe 的匹配不区分大小写，并进行 Unicode 归一化。Prepared context 只有在包含全部 `expected_context`
+片段，且不包含任何 `forbidden_context` 片段时，才支持该 probe。任何 forbidden match 都会直接令 acceptance
+失败，不受 `probe_coverage` 阈值影响。
 
 `execution.type` 选择 adapter，当前 contract 实现 `bub`。`execution.model` 只声明 workload 是否需要 model：
 
@@ -164,7 +170,7 @@ Memory acceptance 使用可观察的 evidence：
 - 要求 capture 时采集了符合条件的 event；
 - 本次运行创建了 Memory，并完成要求的 checkpoint 或 flush；
 - 新建 Memory 引用了 execution 期间采集的 Source；
-- 声明的 recall probe 能获得可用的 prepared context。
+- 声明的 recall probe 能获得满足必需片段与禁用片段约束的 prepared context。
 
 确定性 workload 可以要求固定的 Memory 片段。长程任务通常评估 capture coverage、grounding 与 recall，不要求固定的任务答案。
 
@@ -203,6 +209,9 @@ Evaluator 只读取 replay evidence，不能控制 adapter。Report renderer 只
 Replay 记录 dataset checksum、workload 唯一的 `execution.type`、存在时最终解析出的 model identity、database identity、最终 instruction 与
 PowerContext scope state。公共 envelope 支持离线重新评分。Adapter 原生 evidence 在 envelope 中保留类型信息；当前 Bub
 adapter 记录 ACP summary、captured event、checkpoint、tool observation 与 trajectory artifact。
+
+对于负向 recall contract，replay 记录脱敏前的匹配结论，而不是被匹配的文本。这样既能让离线重新评分与实时结果保持一致，
+也不会通过 replay 暴露已配置的 secret。
 
 最终 artifact sink 会移除已配置的 secret。原生 task artifact 可能包含任务内容，发布前需要检查。
 

--- a/e2e/bub/README.md
+++ b/e2e/bub/README.md
@@ -60,11 +60,16 @@ evaluation:
       query: What database did this project select, and why?
       expected_context:
         - OceanBase
+      forbidden_context:
+        - SQLite
 ```
 
 The dataset can be a local Harbor dataset path or a registry dataset name and version. `execution` selects the
 adapter and its budget. `model` declares only whether the workload requires a model. The runtime selects the model,
 provider, endpoint, and credentials. `evaluation` declares only externally observable Memory behavior.
+Every recall probe requires all `expected_context` fragments and rejects prepared context containing any
+`forbidden_context` fragment. Fragment matching is case-insensitive and Unicode-normalized. Any forbidden match
+fails acceptance independently of the `probe_coverage` threshold.
 Two or more compatible selected tasks with the same `batch:<name>` category share one run-local Harbor task and
 container. Their scopes, evidence, and evaluation remain independent; selecting one task uses the normal path.
 
@@ -182,7 +187,7 @@ Long-horizon acceptance requires observable Memory behavior:
 - completed Bub events were captured at the configured coverage;
 - a checkpoint created Memory in an initially empty scope;
 - new Memory cites sources captured during the run;
-- recall probes return prepared context.
+- recall probes return prepared context that satisfies their required and forbidden fragment contracts.
 
 In-run context injections remain a reported metric, but they do not gate this single-session task because extraction
 may complete only at the final checkpoint. Harbor rewards are diagnostic scores and do not gate Memory acceptance.
@@ -195,6 +200,9 @@ Every workload uses the same offline command:
 REPLAY=.powercontext-e2e/bub/sqlite/acceptance/terminal-bench-db-wal-recovery/replay.json \
 make harness-rescore
 ```
+
+For negative recall contracts, replay evidence stores the pre-redaction match verdict rather than the matched text.
+Offline rescoring therefore preserves the live outcome without exposing a configured secret through the replay.
 
 The harness does not mirror PowerContext Server, PowerContext Client, Bub, Harbor, or any-llm settings. Each component
 loads its native parameters, and the adapter only forwards the native values needed across the nested-container

--- a/e2e/bub/README.md
+++ b/e2e/bub/README.md
@@ -67,9 +67,11 @@ evaluation:
 The dataset can be a local Harbor dataset path or a registry dataset name and version. `execution` selects the
 adapter and its budget. `model` declares only whether the workload requires a model. The runtime selects the model,
 provider, endpoint, and credentials. `evaluation` declares only externally observable Memory behavior.
-Every recall probe requires all `expected_context` fragments and rejects prepared context containing any
-`forbidden_context` fragment. Fragment matching is case-insensitive and Unicode-normalized. Any forbidden match
-fails acceptance independently of the `probe_coverage` threshold.
+Recall probes with `expected_context` contribute to `probe_coverage` and require every expected fragment. Probes
+with only `forbidden_context` express abstention and do not contribute to that coverage. If there are no positive
+probes, `probe_coverage` is `1`. Every probe rejects prepared context containing a forbidden fragment. Fragment
+matching is case-insensitive and Unicode-normalized. Any forbidden match fails acceptance independently of the
+`probe_coverage` threshold.
 Two or more compatible selected tasks with the same `batch:<name>` category share one run-local Harbor task and
 container. Their scopes, evidence, and evaluation remain independent; selecting one task uses the normal path.
 

--- a/e2e/bub/src/powercontext_e2e/catalog.py
+++ b/e2e/bub/src/powercontext_e2e/catalog.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import hashlib
+import unicodedata
 from pathlib import Path
 from typing import ClassVar, Literal
 
@@ -71,10 +72,29 @@ class CaptureThresholds(CatalogModel):
     minimum_in_run_contexts: int = Field(default=0, ge=0)
 
 
+def normalize_context_fragment(value: str) -> str:
+    """Normalize context fragments for stable case-insensitive matching."""
+
+    return unicodedata.normalize("NFC", value.casefold())
+
+
 class RecallProbeSpec(CatalogModel):
     id: str = Field(pattern=r"^[a-z0-9][a-z0-9_-]*$")
     query: str = Field(min_length=1, max_length=8192)
     expected_context: tuple[str, ...] = ()
+    forbidden_context: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_context_fragments(self) -> RecallProbeSpec:
+        for field_name in ("expected_context", "forbidden_context"):
+            if any(not fragment.strip() for fragment in getattr(self, field_name)):
+                raise ValueError(f"{field_name} fragments must be nonblank")  # noqa: TRY003
+
+        expected = tuple(normalize_context_fragment(fragment) for fragment in self.expected_context)
+        forbidden = tuple(normalize_context_fragment(fragment) for fragment in self.forbidden_context)
+        if any(blocked in required for required in expected for blocked in forbidden):
+            raise ValueError("forbidden_context cannot be contained in expected_context")  # noqa: TRY003
+        return self
 
 
 class MemoryEvaluationSpec(CatalogModel):

--- a/e2e/bub/src/powercontext_e2e/evaluation.py
+++ b/e2e/bub/src/powercontext_e2e/evaluation.py
@@ -141,16 +141,17 @@ class MemoryEvaluator:
             and _probe_matches_forbidden_context(probe, probe_spec.forbidden_context)
         ]
         forbidden_context_match_ids = set(forbidden_context_matches)
+        positive_probes = [probe_spec for probe_spec in evaluation.probes if probe_spec.expected_context]
         supported_probes = [
             probe_spec
-            for probe_spec in evaluation.probes
+            for probe_spec in positive_probes
             if (probe := probes_by_id.get(probe_spec.id)) is not None
             and probe.prepared_context.status == "ready"
             and bool(probe.prepared_context.content.strip())
             and _contains_fragments(probe.prepared_context.content, probe_spec.expected_context)
             and probe_spec.id not in forbidden_context_match_ids
         ]
-        probe_coverage = len(supported_probes) / len(evaluation.probes)
+        probe_coverage = len(supported_probes) / len(positive_probes) if positive_probes else 1.0
         in_run_contexts = sum(
             record.event == "context"
             and record.status == "ready"

--- a/e2e/bub/src/powercontext_e2e/evaluation.py
+++ b/e2e/bub/src/powercontext_e2e/evaluation.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
-from .catalog import MemoryEvaluationSpec, OutcomeEvaluationSpec
+from .catalog import MemoryEvaluationSpec, OutcomeEvaluationSpec, normalize_context_fragment
 from .models import (
     CaseEvaluation,
     EvaluationReport,
     EvaluationValue,
     HarborTrialObservation,
+    RecallProbeObservation,
     TaskObservation,
 )
 
@@ -132,6 +133,14 @@ class MemoryEvaluator:
         groundedness = len(grounded_memory) / len(new_memory) if new_memory else 0.0
 
         probes_by_id = {probe.id: probe for probe in observation.probes}
+        forbidden_context_matches = [
+            probe_spec.id
+            for probe_spec in evaluation.probes
+            if (probe := probes_by_id.get(probe_spec.id)) is not None
+            and probe.prepared_context.status == "ready"
+            and _probe_matches_forbidden_context(probe, probe_spec.forbidden_context)
+        ]
+        forbidden_context_match_ids = set(forbidden_context_matches)
         supported_probes = [
             probe_spec
             for probe_spec in evaluation.probes
@@ -139,6 +148,7 @@ class MemoryEvaluator:
             and probe.prepared_context.status == "ready"
             and bool(probe.prepared_context.content.strip())
             and _contains_fragments(probe.prepared_context.content, probe_spec.expected_context)
+            and probe_spec.id not in forbidden_context_match_ids
         ]
         probe_coverage = len(supported_probes) / len(evaluation.probes)
         in_run_contexts = sum(
@@ -235,6 +245,15 @@ class MemoryEvaluator:
                 value=expected_memory_found,
                 reason=f"Expected Memory fragments: {list(evaluation.expected_memory)!r}.",
             )
+        if any(probe.forbidden_context for probe in evaluation.probes):
+            assertions["forbidden_context_absent"] = EvaluationValue(
+                value=not forbidden_context_matches,
+                reason=(
+                    "No forbidden context matched."
+                    if not forbidden_context_matches
+                    else f"Forbidden context matched for probes: {forbidden_context_matches!r}."
+                ),
+            )
         scores = {
             "capture_coverage": EvaluationValue(value=capture_coverage),
             "groundedness": EvaluationValue(value=groundedness),
@@ -261,8 +280,24 @@ class MemoryEvaluator:
 
 
 def _contains_fragments(value: str, expected: tuple[str, ...]) -> bool:
-    folded = value.casefold()
-    return all(fragment.casefold() in folded for fragment in expected)
+    normalized = normalize_context_fragment(value)
+    return all(normalize_context_fragment(fragment) in normalized for fragment in expected)
+
+
+def matches_forbidden_context(value: str, forbidden: tuple[str, ...]) -> bool:
+    normalized = normalize_context_fragment(value)
+    return any(normalize_context_fragment(fragment) in normalized for fragment in forbidden)
+
+
+def _probe_matches_forbidden_context(
+    probe: RecallProbeObservation,
+    forbidden: tuple[str, ...],
+) -> bool:
+    if not forbidden:
+        return False
+    if probe.forbidden_context_matched is not None:
+        return probe.forbidden_context_matched
+    return matches_forbidden_context(probe.prepared_context.content, forbidden)
 
 
 def _attributes(observation: TaskObservation) -> dict[str, str]:

--- a/e2e/bub/src/powercontext_e2e/models.py
+++ b/e2e/bub/src/powercontext_e2e/models.py
@@ -87,6 +87,7 @@ class RecallProbeObservation(EvidenceModel):
     id: str
     query: str
     prepared_context: PreparedContextSnapshot
+    forbidden_context_matched: bool | None = None
 
 
 class HarborTrialObservation(EvidenceModel):

--- a/e2e/bub/src/powercontext_e2e/runner.py
+++ b/e2e/bub/src/powercontext_e2e/runner.py
@@ -43,7 +43,7 @@ from powercontext.http import ListMemoryEntriesRequest, PrepareContextRequest
 
 from .artifacts import write_artifacts
 from .catalog import E2ETask, MemoryEvaluationSpec, OutcomeEvaluationSpec
-from .evaluation import evaluate_observation
+from .evaluation import evaluate_observation, matches_forbidden_context
 from .evidence import fingerprint, load_resolved_instructions, redact, write_evaluation_report, write_evidence
 from .harbor_agent import BUB_ACP_SERVER_VERSION, BUB_VERSION
 from .models import (
@@ -649,11 +649,19 @@ async def _prepared_probes(
 ) -> tuple[RecallProbeObservation, ...]:
     probes = []
     for probe in evaluation.probes:
+        context = await prepared_context(client, scope_id, probe.query)
+        forbidden_context_matched = context.status == "ready" and matches_forbidden_context(
+            context.content,
+            probe.forbidden_context,
+        )
+        if forbidden_context_matched:
+            context = context.model_copy(update={"content": ""})
         probes.append(
             RecallProbeObservation(
                 id=probe.id,
                 query=probe.query,
-                prepared_context=await prepared_context(client, scope_id, probe.query),
+                prepared_context=context,
+                forbidden_context_matched=forbidden_context_matched,
             )
         )
     return tuple(probes)

--- a/e2e/bub/tests/test_long_horizon_acceptance.py
+++ b/e2e/bub/tests/test_long_horizon_acceptance.py
@@ -107,6 +107,58 @@ def test_memory_acceptance_normalizes_required_recall_context() -> None:
     assert report.cases[0].metrics["recall_probes_supported"] == 1
 
 
+def test_memory_acceptance_supports_empty_purely_negative_probe() -> None:
+    task = _task_with_recall_contract(forbidden_context=("obsolete guidance",))
+    observation = _observation(
+        task,
+        prepared_context="",
+        prepared_context_status="empty",
+    )
+
+    report = MemoryEvaluator.evaluate(observation, experiment="negative-abstention-test")
+
+    assert report.accepted
+    case = report.cases[0]
+    assert case.assertions["forbidden_context_absent"].value
+    assert case.scores["probe_coverage"].value == 1
+    assert case.metrics["recall_probes_supported"] == 0
+
+
+def test_memory_acceptance_excludes_purely_negative_probes_from_coverage() -> None:
+    task = _task_with_recall_contract(
+        expected_context=("grounded task evidence",),
+        forbidden_context=(),
+    )
+    evaluation = task.evaluation
+    assert isinstance(evaluation, MemoryEvaluationSpec)
+    positive_probe = evaluation.probes[0]
+    negative_probe = positive_probe.model_copy(
+        update={
+            "id": "no-obsolete-guidance",
+            "expected_context": (),
+            "forbidden_context": ("obsolete guidance",),
+        }
+    )
+    task = task.model_copy(
+        update={"evaluation": evaluation.model_copy(update={"probes": (positive_probe, negative_probe)})}
+    )
+    observation = _observation(
+        task,
+        prepared_context="",
+        prepared_context_by_probe={
+            positive_probe.id: PreparedContextSnapshot(status="ready", content="Grounded task evidence."),
+            negative_probe.id: PreparedContextSnapshot(status="empty"),
+        },
+    )
+
+    report = MemoryEvaluator.evaluate(observation, experiment="mixed-probe-coverage-test")
+
+    assert report.accepted
+    case = report.cases[0]
+    assert case.scores["probe_coverage"].value == 1
+    assert case.metrics["recall_probes_supported"] == 1
+
+
 def test_prepared_probes_discard_forbidden_context_after_recording_verdict() -> None:
     task = _task_with_recall_contract(forbidden_context=("SECRET",))
     probes = _prepared_probe_observations(task, "prefix-SECRET-suffix")
@@ -212,6 +264,8 @@ def _observation(
     task: E2ETask,
     *,
     prepared_context: str,
+    prepared_context_status: str = "ready",
+    prepared_context_by_probe: dict[str, PreparedContextSnapshot] | None = None,
     forbidden_context_matched: bool | None = None,
 ) -> TaskObservation:
     recorded_at = datetime(2026, 8, 13, tzinfo=UTC)
@@ -293,7 +347,11 @@ def _observation(
             RecallProbeObservation(
                 id=probe.id,
                 query=probe.query,
-                prepared_context=PreparedContextSnapshot(status="ready", content=prepared_context),
+                prepared_context=(
+                    prepared_context_by_probe[probe.id]
+                    if prepared_context_by_probe is not None
+                    else PreparedContextSnapshot(status=prepared_context_status, content=prepared_context)
+                ),
                 forbidden_context_matched=forbidden_context_matched,
             )
             for probe in task.evaluation.probes

--- a/e2e/bub/tests/test_long_horizon_acceptance.py
+++ b/e2e/bub/tests/test_long_horizon_acceptance.py
@@ -14,10 +14,15 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
-from powercontext_e2e.catalog import load_tasks
+from powercontext_e2e.artifacts import write_artifacts
+from powercontext_e2e.catalog import E2ETask, MemoryEvaluationSpec, load_tasks
 from powercontext_e2e.evaluation import MemoryEvaluator
 from powercontext_e2e.models import (
     CaptureRecord,
@@ -32,16 +37,186 @@ from powercontext_e2e.models import (
     SourceReferenceSnapshot,
     TaskObservation,
 )
+from powercontext_e2e.rescore import rescore_replay
+from powercontext_e2e.runner import _prepared_probes
+from powercontext_e2e.settings import HarnessSettings
 
 
 def test_memory_acceptance_does_not_require_the_harbor_task_to_pass() -> None:
+    task = _terminal_bench_task()
+    observation = _observation(task, prepared_context="Grounded task evidence.")
+
+    report = MemoryEvaluator.evaluate(observation, experiment="behavior-test")
+
+    assert report.accepted
+    assert report.cases[0].scores["harbor_reward_reward"].value == 1 / 3
+    assert report.cases[0].labels["task_outcome"].value == "not_passed"
+
+
+def test_memory_acceptance_rejects_forbidden_recall_context() -> None:
+    task = _task_with_recall_contract(
+        expected_context=("grounded task evidence",),
+        forbidden_context=("OBSOLETE WAL GUIDANCE",),
+        probe_coverage=0,
+    )
+    clean_observation = _observation(task, prepared_context="Grounded task evidence is current.")
+    clean_report = MemoryEvaluator.evaluate(clean_observation, experiment="negative-context-control")
+
+    assert clean_report.accepted
+
+    observation = _observation(
+        task,
+        prepared_context="Grounded task evidence still includes obsolete wal guidance.",
+    )
+
+    report = MemoryEvaluator.evaluate(observation, experiment="negative-context-test")
+
+    assert not report.accepted
+    case = report.cases[0]
+    assert case.metrics["recall_probes_supported"] == 0
+    assert case.assertions["recall_probes_supported"].value
+    assert case.assertions["forbidden_context_absent"].reason == (
+        "Forbidden context matched for probes: ['investigation']."
+    )
+
+
+def test_memory_acceptance_normalizes_forbidden_recall_context() -> None:
+    task = _task_with_recall_contract(
+        expected_context=("grounded task evidence",),
+        forbidden_context=("CAFÉ",),
+        probe_coverage=0,
+    )
+    observation = _observation(task, prepared_context="Grounded task evidence includes cafe\u0301 notes.")
+
+    report = MemoryEvaluator.evaluate(observation, experiment="unicode-context-test")
+
+    assert not report.accepted
+    assert not report.cases[0].assertions["forbidden_context_absent"].value
+
+
+def test_memory_acceptance_normalizes_required_recall_context() -> None:
+    task = _task_with_recall_contract(
+        expected_context=("CAFÉ",),
+        forbidden_context=(),
+    )
+    observation = _observation(task, prepared_context="Relevant cafe\u0301 notes.")
+
+    report = MemoryEvaluator.evaluate(observation, experiment="unicode-required-context-test")
+
+    assert report.accepted
+    assert report.cases[0].metrics["recall_probes_supported"] == 1
+
+
+def test_prepared_probes_discard_forbidden_context_after_recording_verdict() -> None:
+    task = _task_with_recall_contract(forbidden_context=("SECRET",))
+    probes = _prepared_probe_observations(task, "prefix-SECRET-suffix")
+
+    assert probes[0].forbidden_context_matched is True
+    assert probes[0].prepared_context.content == ""
+
+
+def test_redacted_replay_preserves_forbidden_context_verdict(monkeypatch, tmp_path: Path) -> None:
+    sensitive_value = "prefix-CAFÉ-suffix"
+    monkeypatch.setenv("BUB_API_KEY", sensitive_value)
+    settings = HarnessSettings()
+    task = _task_with_recall_contract(forbidden_context=("CAFÉ",))
+    probes = _prepared_probe_observations(task, "prefix-cafe\u0301-suffix")
+    observation = _observation(task, prepared_context="unused").model_copy(
+        update={"probes": probes},
+    )
+    live_report = MemoryEvaluator.evaluate(observation, experiment="live")
+    live_dir = tmp_path / "live"
+
+    write_artifacts(observation, live_report, live_dir, settings=settings)
+    replay = json.loads((live_dir / "replay.json").read_text(encoding="utf-8"))
+    offline_accepted = rescore_replay(live_dir / "replay.json", tmp_path / "offline", settings)
+
+    assert not live_report.accepted
+    assert sensitive_value not in json.dumps(replay)
+    assert replay["probes"][0]["forbidden_context_matched"] is True
+    assert replay["probes"][0]["prepared_context"]["content"] == ""
+    assert not offline_accepted
+
+
+def test_redacted_replay_trusts_recorded_clean_verdict(monkeypatch, tmp_path: Path) -> None:
+    sensitive_value = "provider-runtime-sensitive-value"
+    monkeypatch.setenv("BUB_API_KEY", sensitive_value)
+    settings = HarnessSettings()
+    task = _task_with_recall_contract(forbidden_context=("[REDACTED]",))
+    probes = _prepared_probe_observations(task, sensitive_value)
+    observation = _observation(task, prepared_context="unused").model_copy(
+        update={"probes": probes},
+    )
+    live_report = MemoryEvaluator.evaluate(observation, experiment="live-clean")
+    live_dir = tmp_path / "live-clean"
+
+    write_artifacts(observation, live_report, live_dir, settings=settings)
+    replay = json.loads((live_dir / "replay.json").read_text(encoding="utf-8"))
+    offline_accepted = rescore_replay(live_dir / "replay.json", tmp_path / "offline-clean", settings)
+
+    assert live_report.accepted
+    assert replay["probes"][0]["prepared_context"]["content"] == "[REDACTED]"
+    assert replay["probes"][0]["forbidden_context_matched"] is False
+    assert offline_accepted
+
+
+def _terminal_bench_task() -> E2ETask:
     repository = Path(__file__).resolve().parents[3]
-    task = next(
+    return next(
         task for task in load_tasks(repository / "e2e" / "bub" / "tasks") if task.id == "terminal-bench-db-wal-recovery"
     )
+
+
+def _task_with_recall_contract(
+    *,
+    expected_context: tuple[str, ...] = (),
+    forbidden_context: tuple[str, ...],
+    probe_coverage: float = 1,
+) -> E2ETask:
+    task = _terminal_bench_task()
+    evaluation = task.evaluation
+    assert isinstance(evaluation, MemoryEvaluationSpec)
+    probe = evaluation.probes[0].model_copy(
+        update={
+            "expected_context": expected_context,
+            "forbidden_context": forbidden_context,
+        }
+    )
+    return task.model_copy(
+        update={
+            "evaluation": evaluation.model_copy(
+                update={
+                    "probes": (probe,),
+                    "thresholds": evaluation.thresholds.model_copy(update={"probe_coverage": probe_coverage}),
+                }
+            )
+        }
+    )
+
+
+def _prepared_probe_observations(task: E2ETask, content: str) -> tuple[RecallProbeObservation, ...]:
+    evaluation = task.evaluation
+    assert isinstance(evaluation, MemoryEvaluationSpec)
+    client = SimpleNamespace(
+        prepare_context=AsyncMock(
+            return_value=SimpleNamespace(
+                status=SimpleNamespace(value="ready"),
+                content=content,
+            )
+        )
+    )
+    return asyncio.run(_prepared_probes(client, evaluation, "scope-id"))
+
+
+def _observation(
+    task: E2ETask,
+    *,
+    prepared_context: str,
+    forbidden_context_matched: bool | None = None,
+) -> TaskObservation:
     recorded_at = datetime(2026, 8, 13, tzinfo=UTC)
     captured_source = "bub-event:captured"
-    observation = TaskObservation(
+    return TaskObservation(
         run_id="behavior-test",
         environment=RunEnvironment(
             commit="abcdef0",
@@ -118,14 +293,9 @@ def test_memory_acceptance_does_not_require_the_harbor_task_to_pass() -> None:
             RecallProbeObservation(
                 id=probe.id,
                 query=probe.query,
-                prepared_context=PreparedContextSnapshot(status="ready", content="Grounded task evidence."),
+                prepared_context=PreparedContextSnapshot(status="ready", content=prepared_context),
+                forbidden_context_matched=forbidden_context_matched,
             )
             for probe in task.evaluation.probes
         ),
     )
-
-    report = MemoryEvaluator.evaluate(observation, experiment="behavior-test")
-
-    assert report.accepted
-    assert report.cases[0].scores["harbor_reward_reward"].value == 1 / 3
-    assert report.cases[0].labels["task_outcome"].value == "not_passed"

--- a/e2e/bub/tests/test_workload_catalog.py
+++ b/e2e/bub/tests/test_workload_catalog.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from powercontext_e2e.catalog import load_tasks, select_tasks
+from powercontext_e2e.catalog import RecallProbeSpec, load_tasks, select_tasks
 from powercontext_e2e.runner import group_tasks
 
 
@@ -71,3 +71,36 @@ def test_batch_category_cannot_escape_the_runtime_dataset() -> None:
 
     with pytest.raises(ValueError, match="valid batch category"):
         group_tasks((task,))
+
+
+def test_recall_probe_manifest_accepts_forbidden_context() -> None:
+    probe = RecallProbeSpec.model_validate({
+        "id": "database-decision",
+        "query": "Which database decision is current?",
+        "expected_context": ["OceanBase"],
+        "forbidden_context": ["SQLite"],
+    })
+
+    assert probe.forbidden_context == ("SQLite",)
+
+
+@pytest.mark.parametrize("field_name", ["expected_context", "forbidden_context"])
+def test_recall_probe_manifest_rejects_blank_context_fragments(field_name: str) -> None:
+    payload = {
+        "id": "database-decision",
+        "query": "Which database decision is current?",
+        field_name: ["  "],
+    }
+
+    with pytest.raises(ValueError, match=f"{field_name} fragments must be nonblank"):
+        RecallProbeSpec.model_validate(payload)
+
+
+def test_recall_probe_manifest_rejects_impossible_context_contract() -> None:
+    with pytest.raises(ValueError, match="forbidden_context cannot be contained in expected_context"):
+        RecallProbeSpec.model_validate({
+            "id": "database-decision",
+            "query": "Which database decision is current?",
+            "expected_context": ["SQLite"],
+            "forbidden_context": ["sql"],
+        })


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Refs #1263.

Follow-up to #1272.

# Rationale for this change

PR #1272 added declarative recall probes but deferred negative benchmark cases because the evaluator could not express context that must not be returned. Without a negative contract, a probe can satisfy its required fragments while still returning stale or otherwise forbidden context.

# What changes are included in this PR?

- Add an optional `forbidden_context` contract to recall probes.
- Match required and forbidden fragments case-insensitively with Unicode normalization.
- Reject blank fragments and contracts where a forbidden fragment is contained in required context.
- Treat any forbidden match as a hard acceptance failure, independent of `probe_coverage`.
- Record the pre-redaction Boolean verdict for replay scoring and discard matched prepared context before persistence.
- Preserve compatibility with existing manifests and older replays that do not contain the new field.
- Document the contract in the Bub README and the English and Chinese RFCs.

The related production substring paths were checked: recall-probe matching is updated here, while `expected_memory` remains a separate Memory-recording contract and is unchanged.

# Are there any user-facing changes?

E2E workload authors can now declare context that a recall probe must not return. Existing manifests keep their previous behavior because `forbidden_context` defaults to empty. Existing evaluation reports are unchanged unless a workload declares a forbidden fragment. There are no PowerContext Server, Client, or persisted Memory API changes, and no new model calls or scheduled work.

# How was this change tested?

- `uv run --locked ruff check e2e/bub`
- `uv run --locked ruff format --check e2e/bub`
- `uv run --locked ty check --project e2e/bub --python e2e/bub/.venv --python-version 3.12 e2e/bub/src integrations/bub/src`
- `uv run --project e2e/bub python -m pytest e2e/bub/tests -q` (`23 passed`)
- `uv run --project e2e/bub powercontext-e2e --help`
- `git diff --check`

Regression coverage includes a forbidden match with `probe_coverage: 0`, canonically equivalent Unicode, manifest validation, removal of matched context before replay persistence, and live/offline replay parity for both recorded `true` and `false` verdicts.

# AI usage statement

OpenAI Codex with GPT-5.6-sol was used for implementation assistance and independent adversarial review. The final diff passed the repository checks listed above, and the final independent review reported no remaining findings.
