### PR TITLE
fix: doctor POWERCONTEXT_CLIENT_SERVER_URL invalid

### DIFF
--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -770,7 +770,10 @@ def doctor(
     context: typer.Context,
     server_url: Annotated[
         str,
-        typer.Option(help="PowerContext Server base URL."),
+        typer.Option(
+            envvar="POWERCONTEXT_CLIENT_SERVER_URL",
+            help="PowerContext Server base URL.",
+        ),
     ] = "http://127.0.0.1:8000",
     json_output: Annotated[
         bool,

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -34,6 +34,7 @@ from urllib.request import Request, urlopen
 import typer
 from pydantic import ValidationError
 
+from powercontext.client.settings import normalize_server_url
 from powercontext.http import HealthResponse, ReadinessResponse, ReadinessStatus
 from powercontext.paths import powercontext_data_dir
 from powercontext.transport import is_loopback_host
@@ -1046,7 +1047,12 @@ def run_diagnostics(*, server_url: str) -> dict[str, Diagnostic]:
     """Collect installed-environment diagnostics without changing state."""
 
     package = Diagnostic(status=DiagnosticStatus.OK, detail=f"powercontext {version('powercontext')}")
-    liveness = _server_liveness_diagnostic(server_url)
+    try:
+        server_url = normalize_server_url(server_url)
+    except ValueError as error:
+        liveness = Diagnostic(status=DiagnosticStatus.FAILED, detail=str(error))
+    else:
+        liveness = _server_liveness_diagnostic(server_url)
     readiness = (
         _server_readiness_diagnostic(server_url)
         if liveness.ok
@@ -1149,9 +1155,6 @@ def run_claude_code_diagnostics() -> dict[str, Diagnostic]:
 
 
 def _server_liveness_diagnostic(server_url: str) -> Diagnostic:
-    error = _server_url_error(server_url)
-    if error is not None:
-        return Diagnostic(status=DiagnosticStatus.FAILED, detail=error)
     try:
         status_code, payload = _request_json(server_url, "/health/live")
     except OSError:
@@ -1190,20 +1193,6 @@ def _server_readiness_diagnostic(server_url: str) -> Diagnostic:
         detail=f"{server_url} status={readiness.status.value}",
         checks=readiness.checks,
     )
-
-
-def _server_url_error(server_url: str) -> str | None:
-    parsed = urlsplit(server_url)
-    if (
-        parsed.scheme not in {"http", "https"}
-        or parsed.hostname is None
-        or parsed.username is not None
-        or parsed.password is not None
-        or parsed.query
-        or parsed.fragment
-    ):
-        return "Server URL must be an HTTP base URL without credentials or query data"
-    return None
 
 
 def _request_json(server_url: str, path: str) -> tuple[int, object]:

--- a/src/powercontext/client/settings.py
+++ b/src/powercontext/client/settings.py
@@ -16,12 +16,31 @@
 
 from __future__ import annotations
 
-from pydantic import Field, HttpUrl, SecretStr, TypeAdapter, field_validator
+from urllib.parse import urlsplit
+
+from pydantic import Field, HttpUrl, SecretStr, TypeAdapter, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from powercontext.transport import is_plaintext_non_loopback
 
 _HTTP_URL = TypeAdapter(HttpUrl)
+
+
+def normalize_server_url(value: str) -> str:
+    """Validate and normalize a Server URL for outbound Client and CLI requests."""
+
+    try:
+        normalized = str(_HTTP_URL.validate_python(value)).rstrip("/")
+    except ValidationError as error:
+        raise ValueError("PowerContext Server URL must be a valid HTTP or HTTPS URL") from error  # noqa: TRY003
+    parsed = urlsplit(normalized)
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("PowerContext Server URL must not contain credentials")  # noqa: TRY003
+    if parsed.query or parsed.fragment:
+        raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
+    if is_plaintext_non_loopback(normalized):
+        raise ValueError("Unencrypted PowerContext Server URLs must be loopback addresses")  # noqa: TRY003
+    return normalized
 
 
 class ClientSettings(BaseSettings):
@@ -40,17 +59,7 @@ class ClientSettings(BaseSettings):
     @field_validator("server_url")
     @classmethod
     def validate_server_url(cls, value: str) -> str:
-        from urllib.parse import urlsplit
-
-        normalized = str(_HTTP_URL.validate_python(value)).rstrip("/")
-        parsed = urlsplit(normalized)
-        if parsed.username is not None or parsed.password is not None:
-            raise ValueError("PowerContext Server URL must not contain credentials")  # noqa: TRY003
-        if parsed.query or parsed.fragment:
-            raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
-        if is_plaintext_non_loopback(normalized):
-            raise ValueError("Unencrypted PowerContext Server URLs must be loopback addresses")  # noqa: TRY003
-        return normalized
+        return normalize_server_url(value)
 
 
-__all__ = ["ClientSettings"]
+__all__ = ["ClientSettings", "normalize_server_url"]

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -585,7 +585,7 @@ def test_default_doctor_checks_server_without_inspecting_codex(monkeypatch) -> N
 
 
 def test_default_doctor_uses_client_server_url_from_environment(monkeypatch) -> None:
-    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "http://127.0.0.1:8888")
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "http://127.0.0.1:8888/")
     urlopen = Mock(
         side_effect=[
             _Response(200, {"status": "ok"}),
@@ -603,6 +603,18 @@ def test_default_doctor_uses_client_server_url_from_environment(monkeypatch) -> 
         "http://127.0.0.1:8888/health/live",
         "http://127.0.0.1:8888/health/ready",
     ]
+
+
+def test_default_doctor_rejects_non_loopback_plaintext_environment_url_without_request(monkeypatch) -> None:
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "http://memory.example")
+    urlopen = Mock()
+    monkeypatch.setattr(system_cli, "urlopen", urlopen)
+
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Unencrypted PowerContext Server URLs must be loopback addresses" in result.output
+    urlopen.assert_not_called()
 
 
 def test_default_doctor_skips_readiness_when_liveness_is_unreachable(monkeypatch) -> None:

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -604,6 +604,25 @@ def test_default_doctor_uses_client_server_url_from_environment(monkeypatch) -> 
         "http://127.0.0.1:8888/health/ready",
     ]
 
+    # Explicit CLI argument should override the environment variable.
+    urlopen.reset_mock()
+    urlopen.side_effect = [
+        _Response(200, {"status": "ok"}),
+        _Response(200, {"status": "ready", "checks": {"runtime": "ready", "database": "ready"}}),
+    ]
+    override = CliRunner().invoke(
+        create_cli([doctor_app]),
+        ["doctor", "--server-url", "http://127.0.0.1:9999"],
+    )
+
+    assert override.exit_code == 0
+    assert "server liveness: ok - http://127.0.0.1:9999 status=ok" in override.output
+    assert "server readiness: ok - http://127.0.0.1:9999 status=ready" in override.output
+    assert [call.args[0].full_url for call in urlopen.call_args_list] == [
+        "http://127.0.0.1:9999/health/live",
+        "http://127.0.0.1:9999/health/ready",
+    ]
+
 
 def test_default_doctor_skips_readiness_when_liveness_is_unreachable(monkeypatch) -> None:
     urlopen = Mock(side_effect=OSError("connection refused"))

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -584,6 +584,27 @@ def test_default_doctor_checks_server_without_inspecting_codex(monkeypatch) -> N
     assert list(payload["checks"]) == ["package", "server_liveness", "server_readiness"]
 
 
+def test_default_doctor_uses_client_server_url_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "http://127.0.0.1:8888")
+    urlopen = Mock(
+        side_effect=[
+            _Response(200, {"status": "ok"}),
+            _Response(200, {"status": "ready", "checks": {"runtime": "ready", "database": "ready"}}),
+        ]
+    )
+    monkeypatch.setattr(system_cli, "urlopen", urlopen)
+
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor"])
+
+    assert result.exit_code == 0
+    assert "server liveness: ok - http://127.0.0.1:8888 status=ok" in result.output
+    assert "server readiness: ok - http://127.0.0.1:8888 status=ready" in result.output
+    assert [call.args[0].full_url for call in urlopen.call_args_list] == [
+        "http://127.0.0.1:8888/health/live",
+        "http://127.0.0.1:8888/health/ready",
+    ]
+
+
 def test_default_doctor_skips_readiness_when_liveness_is_unreachable(monkeypatch) -> None:
     urlopen = Mock(side_effect=OSError("connection refused"))
     monkeypatch.setattr(system_cli, "urlopen", urlopen)


### PR DESCRIPTION
# Which issue or RFC does this PR close?

<!--
Link the related issue or RFC using GitHub syntax.
For example, `Closes #123` indicates that this PR will close issue #123.
If this PR implements an RFC, link the RFC and any existing tracking issue.
-->

Closes #1433.

# Rationale for this change

<!--
Explain why this change is needed. If the linked issue or RFC already explains the rationale clearly, a short summary is enough.
-->

`powercontext live` and `powercontext ready` respect `POWERCONTEXT_CLIENT_SERVER_URL`, but `powercontext doctor` previously fell back to `http://127.0.0.1:8000` unless `--server-url` was provided explicitly. This could make diagnostics target the wrong Server and report a misleading connection failure.

# What changes are included in this PR?

<!--
Summarize the important changes. Focus on behavior, API, docs, tests, and migration impact.
-->

- Bind the `powercontext doctor --server-url` option to `POWERCONTEXT_CLIENT_SERVER_URL`.
- Route the selected URL through the same validation and normalization used by `ClientSettings`, including the shared prohibition on plaintext non-loopback HTTP.
- Preserve the existing precedence: an explicit `--server-url` value overrides the environment variable, which overrides the default URL.
- Add regression coverage for environment-based selection, URL normalization, and rejection before any request is made.
- No persisted-format, documentation, or migration changes are required.

# Are there any user-facing changes?

<!--
If there are user-facing changes, documentation may need to be updated before approval.
If there are breaking changes to public APIs or persisted formats, call them out explicitly.
-->

Yes. `powercontext doctor` now uses `POWERCONTEXT_CLIENT_SERVER_URL` when `--server-url` is not provided. This is a backward-compatible behavior fix with no breaking changes.

# How was this change tested?

<!--
List commands run, tests added or updated, and any manual validation performed.
-->

- Added regression tests for environment-based URL selection and rejection of plaintext non-loopback URLs without issuing a request.
- Ran `.venv/bin/python -m pytest tests/test_system_cli.py tests/test_client.py tests/test_transport.py tests/test_cli.py -q` (`121 passed`).
- Ran `.venv/bin/prek run --files src/powercontext/client/settings.py src/powercontext/cli/system.py tests/test_system_cli.py` (all checks passed).
- Verified that `powercontext doctor --help` documents `POWERCONTEXT_CLIENT_SERVER_URL` for `--server-url`.

# AI usage statement

<!--
If AI tools were used to build this PR, describe the tool and model where possible.
If not applicable, write `Not used`.
-->
