### PR TITLE
fix: env file parser

### DIFF
--- a/src/powercontext/cli/env_file.py
+++ b/src/powercontext/cli/env_file.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import Collection, Generator, Mapping, MutableMapping
+from collections.abc import Collection, Generator, Iterator, Mapping, MutableMapping
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -44,7 +44,8 @@ def parse_environment(content: str, *, source: str = "environment") -> dict[str,
     """
 
     environment: dict[str, str] = {}
-    for line_number, line in enumerate(content.splitlines(), start=1):
+    lines = iter(enumerate(content.splitlines(), start=1))
+    for line_number, line in lines:
         stripped = line.lstrip(" \t")
         if not stripped or stripped.startswith("#"):
             continue
@@ -53,12 +54,7 @@ def parse_environment(content: str, *, source: str = "environment") -> dict[str,
             stripped = stripped[export.end() :]
         if "\x00" in stripped:
             raise EnvironmentFileError(f"invalid NUL character at {source}:{line_number}")  # noqa: TRY003
-        try:
-            tokens = _split_shell_words(stripped)
-        except ValueError as error:
-            raise EnvironmentFileError(  # noqa: TRY003
-                f"invalid assignment at {source}:{line_number}: {error}"
-            ) from error
+        tokens = _split_assignment(stripped, lines, source=source, line_number=line_number)
         if not tokens:
             continue
         if len(tokens) != 1 or "=" not in tokens[0]:
@@ -74,6 +70,37 @@ def parse_environment(content: str, *, source: str = "environment") -> dict[str,
             )
         environment[name] = value
     return environment
+
+
+def _split_assignment(
+    first_line: str,
+    following_lines: Iterator[tuple[int, str]],
+    *,
+    source: str,
+    line_number: int,
+) -> list[str]:
+    """Split one assignment, consuming physical lines until its quotes close."""
+
+    assignment = first_line
+    while True:
+        try:
+            return _split_shell_words(assignment)
+        except ValueError as error:
+            if str(error) != _NO_CLOSING_QUOTATION:
+                raise EnvironmentFileError(  # noqa: TRY003
+                    f"invalid assignment at {source}:{line_number}: {error}"
+                ) from error
+            try:
+                continuation_line_number, continuation = next(following_lines)
+            except StopIteration:
+                raise EnvironmentFileError(  # noqa: TRY003
+                    f"invalid assignment at {source}:{line_number}: {error}"
+                ) from error
+            if "\x00" in continuation:
+                raise EnvironmentFileError(  # noqa: TRY003
+                    f"invalid NUL character at {source}:{continuation_line_number}"
+                ) from None
+            assignment = f"{assignment}\n{continuation}"
 
 
 def _split_shell_words(line: str) -> list[str]:  # noqa: C901

--- a/src/powercontext/cli/env_file.py
+++ b/src/powercontext/cli/env_file.py
@@ -81,35 +81,52 @@ def _split_assignment(
 ) -> list[str]:
     """Split one assignment, consuming physical lines until its quotes close."""
 
-    assignment = first_line
-    while True:
-        try:
-            return _split_shell_words(assignment)
-        except ValueError as error:
-            if str(error) != _NO_CLOSING_QUOTATION:
-                raise EnvironmentFileError(  # noqa: TRY003
-                    f"invalid assignment at {source}:{line_number}: {error}"
-                ) from error
-            try:
-                continuation_line_number, continuation = next(following_lines)
-            except StopIteration:
-                raise EnvironmentFileError(  # noqa: TRY003
-                    f"invalid assignment at {source}:{line_number}: {error}"
-                ) from error
-            if "\x00" in continuation:
-                raise EnvironmentFileError(  # noqa: TRY003
-                    f"invalid NUL character at {source}:{continuation_line_number}"
-                ) from None
-            assignment = f"{assignment}\n{continuation}"
-
-
-def _split_shell_words(line: str) -> list[str]:  # noqa: C901
-    """Split one shell assignment without expansion or command evaluation."""
-
     words: list[str] = []
     word: list[str] = []
     quote = ""
     word_started = False
+    line = first_line
+    while True:
+        try:
+            quote, word_started = _scan_shell_words(
+                line,
+                words,
+                word,
+                quote=quote,
+                word_started=word_started,
+            )
+        except ValueError as error:
+            raise EnvironmentFileError(  # noqa: TRY003
+                f"invalid assignment at {source}:{line_number}: {error}"
+            ) from error
+        if not quote:
+            if word_started:
+                words.append("".join(word))
+            return words
+        try:
+            continuation_line_number, line = next(following_lines)
+        except StopIteration:
+            error = ValueError(_NO_CLOSING_QUOTATION)
+            raise EnvironmentFileError(  # noqa: TRY003
+                f"invalid assignment at {source}:{line_number}: {error}"
+            ) from error
+        if "\x00" in line:
+            raise EnvironmentFileError(  # noqa: TRY003
+                f"invalid NUL character at {source}:{continuation_line_number}"
+            )
+        word.append("\n")
+
+
+def _scan_shell_words(  # noqa: C901
+    line: str,
+    words: list[str],
+    word: list[str],
+    *,
+    quote: str,
+    word_started: bool,
+) -> tuple[str, bool]:
+    """Scan one physical line while carrying the current assignment state."""
+
     index = 0
     while index < len(line):
         character = line[index]
@@ -142,7 +159,7 @@ def _split_shell_words(line: str) -> list[str]:  # noqa: C901
         elif character in {" ", "\t"}:
             if word_started:
                 words.append("".join(word))
-                word = []
+                word.clear()
                 word_started = False
         elif character == "#" and not word_started:
             break
@@ -152,11 +169,7 @@ def _split_shell_words(line: str) -> list[str]:  # noqa: C901
             word.append(character)
             word_started = True
         index += 1
-    if quote:
-        raise ValueError(_NO_CLOSING_QUOTATION)
-    if word_started:
-        words.append("".join(word))
-    return words
+    return quote, word_started
 
 
 def read_environment_file(path: Path) -> dict[str, str]:

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -249,6 +249,29 @@ def test_validate_reports_invalid_numeric_values_without_a_traceback(tmp_path: P
     assert "Traceback" not in result.output
 
 
+def test_validate_accepts_multiline_quoted_dashboard_scopes(tmp_path: Path) -> None:
+    environment = tmp_path / ".env"
+    single_line = (
+        'POWERCONTEXT_SERVER_DASHBOARD_SCOPES=\'[{"scope_id":"project:quickstart","display_name":"Quick Start"}]\''
+    )
+    multiline = """POWERCONTEXT_SERVER_DASHBOARD_SCOPES='[
+  {
+    "scope_id": "project:quickstart",
+    "display_name": "Quick Start"
+  }
+]'"""
+    content = config_cli.render_managed_block(_configuration())
+    assert single_line in content
+    content = content.replace(single_line, multiline)
+    environment.write_text(content, encoding="utf-8")
+
+    with patch.object(config_cli, "_validate_provider_models"):
+        result = CliRunner().invoke(config_cli.app, ["validate", "--env-file", str(environment)])
+
+    assert result.exit_code == 0
+    assert "Configuration is valid" in result.output
+
+
 def test_show_redacts_standard_credential_container_variables(tmp_path: Path) -> None:
     environment = tmp_path / ".env"
     environment.write_text(

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -251,18 +251,17 @@ def test_validate_reports_invalid_numeric_values_without_a_traceback(tmp_path: P
 
 def test_validate_accepts_multiline_quoted_dashboard_scopes(tmp_path: Path) -> None:
     environment = tmp_path / ".env"
-    single_line = (
-        'POWERCONTEXT_SERVER_DASHBOARD_SCOPES=\'[{"scope_id":"project:quickstart","display_name":"Quick Start"}]\''
-    )
     multiline = """POWERCONTEXT_SERVER_DASHBOARD_SCOPES='[
   {
     "scope_id": "project:quickstart",
     "display_name": "Quick Start"
   }
 ]'"""
-    content = config_cli.render_managed_block(_configuration())
-    assert single_line in content
-    content = content.replace(single_line, multiline)
+    generated = config_cli.render_managed_block(_configuration())
+    content = "\n".join(
+        line for line in generated.splitlines() if not line.startswith("POWERCONTEXT_SERVER_DASHBOARD_SCOPES=")
+    )
+    content = f"{content}\n{multiline}\n"
     environment.write_text(content, encoding="utf-8")
 
     with patch.object(config_cli, "_validate_provider_models"):

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -14,7 +14,9 @@
 
 from __future__ import annotations
 
+import json
 import os
+import time
 
 import pytest
 
@@ -64,6 +66,20 @@ def test_multiline_double_quoted_value_unescapes_json_quotes() -> None:
     content = 'JSON="[\n  {\\"name\\": \\"value\\"}\n]"\n'
 
     assert parse_environment(content) == {"JSON": '[\n  {"name": "value"}\n]'}
+
+
+def test_large_multiline_value_parses_within_linear_time_budget() -> None:
+    value = json.dumps(
+        [{"scope_id": f"project:{index}", "display_name": f"Project {index}"} for index in range(800)],
+        indent=2,
+    )
+    started = time.monotonic()
+
+    parsed = parse_environment(f"SCOPES='{value}'\n")
+
+    elapsed = time.monotonic() - started
+    assert parsed == {"SCOPES": value}
+    assert elapsed < 1.0, f"large multiline value took {elapsed:.3f}s to parse"
 
 
 def test_url_fragment_assignment_survives() -> None:

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -39,6 +39,33 @@ def test_quoted_values_keep_hashes_and_spaces() -> None:
     assert parse_environment(content) == {"TOKEN": "#not a comment", "OTHER": "plain#tag"}
 
 
+def test_multiline_quoted_json_value_is_preserved() -> None:
+    content = """POWERCONTEXT_SERVER_DASHBOARD_SCOPES='[
+  {
+    "scope_id": "git:github.com/oceanbase/powercontext",
+    "display_name": "powercontext"
+  }
+]'
+OTHER=value
+"""
+
+    assert parse_environment(content) == {
+        "POWERCONTEXT_SERVER_DASHBOARD_SCOPES": """[
+  {
+    "scope_id": "git:github.com/oceanbase/powercontext",
+    "display_name": "powercontext"
+  }
+]""",
+        "OTHER": "value",
+    }
+
+
+def test_multiline_double_quoted_value_unescapes_json_quotes() -> None:
+    content = 'JSON="[\n  {\\"name\\": \\"value\\"}\n]"\n'
+
+    assert parse_environment(content) == {"JSON": '[\n  {"name": "value"}\n]'}
+
+
 def test_url_fragment_assignment_survives() -> None:
     assert parse_environment("URL=https://example.com/page#section\n") == {"URL": "https://example.com/page#section"}
 


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1443.

# Rationale for this change

PowerContext parsed environment files one physical line at a time. As a result, a quoted value that continued onto subsequent lines was rejected at its opening line with `No closing quotation`, even when the quote was closed later in the file. This prevented readable multiline JSON values such as `POWERCONTEXT_SERVER_DASHBOARD_SCOPES` from being used with `--env-file`.

# What changes are included in this PR?

- Continue consuming physical lines when a quoted environment value has not closed yet.
- Preserve newlines and indentation inside multiline single-quoted and double-quoted values.
- Keep the parser shell-free and retain its existing validation for shell expansion, invalid assignments, duplicate names, and NUL characters.
- Add parser regression coverage for multiline JSON, double-quoted values, and assignments following a multiline value.
- Add CLI regression coverage proving that `powercontext config validate --env-file` accepts multiline dashboard scope JSON.

# Are there any user-facing changes?

Yes. Commands that accept `--env-file` now support multiline quoted values. Existing single-line environment files continue to behave as before. There are no public API changes, persisted-format changes, breaking changes, or migration requirements.

# How was this change tested?

- Reproduced the original `No closing quotation` failure before applying the fix.
- `make check` — passed, including lock-file validation, pre-commit hooks, Ruff, and type checking.
- `uv run pytest tests/test_env_file.py tests/test_config_cli.py -q` — 49 passed.
- `uv run pytest tests/test_server.py tests/test_service_environment.py tests/test_service.py -q` — 148 passed, 2 skipped.
- `make test` — 1,288 passed and 19 skipped. Three `tests/client/test_receiver_service.py` tests failed locally because they exercise Linux-only systemd service installation while the suite was run on macOS; these failures are unrelated to the environment-file parser change.

# AI usage statement