### PR TITLE
fix(server): preserve binary cursor keys on Windows

### DIFF
--- a/.github/workflows/native-service.yml
+++ b/.github/workflows/native-service.yml
@@ -116,6 +116,13 @@ jobs:
           uv venv .native-venv
           uv pip install --python .native-venv\Scripts\python.exe "powercontext[cli,server] @ $wheelUri" pytest
 
+      - name: Verify binary cursor persistence and restart compatibility
+        shell: pwsh
+        run: >-
+          .native-venv\Scripts\python.exe -m pytest -q
+          tests/test_cursor_secret.py
+          tests/test_server.py::test_server_reuses_file_backed_cursor_secret_across_restarts
+
       - name: Exercise the real Task Scheduler lifecycle
         shell: pwsh
         run: >-
@@ -127,6 +134,13 @@ jobs:
         if: failure()
         shell: pwsh
         run: |
+          Get-ChildItem -LiteralPath "$env:RUNNER_TEMP\powercontext-native-tests" -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -in @('server.stdout.log', 'server.stderr.log') } |
+            ForEach-Object {
+              Write-Output "::group::$($_.FullName)"
+              Get-Content -LiteralPath $_.FullName -Tail 100
+              Write-Output "::endgroup::"
+            }
           schtasks.exe /Query /TN "$env:POWERCONTEXT_NATIVE_SERVICE_IDENTIFIER" /XML /HRESULT
           if ($LASTEXITCODE -ne 0) { exit 0 }
           schtasks.exe /Query /TN "$env:POWERCONTEXT_NATIVE_SERVICE_IDENTIFIER" /FO LIST /V /HRESULT

--- a/src/powercontext/server/cursor_secret.py
+++ b/src/powercontext/server/cursor_secret.py
@@ -53,7 +53,9 @@ def _load_or_create(path: Path) -> bytes:
 
     generated = secrets.token_bytes(_CURSOR_SECRET_BYTES)
     try:
-        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        # Windows text descriptors translate LF bytes even when using os.write.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+        descriptor = os.open(path, flags, 0o600)
     except FileExistsError:
         return _read(path)
     try:

--- a/tests/test_cursor_secret.py
+++ b/tests/test_cursor_secret.py
@@ -14,8 +14,10 @@
 
 from __future__ import annotations
 
+import os
 import stat
 
+import pytest
 from pydantic import SecretStr
 
 from powercontext.builtin.persistence.oceanbase import OceanBaseConfig
@@ -23,7 +25,16 @@ from powercontext.builtin.persistence.sqlite import SQLiteConfig
 from powercontext.server.cursor_secret import resolve_cursor_secret
 
 
-def test_file_backed_sqlite_reuses_private_cursor_secret(tmp_path) -> None:
+@pytest.fixture
+def generated_secret(monkeypatch) -> bytes:
+    # Include LF and other control bytes so Windows text translation cannot hide
+    # behind a randomly generated key that happens not to contain a newline.
+    secret = bytes(range(32))
+    monkeypatch.setattr("powercontext.server.cursor_secret.secrets.token_bytes", lambda size: secret[:size])
+    return secret
+
+
+def test_file_backed_sqlite_reuses_private_cursor_secret(tmp_path, generated_secret) -> None:
     database_path = tmp_path / "powercontext.db"
     config = SQLiteConfig(url=f"sqlite+aiosqlite:///{database_path}")
 
@@ -31,9 +42,10 @@ def test_file_backed_sqlite_reuses_private_cursor_secret(tmp_path) -> None:
     second = resolve_cursor_secret(config, None)
 
     key_path = tmp_path / ".powercontext.db.cursor-key"
-    assert first == second
-    assert first is not None and len(first) == 32
-    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+    assert first == second == generated_secret
+    assert key_path.read_bytes() == generated_secret
+    if os.name != "nt":
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
 
 
 def test_explicit_cursor_secret_overrides_database_storage(tmp_path) -> None:
@@ -46,13 +58,17 @@ def test_explicit_cursor_secret_overrides_database_storage(tmp_path) -> None:
     assert not (tmp_path / ".powercontext.db.cursor-key").exists()
 
 
-def test_remote_database_without_override_reuses_local_persisted_secret(tmp_path, monkeypatch) -> None:
+def test_remote_database_without_override_reuses_local_persisted_secret(
+    tmp_path, monkeypatch, generated_secret
+) -> None:
     monkeypatch.setenv("POWERCONTEXT_HOME", str(tmp_path))
     config = OceanBaseConfig(url=SecretStr("mysql+aoceanbase://user:password@127.0.0.1:2881/test?charset=utf8mb4"))
 
     first = resolve_cursor_secret(config, None)
     second = resolve_cursor_secret(config, None)
 
-    assert first == second
-    assert first is not None and len(first) == 32
-    assert stat.S_IMODE((tmp_path / "cursor-signing.key").stat().st_mode) == 0o600
+    key_path = tmp_path / "cursor-signing.key"
+    assert first == second == generated_secret
+    assert key_path.read_bytes() == generated_secret
+    if os.name != "nt":
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -180,7 +180,8 @@ def test_server_settings_configure_default_project_skill_targets(tmp_path, monke
     assert all(target.allow_managed_publish for target in settings.external_skills.targets)
 
 
-def test_server_reuses_file_backed_cursor_secret_across_restarts(tmp_path) -> None:
+def test_server_reuses_file_backed_cursor_secret_across_restarts(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("powercontext.server.cursor_secret.secrets.token_bytes", lambda size: b"\n" * size)
     database = SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}")
     settings = ServerSettings(
         database=database,


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1463.

Found while investigating the Windows native-service check on #1459. This fix is based directly on `master` and is independent of the DSH changes.

# Rationale for this change

On Windows, `os.open` defaults to text mode. Writing a random 32-byte cursor key containing LF expands it to CRLF on disk. The first Server process uses the original key and starts successfully; the next process reads the expanded file and fails startup because its length is no longer 32 bytes. Retrying CI can avoid the random LF byte and conceal the defect.

# What changes are included in this PR?

- Open new cursor-key files with `O_BINARY` where supported, preserving exclusive creation and existing POSIX file permissions.
- Make both SQLite and other-database local key persistence tests deterministic with control bytes, and verify the exact persisted bytes. Keep POSIX mode assertions on POSIX systems.
- Exercise actual HTTP pagination across Server lifespans using a key containing LF, proving that previously issued cursors remain usable.
- Run these regressions against the installed wheel in Windows CI, alongside the existing real Task Scheduler lifecycle tests. Print captured Server logs in the failure output before querying a task that test cleanup may already have removed.

# Are there any user-facing changes?

Newly generated cursor keys retain their original bytes on Windows, allowing subsequent Server starts. Existing valid keys and cursor formats are unchanged. This does not automatically replace malformed key files or rotate signing keys.

# How was this change tested?

- Before the fix, the deterministic persistence/restart checks produced **3 failed, 1 passed** on Windows with the same length-validation error found in the CI artifact.
- `python -m pytest -q tests/test_cursor_secret.py tests/test_server.py`: **51 passed** on Windows/Python 3.12.13.
- Built a wheel and installed `powercontext[cli,server]` plus pytest into a fresh `.native-venv`; the exact new Windows CI regression command passed **4 tests**, including HTTP cursor reuse after restart.
- `uv lock --check`, `uv run --no-sync prek run -a`, `uv run --no-sync ty check`, and `git diff --check`: passed.
- A local attempt at the real native suite was denied at `schtasks /Create` by this host. The existing GitHub-hosted Windows lifecycle job remains required to validate install/stop/start/uninstall; its checks are not skipped or relaxed.
- Upstream CI at `2fb02a2e`: **17/17 checks passed**, including Python 3.11–3.14, SQLite/OceanBase acceptance, and native Linux/macOS/Windows services. The [Windows job](https://github.com/oceanbase/powercontext/actions/runs/33898013675/job/101105173539) passed all four deterministic cursor checks and all four applicable real lifecycle tests; its one skip is the macOS-only scenario.

# AI usage statement

Implemented with OpenAI Codex. The failure was traced to the uploaded CI service logs, reproduced deterministically on Windows before changing production code, and checked against both source and the built distribution. No credentials or private model configuration are included.
