### PR TITLE
fix(persistence): stop leaking sqlite-vec rows on Memory commits

### DIFF
--- a/src/powercontext/builtin/persistence/memory.py
+++ b/src/powercontext/builtin/persistence/memory.py
@@ -469,6 +469,10 @@ class RelationalMemoryBackend:
                 insert(MEMORY_ENTRY_VERSIONS_TABLE),
                 [_entry_values(self._scope_id, entry) for entry in value.entry_versions],
             )
+        # Clear the index before the heads go, as rebuild_projections does: index
+        # metadata may cascade from the heads, and an index can only find its
+        # rows through that metadata.
+        await self._index.replace(connection, self._scope_id, value.memory.as_ref(), ())
         await connection.execute(
             delete(MEMORY_ENTRY_HEADS_TABLE).where(
                 MEMORY_ENTRY_HEADS_TABLE.c.scope_id == self._scope_id,

--- a/src/powercontext/builtin/persistence/sqlite/memory_index.py
+++ b/src/powercontext/builtin/persistence/sqlite/memory_index.py
@@ -152,6 +152,9 @@ _INSERT_FTS_SQL = text(
     """
 )
 _DELETE_VECTOR_SQL = text("DELETE FROM pc_memory_entry_vec WHERE rowid = :vector_id")
+_DELETE_ORPHAN_VECTORS_SQL = (
+    "DELETE FROM pc_memory_entry_vec WHERE rowid NOT IN (SELECT vector_id FROM pc_memory_vector_entries)"
+)
 _INSERT_VECTOR_SQL = text("INSERT INTO pc_memory_entry_vec (rowid, embedding) VALUES (:vector_id, :embedding)")
 _SELECT_VECTOR_SQL = text("SELECT embedding FROM pc_memory_entry_vec WHERE rowid = :vector_id")
 _VECTOR_SEARCH_SQL = text(
@@ -347,6 +350,9 @@ class SQLiteMemoryVectorIndex:
             raise CapabilityNotSupportedError("vector", detail) from error
         if row is None or int(row[0]) != -1:
             raise CapabilityNotSupportedError("vector", "sqlite-vec probe returned an invalid row")
+        # Embeddings are only reachable through their metadata rows. Drop any that
+        # lost theirs, so stale neighbors cannot take the place of live entries.
+        await connection.exec_driver_sql(_DELETE_ORPHAN_VECTORS_SQL)
 
     async def replace(
         self,

--- a/tests/builtin/persistence/test_sqlite_memory_vector_index.py
+++ b/tests/builtin/persistence/test_sqlite_memory_vector_index.py
@@ -62,6 +62,28 @@ def test_vector_index_probe_clears_a_leftover_probe_row(tmp_path) -> None:
     asyncio.run(scenario())
 
 
+def test_vector_index_initialize_drops_embeddings_without_metadata(tmp_path) -> None:
+    async def scenario() -> None:
+        async with (
+            SQLiteProfile.open(
+                SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'memory.db'}"),
+                tables=SQLITE_MEMORY_VECTOR_TABLES,
+                load_vector_extension=True,
+            ) as profile,
+            profile.database.transaction() as connection,
+        ):
+            await connection.exec_driver_sql("CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0(embedding float[3])")
+            await connection.execute(
+                _INSERT_VECTOR_SQL,
+                {"vector_id": 7, "embedding": _pack_vector((0.0, 0.0, 1.0))},
+            )
+            await SQLiteMemoryVectorIndex(_profile(3)).initialize(connection)
+            remaining = (await connection.exec_driver_sql("SELECT count(*) FROM pc_memory_entry_vec")).scalar()
+            assert int(remaining) == 0
+
+    asyncio.run(scenario())
+
+
 def test_vector_index_probe_reports_a_table_dimension_mismatch(tmp_path) -> None:
     async def scenario() -> None:
         async with (

--- a/tests/e2e/test_sqlite_vec.py
+++ b/tests/e2e/test_sqlite_vec.py
@@ -43,6 +43,9 @@ class _KeywordEmbeddingModel:
                 return (1.0, 0.0, 0.0)
             if "gamma" in normalized:
                 return (0.0, 0.0, 1.0)
+            if "delta" in normalized:
+                # Close to gamma, but never an exact match.
+                return (0.0, 0.1, 1.0)
             return (0.0, 1.0, 0.0)
 
         vectors = tuple(vector(text) for text in texts)
@@ -80,5 +83,70 @@ def test_sqlite_vec_supports_vector_and_hybrid_search(tmp_path) -> None:
             assert vector.hits[0].text == "Alpha semantic record."
             assert hybrid.hits[0].matched_by == ("fts", "vector")
             assert gamma.hits[0].text == "Gamma semantic record."
+
+    asyncio.run(scenario())
+
+
+def test_sqlite_vec_keeps_one_embedding_per_live_entry_across_appends(tmp_path) -> None:
+    async def scenario() -> None:
+        config = SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'memory.db'}")
+        async with open_builtin_contexts(
+            BuiltinConfig(database=config),
+            embedding_model=_KeywordEmbeddingModel(),
+        ) as contexts:
+            memory_service = (await contexts.get("project")).artifacts.memory
+            memory = await memory_service.remember(
+                memory=None,
+                entries=(MemoryEntryInput(kind="fact", text="Gamma semantic record."),),
+                mode="append",
+            )
+            for step in range(4):
+                memory = await memory_service.remember(
+                    memory=memory,
+                    entries=(MemoryEntryInput(kind="fact", text=f"Alpha record {step}."),),
+                    mode="append",
+                )
+
+            async with contexts.database.transaction() as connection:
+                metadata = await connection.exec_driver_sql("SELECT count(*) FROM pc_memory_vector_entries")
+                vectors = await connection.exec_driver_sql("SELECT count(*) FROM pc_memory_entry_vec")
+                assert (metadata.scalar(), vectors.scalar()) == (5, 5)
+
+    asyncio.run(scenario())
+
+
+def test_sqlite_vec_search_is_unaffected_by_writes_in_other_scopes(tmp_path) -> None:
+    async def scenario() -> None:
+        config = SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'memory.db'}")
+        async with open_builtin_contexts(
+            BuiltinConfig(database=config),
+            embedding_model=_KeywordEmbeddingModel(),
+        ) as contexts:
+            quiet = (await contexts.get("quiet")).artifacts.memory
+            busy = (await contexts.get("busy")).artifacts.memory
+            target = await quiet.remember(
+                memory=None,
+                entries=(MemoryEntryInput(kind="fact", text="Delta semantic record."),),
+                mode="append",
+            )
+            assert target is not None
+            churned = await busy.remember(
+                memory=None,
+                entries=(
+                    MemoryEntryInput(kind="fact", text="Gamma one."),
+                    MemoryEntryInput(kind="fact", text="Gamma two."),
+                ),
+                mode="append",
+            )
+            for step in range(4):
+                churned = await busy.remember(
+                    memory=churned,
+                    entries=(MemoryEntryInput(kind="fact", text=f"Alpha record {step}."),),
+                    mode="append",
+                )
+
+            result = await quiet.search("gamma", memories=(target,), mode="vector")
+
+            assert [hit.text for hit in result.hits] == ["Delta semantic record."]
 
     asyncio.run(scenario())


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1469.

# Rationale for this change

`RelationalMemoryBackend._commit` deletes the active-head rows before asking the index to replace the projections. The sqlite-vec metadata table (`pc_memory_vector_entries`) cascades from those heads, and the vec0 rows in `pc_memory_entry_vec` are only reachable through that metadata, so every commit leaves the previous revision's embeddings behind as orphans. Growth is quadratic in the number of appends: one entry plus four appends leaves 10 orphans for 5 live entries.

The vector search passes the live metadata count as the KNN neighbor limit while the KNN scans the whole vec0 table, so orphans that were nearer to the query displaced live entries. In practice, appends in one scope made vector searches in another scope return nothing. `rebuild_projections` could not repair it because it also finds vec0 rows only through the metadata. The ordering issue predates the sqlite-vec migration in #1306; the Vec1 search used the same `k = total` limit.

# What changes are included in this PR?

- `RelationalMemoryBackend._commit` clears the index for the memory before deleting the heads, the same order `rebuild_projections` already uses, so the metadata is still present when the vec0 rows are removed.
- `SQLiteMemoryVectorIndex.initialize` deletes vec0 rows that have no metadata row, so databases written by earlier versions recover on the next start instead of carrying the orphans forever.
- Regression tests: `tests/e2e/test_sqlite_vec.py` checks one embedding per live entry across appends and that a vector search is unaffected by writes in other scopes; `tests/builtin/persistence/test_sqlite_memory_vector_index.py` checks that `initialize` drops embeddings without metadata.

No API, schema, persisted-format, or documentation changes. The OceanBase and seekdb backends are unaffected: their vector table has no foreign key to the heads and `replace` deletes by scope and artifact.

# Are there any user-facing changes?

Behavioral fix only. Vector and hybrid Memory search on the SQLite backend no longer lose hits after unrelated writes, and the SQLite file stops growing with stale embeddings. The first start after upgrading runs one pass over `pc_memory_entry_vec` to drop existing orphans, which may take a moment on long-lived databases. No breaking changes.

# How was this change tested?

- Reproduced on `master` (`fc75f92`) with the script in the issue: 7 live entries left 21 vec0 rows (14 orphans) and a cross-scope vector search went from `['Delta record.']` to `[]`. With `foreign_keys=False` the leak does not occur, confirming the cascade as the cause. With the fix: 7 / 7 / 0 and the search still returns the entry.
- The three new tests fail on `master` and pass with the fix.
- `uv run python -m pytest --doctest-modules`: full suite green (1324 passed, 21 skipped).
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`: clean.

# AI usage statement

AI-assisted; the change and tests were reviewed and validated by the author.