### PR TITLE
fix(service): kickstart newly bootstrapped LaunchAgents

### DIFF
--- a/src/powercontext/service/adapters/launchd.py
+++ b/src/powercontext/service/adapters/launchd.py
@@ -205,6 +205,10 @@ class LaunchdUserAdapter:
             is_loaded = False
         if not is_loaded:
             self._run("bootstrap", self._domain, str(self.artifact_path))
+            # bootstrap registers the job, while kickstart is the launchd
+            # operation that guarantees an immediate start regardless of the
+            # configured launch conditions.
+            self._run("kickstart", self._target)
         elif self.manager_state() is not ManagerState.ACTIVE:
             self._run("kickstart", "-k", self._target)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1086,6 +1086,27 @@ def test_launchd_stop_waits_until_bootout_removes_the_loaded_job(
     run.assert_called_once_with("bootout", "gui/501/com.oceanbase.powercontext")
 
 
+def test_launchd_start_kickstarts_a_newly_bootstrapped_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = LaunchdUserAdapter(home=tmp_path, uid=501)
+    monkeypatch.setattr(
+        adapter,
+        "loaded_registration",
+        lambda: ManagerRegistration(ManagerOwnershipState.NOT_LOADED),
+    )
+    run = Mock()
+    monkeypatch.setattr(adapter, "_run", run)
+
+    adapter.start(reload_definition=False)
+
+    assert run.call_args_list == [
+        (("bootstrap", "gui/501", str(adapter.artifact_path)), {}),
+        (("kickstart", "gui/501/com.oceanbase.powercontext"), {}),
+    ]
+
+
 @pytest.mark.parametrize("corruption", ["fragment", "path", "arguments", "marker", "metadata"])
 def test_systemd_loaded_registration_requires_matching_fragment_command_and_metadata(
     tmp_path: Path,


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1479.

# Rationale for this change

The macOS service adapter currently relies on `launchctl bootstrap` to both register and immediately start a LaunchAgent. Registration can succeed without a process becoming active, so installs and explicit restarts intermittently wait for the HTTP endpoint until they time out. This has reproduced in several native macOS workflow runs, including #1459.

# What changes are included in this PR?

- Explicitly call `launchctl kickstart` after bootstrapping a new or replaced LaunchAgent.
- Preserve the existing `kickstart -k` behavior for a loaded but inactive job.
- Add a regression test that verifies a newly bootstrapped job is immediately kickstarted.

The plist's `RunAtLoad` and `KeepAlive` settings remain responsible for login startup and recovery. This change makes an explicit install/start request deterministic and surfaces a launchd start error immediately.

# Are there any user-facing changes?

On macOS, `powercontext service install` and explicit service restart now reliably start the personal Server immediately after registration. There are no public API, configuration, or persisted-format changes.

# How was this change tested?

- `uv run pytest -q tests/test_service.py -k launchd` — 23 passed, 1 skipped
- `uv run pytest -q tests/test_service.py tests/test_service_bootstrap.py -k 'not unsafe_retry_state'` — 96 passed, 5 skipped
- `uv run prek run -a`
- `git diff --check`

The repository's native-service workflow will exercise the complete install, stop, restart, and uninstall lifecycle on a real macOS LaunchAgent.

# AI usage statement

OpenAI Codex was used to inspect the failing CI artifacts and historical runs, identify the launchd lifecycle race, implement the change, and run the listed validation. The resulting diff and test evidence were reviewed before submission.
