### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You decide what will matter later and what needs to move with the task. PowerCon
 Install the latest released [PowerContext](https://pypi.org/project/powercontext/):
 
 ```bash
-uv tool install "powercontext[cli,server]==0.1.0"
+uv tool install "powercontext[cli,server]==0.2.0"
 ```
 
 Start a local Server in its own terminal:
@@ -36,15 +36,12 @@ Start a local Server in its own terminal:
 powercontext server run
 ```
 
-The `powercontext service` command is not available in the `0.1.0` release. Keep `powercontext server run` running
-while you use PowerContext, or install the unreleased `master` version below to use the native personal service.
-
 The Server stores context in a local SQLite database by default.
 
 Then set up an agent integration from the matching release. For example:
 
 ```bash
-powercontext setup codex --ref powercontext-v0.1.0
+powercontext setup codex --ref powercontext-v0.2.0
 ```
 
 Keep the PowerContext tool and agent integration on the same Git ref. To try the latest unreleased `master`, install
@@ -55,8 +52,8 @@ uv tool install --force "powercontext[cli,server] @ git+https://github.com/ocean
 powercontext setup codex --source oceanbase/powercontext --ref master
 ```
 
-The current `master` also provides an optional persistent personal Server that survives terminal closure and can
-start again after login:
+For a persistent personal Server that survives terminal closure and can start again after login, stop the foreground
+Server and install the optional native service:
 
 ```bash
 powercontext service install # Uninstall with `powercontext service uninstall`

--- a/README_CN.md
+++ b/README_CN.md
@@ -27,7 +27,7 @@ PowerContext 让上下文跟随工作，跨越不同的对话。你回来时，�
 安装最新发布的 [PowerContext](https://pypi.org/project/powercontext/)：
 
 ```bash
-uv tool install "powercontext[cli,server]==0.1.0"
+uv tool install "powercontext[cli,server]==0.2.0"
 ```
 
 在单独的终端中启动本地 Server：
@@ -36,15 +36,12 @@ uv tool install "powercontext[cli,server]==0.1.0"
 powercontext server run
 ```
 
-`0.1.0` 发布版不包含 `powercontext service` 命令。使用 PowerContext 时，请保持 `powercontext server run`
-进程运行；如需使用原生个人服务，请改用下文尚未发布的 `master` 版本。
-
 Server 默认将上下文保存到本地 SQLite 数据库。
 
 然后从同一个发布版本配置 Agent 集成。例如：
 
 ```bash
-powercontext setup codex --ref powercontext-v0.1.0
+powercontext setup codex --ref powercontext-v0.2.0
 ```
 
 PowerContext 工具与 Agent 集成应始终使用同一个 Git ref。如需试用最新但尚未发布的 `master`，请同时从
@@ -55,7 +52,7 @@ uv tool install --force "powercontext[cli,server] @ git+https://github.com/ocean
 powercontext setup codex --source oceanbase/powercontext --ref master
 ```
 
-当前 `master` 还提供可选的持久个人 Server，它可以在终端关闭后继续运行，并在下次登录后再次启动：
+如需让个人 Server 在终端关闭后继续运行，并在下次登录后再次启动，请先停止前台 Server，再安装可选的原生服务：
 
 ```bash
 powercontext service install # 卸载请运行 `powercontext service uninstall`

--- a/README_JP.md
+++ b/README_JP.md
@@ -27,7 +27,7 @@ PowerContext は、会話をまたいでもコンテキストを作業ととも�
 最新リリースの [PowerContext](https://pypi.org/project/powercontext/) をインストールします：
 
 ```bash
-uv tool install "powercontext[cli,server]==0.1.0"
+uv tool install "powercontext[cli,server]==0.2.0"
 ```
 
 別のターミナルでローカル Server を起動します：
@@ -36,16 +36,12 @@ uv tool install "powercontext[cli,server]==0.1.0"
 powercontext server run
 ```
 
-`0.1.0` リリースには `powercontext service` コマンドは含まれていません。PowerContext の使用中は
-`powercontext server run` を実行したままにするか、ネイティブの個人用サービスを使用するために、以下の未リリース版
-`master` をインストールしてください。
-
 Server はデフォルトで、コンテキストをローカルの SQLite データベースに保存します。
 
 次に同じリリースから Agent との連携を設定します。例：
 
 ```bash
-powercontext setup codex --ref powercontext-v0.1.0
+powercontext setup codex --ref powercontext-v0.2.0
 ```
 
 PowerContext ツールと Agent 連携には、常に同じ Git ref を使用してください。最新の未リリース版 `master` を試す場合は、
@@ -56,7 +52,8 @@ uv tool install --force "powercontext[cli,server] @ git+https://github.com/ocean
 powercontext setup codex --source oceanbase/powercontext --ref master
 ```
 
-現在の `master` では、ターミナルを閉じても動作を続け、次回ログイン時に再び起動できる個人用 Server も利用できます：
+ターミナルを閉じても動作を続け、次回ログイン時に再び起動できる個人用 Server が必要な場合は、
+フォアグラウンドの Server を停止してから、オプションのネイティブサービスをインストールします：
 
 ```bash
 powercontext service install # アンインストールは `powercontext service uninstall`

--- a/openapi/powercontext.yaml
+++ b/openapi/powercontext.yaml
@@ -16,7 +16,7 @@ openapi: 3.0.3
 info:
   title: PowerContext API
   description: Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.
-  version: 0.1.0
+  version: 0.2.0
 security:
   - BearerAuth: []
   - {}

--- a/src/powercontext/http/_generated/operations.py
+++ b/src/powercontext/http/_generated/operations.py
@@ -147,7 +147,7 @@ from powercontext.http._generated.models import (
 OPENAPI_VERSION = "3.0.3"
 API_TITLE = "PowerContext API"
 API_DESCRIPTION = "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities."
-API_VERSION = "0.1.0"
+API_VERSION = "0.2.0"
 
 RequestT = TypeVar("RequestT")
 ResponseT = TypeVar("ResponseT")

--- a/src/powercontext/http/_generated/schema.py
+++ b/src/powercontext/http/_generated/schema.py
@@ -7,7 +7,7 @@ OPENAPI_SCHEMA: dict[str, JsonValue] = {
     "info": {
         "title": "PowerContext API",
         "description": "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.",
-        "version": "0.1.0",
+        "version": "0.2.0",
     },
     "paths": {
         "/health/live": {

--- a/website/src/lib/releases.ts
+++ b/website/src/lib/releases.ts
@@ -28,6 +28,44 @@ export interface Release {
 
 export const releases: Release[] = [
   {
+    version: 'v0.2.0',
+    date: '2026-09-07',
+    title: {
+      en: 'Organize context, control access, and distribute Skills',
+      zh: '组织上下文、控制访问、分发 Skill',
+    },
+    summary: {
+      en: 'PowerContext adds Server-owned Scopes, resource-level access control, and a complete Skill package workflow, with native personal services on macOS, Linux, and Windows.',
+      zh: 'PowerContext 新增由 Server 管理的 Scope、资源级访问控制和完整的 Skill 包工作流，并支持 macOS、Linux 和 Windows 原生个人服务。',
+    },
+    changes: {
+      en: [
+        'Organize Scopes with parent relationships and explicit context references, reuse Agent bindings, and inspect exact, subtree, or all-Scope views in the Dashboard and Handoff Reports.',
+        'Apply one access-control boundary across HTTP, MCP, and Dashboard data, with resource roles, revocable Bindings, audit records, and Casbin or AuthZEN adapters.',
+        'Review and version complete Skill packages, including scripts and resources; publish to local Codex or Claude Code targets or deliver exact Revisions through a remote Receiver.',
+        'Keep a personal Server running through the native service manager on macOS, Linux, or Windows using powercontext service install/status/uninstall.',
+        'Create and read Sources, manage Artifact Revisions through scoped REST endpoints, and explore the interactive Scalar API reference.',
+        'Configure separate generation, embedding, and reranking endpoints and model settings; inspect process metrics and host-visible integration diagnostics.',
+        'Use the redesigned bilingual documentation site, Agent and API tutorials, and benchmark result pages.',
+        'Fix sqlite-vec row accumulation on Memory commits, binary cursor-key persistence on Windows, environment-file parsing, and DSH Scope error handling.',
+        'Upgrade Server, clients, and integrations together. Unregistered legacy scope_id values now return scope_not_found; older OceanBase identity columns require utf8mb4_bin collation. Review data migration before upgrading an existing database.',
+      ],
+      zh: [
+        '通过父子关系和显式上下文引用组织 Scope，复用 Agent 绑定，并在 Dashboard 和 Handoff Report 中查看单个 Scope、子树或全部 Scope。',
+        '为 HTTP、MCP 和 Dashboard 数据统一执行访问控制，支持资源角色、可撤销的 Binding、审计记录，以及 Casbin 或 AuthZEN 适配器。',
+        '审核和管理包含脚本及资源文件的完整 Skill 包，将指定 Revision 发布到本机 Codex、Claude Code，或通过远程 Receiver 分发。',
+        '通过 powercontext service install/status/uninstall，使用 macOS、Linux 或 Windows 原生服务管理器运行个人 Server。',
+        '通过按 Scope 划分的 REST 接口创建和读取 Source、管理 Artifact Revision，并使用 Scalar 交互式 API 参考。',
+        '为生成、Embedding 和重排分别配置端点与模型参数，查看进程指标，并在 Agent Host 中获得集成诊断。',
+        '使用重新设计的中英文文档网站、Agent 和 API 教程，以及 Benchmark 结果页面。',
+        '修复 Memory 提交时 sqlite-vec 行累积、Windows 二进制游标密钥持久化、环境文件解析和 DSH Scope 错误处理问题。',
+        'Server、客户端和集成需一起升级。未注册的旧 scope_id 现在返回 scope_not_found；旧 OceanBase 身份列需使用 utf8mb4_bin 排序规则。升级已有数据库前，请先确认数据迁移方案。',
+      ],
+    },
+    installCommand: 'uv tool install --force "powercontext[cli,server]==0.2.0"',
+    githubUrl: 'https://github.com/oceanbase/powercontext/releases/tag/powercontext-v0.2.0',
+  },
+  {
     version: 'v0.1.0',
     date: '2026-08-31',
     title: {


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Release preparation for v0.2.0, following [PowerContext v0.1.0](https://github.com/oceanbase/powercontext/releases/tag/powercontext-v0.1.0). No separate tracking issue.

# Rationale for this change

Prepare the public API metadata, installation instructions, and bilingual changelog for PowerContext v0.2.0. The release uses `powercontext-v0.2.0`, which resolves to Python package version `0.2.0` through the existing Hatch VCS configuration.

# What changes are included in this PR?

- Set the canonical OpenAPI version to `0.2.0` and regenerate the checked-in Python API metadata.
- Update English, Chinese, and Japanese README installation commands and integration refs to the matching release, and describe the native personal service as available in the release.
- Add English and Chinese website release entries covering Scope organization, access control, Skill packages and distribution, personal services, APIs, inference configuration, diagnostics, and fixes.

# Are there any user-facing changes?

Installation examples now select v0.2.0. The release notes call out coordinated Server/client/integration upgrades, the requirement for registered Scope IDs, and migration considerations for older OceanBase identity-column collations. This PR updates release metadata and documentation; it introduces no new API paths or persistence changes.

# How was this change tested?

- `make api-generate`
- `make contract-test` — 43 passed.
- `make check` — integration manifest checks, lock consistency, hooks, and type checks passed.
- `make docs-test` — passed with Node.js 24.14.1; both v0.2.0 language pages exported, along with 87 HTTP API pages and 384 Python API pages.
- `uv run prek run -a` before committing.
- In a disposable clone, tagged the release preparation as `powercontext-v0.2.0`, verified Hatch version `0.2.0`, built wheel and source distributions, checked embedded API version metadata, and passed `twine check` for both packages.
- `git diff --check`

# AI usage statement

Prepared with assistance from OpenAI Codex (GPT-6) for version updates, bilingual release copy, and validation.
