### PR TITLE
feat(service): enhance error message for shell environment variable handling

### DIFF
--- a/src/powercontext/service/controller.py
+++ b/src/powercontext/service/controller.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 import time
 from collections.abc import Callable, Generator
@@ -249,9 +250,8 @@ class ServiceController:
                 if name == "POWERCONTEXT_HOME" or name.startswith(_PERSISTED_ENVIRONMENT_PREFIX)
             )
             if inherited:
-                raise ServiceError(  # noqa: TRY003
-                    "personal services do not copy shell environment variables; write the Server configuration "
-                    "to a protected file and pass --env-file",
+                raise ServiceError(
+                    _environment_file_guidance(inherited),
                     exit_code=2,
                 )
         clean_home_context = (
@@ -421,6 +421,25 @@ def _windows_service_lock(path: Path, *, timeout: float) -> Generator[None, None
             os.lseek(descriptor, 0, os.SEEK_SET)
             locking(descriptor, lock_unlock, 1)
         os.close(descriptor)
+
+
+def _environment_file_guidance(names: list[str]) -> str:
+    # Only display values known not to carry credentials; other settings may
+    # include tokens or database URLs with embedded passwords.
+    visible = {"POWERCONTEXT_HOME", "POWERCONTEXT_SERVER_HTTP_HOST", "POWERCONTEXT_SERVER_HTTP_PORT"}
+    assignments = "\n".join(
+        f"  {name}={shlex.quote(os.environ[name]) if name in visible else '<your-current-value>'}" for name in names
+    )
+    hidden_hint = (
+        "Fill in <your-current-value> with your actual value.\n" if any(n not in visible for n in names) else ""
+    )
+    return (
+        "personal services do not copy shell environment variables. Currently set:\n"
+        f"{assignments}\n"
+        "Save these settings in powercontext.env (UTF-8, owned by you with access restricted to you).\n"
+        f"{hidden_hint}"
+        'Then run: powercontext service install --env-file "<path-to-powercontext.env>"'
+    )
 
 
 def _endpoint(host: str, port: int) -> str:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -575,12 +575,22 @@ def test_service_install_requires_persistent_config_for_shell_server_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("POWERCONTEXT_SERVER_HTTP_PORT", "8123")
+    monkeypatch.setenv("POWERCONTEXT_HOME", "private-data-directory")
+    monkeypatch.setenv("POWERCONTEXT_SERVER_API_KEY", "secret-test-token")
     adapter = FakeAdapter(tmp_path)
 
     with pytest.raises(ServiceError, match="do not copy shell environment variables") as raised:
         ServiceController(adapter).install()
 
     assert raised.value.exit_code == 2
+    message = str(raised.value)
+    assert "POWERCONTEXT_SERVER_HTTP_PORT" in message
+    assert "POWERCONTEXT_HOME" in message
+    assert "POWERCONTEXT_SERVER_HTTP_PORT=8123" in message
+    assert "POWERCONTEXT_HOME=private-data-directory" in message
+    assert "POWERCONTEXT_SERVER_API_KEY=<your-current-value>" in message
+    assert "secret-test-token" not in message
+    assert "powercontext service install --env-file" in message
     assert adapter.events == []
 
 


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Related to #1298.

# Rationale for this change

`powercontext service install` rejects shell-based Server configuration without clearly identifying the settings or explaining how to proceed.

# What changes are included in this PR?

- List the detected environment variables and display values for the data directory, HTTP host, and port.
- Hide potentially sensitive values.
- Explain how to save configuration and install with `--env-file`.
- Extend regression coverage for actionable guidance and sensitive-value redaction.

# Are there any user-facing changes?

Service installation errors now include configuration details and a recovery command on all platforms. No changes to installation behavior, public APIs, or persisted formats.

<img width="1043" height="119" alt="image" src="https://github.com/user-attachments/assets/619f5915-b003-451e-ab0e-9ac21c24b888" />


# How was this change tested?

- `uv run pytest -q tests/test_service.py -k requires_persistent_config`
- `make check`
- Manually triggered the error in PowerShell with `POWERCONTEXT_HOME` set.

# AI usage statement

OpenAI Codex assisted with implementation, tests, and PR description.