### PR TITLE
fix(website): resolve relative documentation links

### DIFF
--- a/website/scripts/verify-static-export.ts
+++ b/website/scripts/verify-static-export.ts
@@ -25,6 +25,7 @@ const prerenderManifestPath = path.join(websiteDirectory, '.next', 'prerender-ma
 const pythonDirectory = path.join(websiteDirectory, '.generated', 'python');
 const locales = ['en', 'zh'] as const;
 const httpMethods = ['get', 'put', 'post', 'delete', 'patch', 'head', 'options', 'trace'] as const;
+const documentationLinkCheckRoutes = locales.map((locale) => `/${locale}/docs/tutorials/codex-quickstart`);
 
 type PythonModule = {
   path?: string;
@@ -35,6 +36,32 @@ type PythonModule = {
 function outputPage(route: string) {
   const segments = route.split('/').filter(Boolean);
   return path.join(outputDirectory, ...segments, 'index.html');
+}
+
+function extractAnchorHrefs(html: string) {
+  return Array.from(html.matchAll(/<a\b[^>]*\bhref=(['"])(.*?)\1/gi), (match) => match[2]);
+}
+
+async function findBrokenDocumentationLinks(route: string) {
+  const html = await readFile(outputPage(route), 'utf8');
+  const broken: string[] = [];
+
+  for (const href of extractAnchorHrefs(html)) {
+    if (/^(?:[a-z][a-z\d+.-]*:|#)/i.test(href)) continue;
+    if (/\.mdx?(?:[?#]|$)/i.test(href)) {
+      broken.push(`${href} (unresolved Markdown path)`);
+      continue;
+    }
+
+    const target = new URL(href, `https://powercontext.invalid${route}/`);
+    try {
+      await access(outputPage(decodeURIComponent(target.pathname)));
+    } catch {
+      broken.push(`${href} (missing ${target.pathname})`);
+    }
+  }
+
+  return broken;
 }
 
 function collectPythonPaths(module: PythonModule, paths: Set<string>) {
@@ -86,6 +113,7 @@ const prerenderedRoutes = new Set(Object.keys(prerenderManifest.routes));
 const expectedRoutes = [...httpRoutes, ...pythonRoutes];
 const missingFromManifest = expectedRoutes.filter((route) => !prerenderedRoutes.has(route));
 const missingFromOutput: string[] = [];
+const brokenDocumentationLinks = new Map<string, string[]>();
 
 await Promise.all(
   expectedRoutes.map(async (route) => {
@@ -97,7 +125,14 @@ await Promise.all(
   }),
 );
 
-if (missingFromManifest.length > 0 || missingFromOutput.length > 0) {
+await Promise.all(
+  documentationLinkCheckRoutes.map(async (route) => {
+    const broken = await findBrokenDocumentationLinks(route);
+    if (broken.length > 0) brokenDocumentationLinks.set(route, broken);
+  }),
+);
+
+if (missingFromManifest.length > 0 || missingFromOutput.length > 0 || brokenDocumentationLinks.size > 0) {
   const details = [
     missingFromManifest.length > 0
       ? `Missing from Next prerender manifest:\n${missingFromManifest.sort().join('\n')}`
@@ -105,11 +140,17 @@ if (missingFromManifest.length > 0 || missingFromOutput.length > 0) {
     missingFromOutput.length > 0
       ? `Missing from static output:\n${missingFromOutput.sort().join('\n')}`
       : undefined,
+    brokenDocumentationLinks.size > 0
+      ? `Broken Codex tutorial links:\n${Array.from(brokenDocumentationLinks, ([route, links]) =>
+          `${route}:\n${links.map((link) => `  ${link}`).join('\n')}`,
+        ).join('\n')}`
+      : undefined,
   ].filter(Boolean);
 
-  throw new Error(`Static API export is incomplete.\n\n${details.join('\n\n')}`);
+  throw new Error(`Static export verification failed.\n\n${details.join('\n\n')}`);
 }
 
 console.log(
-  `Verified ${httpRoutes.size} HTTP API pages and ${pythonRoutes.size} Python API pages in the static export.`,
+  `Verified ${httpRoutes.size} HTTP API pages, ${pythonRoutes.size} Python API pages, and ` +
+    `${documentationLinkCheckRoutes.length} Codex tutorial pages in the static export.`,
 );

--- a/website/src/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/website/src/app/[lang]/docs/[[...slug]]/page.tsx
@@ -18,6 +18,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page';
+import type { AnchorHTMLAttributes } from 'react';
 import { getMDXComponents } from '@/components/mdx';
 import { isLanguage, languages } from '@/lib/i18n';
 import { source } from '@/lib/source';
@@ -30,6 +31,22 @@ function getDocumentationPage(lang: string, slug: string[] = []) {
   return source.getPage(['docs', ...slug], lang);
 }
 
+function createDocumentationLink(page: NonNullable<ReturnType<typeof getDocumentationPage>>) {
+  // Fumadocs removes the locale from its lookup keys but keeps it in page.path.
+  const localePrefix = page.locale ? `${page.locale}/` : '';
+  const sourcePage = {
+    ...page,
+    path: page.path.startsWith(localePrefix) ? page.path.slice(localePrefix.length) : page.path,
+  };
+  const RelativeLink = createRelativeLink(source, sourcePage);
+
+  return function DocumentationLink({ href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) {
+    // Fumadocs resolves explicit relative paths only; Markdown also permits a bare sibling filename.
+    const sourceHref = href && /^[^./#][^:]*\.(?:md|mdx)(?:[?#].*)?$/.test(href) ? `./${href}` : href;
+    return <RelativeLink href={sourceHref} {...props} />;
+  };
+}
+
 export default async function DocumentationPage({ params }: PageProps) {
   const { lang, slug } = await params;
   if (!isLanguage(lang)) notFound();
@@ -38,6 +55,7 @@ export default async function DocumentationPage({ params }: PageProps) {
 
   const MDX = page.data.body;
   const isOverview = !slug?.length;
+  const DocumentationLink = createDocumentationLink(page);
   return (
     <DocsPage full={page.data.full} toc={page.data.toc}>
       {isOverview ? (
@@ -47,7 +65,7 @@ export default async function DocumentationPage({ params }: PageProps) {
         </>
       ) : null}
       <DocsBody>
-        <MDX components={getMDXComponents({ a: createRelativeLink(source, page) })} />
+        <MDX components={getMDXComponents({ a: DocumentationLink })} />
       </DocsBody>
     </DocsPage>
   );


### PR DESCRIPTION
# Which issue or RFC does this PR close?

<!--
Link the related issue or RFC using GitHub syntax.
For example, `Closes #123` indicates that this PR will close issue #123.
If this PR implements an RFC, link the RFC and any existing tracking issue.
-->

Closes #1484 .

# Rationale for this change

Relative Markdown links in the English and Chinese Codex quickstart pages were emitted unchanged in the generated HTML. Because the browser resolved paths such as `agent-quickstart.md` and `../how-to/troubleshoot.md` relative to the public page URL, they produced incorrect routes and returned 404 pages.

The issue was caused by a mismatch between the locale-prefixed page path and Fumadocs' locale-stripped lookup path. Fumadocs also only resolves explicitly relative paths, while Markdown permits bare sibling filenames.
<!--
Explain why this change is needed. If the linked issue or RFC already explains the rationale clearly, a short summary is enough.
-->

# What changes are included in this PR?
- Normalize documentation page paths before resolving relative links by removing the locale prefix used only in the source path.
- Normalize bare sibling Markdown links such as `agent-quickstart.md` to explicit relative paths before passing them to Fumadocs.
- Preserve the existing relative links in the Markdown sources so they continue to work when viewed directly on GitHub.
- Extend static export verification to check the English and Chinese Codex quickstart pages.
- Fail verification when either quickstart page contains an unresolved `.md` or `.mdx` link, or links to a missing internal static page.
<!--
Summarize the important changes. Focus on behavior, API, docs, tests, and migration impact.
-->

# Are there any user-facing changes?
Yes. Internal documentation links on the English and Chinese Codex quickstart pages now navigate to the correct localized pages instead of returning 404 errors.

There are no breaking changes.
<!--
If there are user-facing changes, documentation may need to be updated before approval.
If there are breaking changes to public APIs or persisted formats, call them out explicitly.
-->

# How was this change tested?
```bash
pnpm --dir website lint
pnpm --dir website types:check
pnpm --dir website build
```
<!--
List commands run, tests added or updated, and any manual validation performed.
-->

# AI usage statement
OpenAI Codex was used to investigate and fix.
<!--
If AI tools were used to build this PR, describe the tool and model where possible.
If not applicable, write `Not used`.
-->
