### PR TITLE
feat(dsh): diagnose effective Server configuration and matched setup

### DIFF
--- a/docs/en/docs/how-to/configure-dsh.md
+++ b/docs/en/docs/how-to/configure-dsh.md
@@ -5,23 +5,120 @@ description: Install the PowerContext DeepSeek Harness plugin and control its lo
 
 # Configure DeepSeek Harness
 
-## Install or refresh the plugin
+## Install matching Server and plugin versions
 
-Install DeepSeek Harness first and make sure the web profile exists. Then run:
+Install DeepSeek Harness and make sure its Web profile is available. The real-host acceptance suite pins DSH
+0.1.2-rc.1. Choose one PowerContext installation path and keep the Server and plugin together.
 
-```bash
-powercontext setup dsh --source oceanbase/powercontext --ref master
-```
-
-The command installs the plugin from `integrations/dsh/plugins/powercontext` and creates the user data directory. The directory must contain a built `lib/index.js`. It is safe to run again: a valid checkout is reused, and a broken checkout for the same ref is replaced. Pass the same `--ref` used to install the PowerContext tool. `--source` accepts a GitHub slug or a `https://github.com/...` URL.
-
-A local checkout works the same way:
+For released PowerContext 0.2.0:
 
 ```bash
-powercontext setup dsh --source .
+uv tool install --force "powercontext[cli,server]==0.2.0"
+powercontext setup dsh --source oceanbase/powercontext --ref powercontext-v0.2.0
 ```
 
-`setup dsh` calls `dsh plugin --profile web add`. Open a new `dsh web` session after setup.
+Release 0.2.0 includes the direct-operation Scope error boundary. The layered Doctor and automatic snapshot
+presentation described below require the current development checkout; do not expect them in that release.
+
+For development, install both components from one checkout and record its commit:
+
+```bash
+git clone --branch master https://github.com/oceanbase/powercontext.git powercontext-dsh-dev
+git -C powercontext-dsh-dev rev-parse HEAD
+uv tool install --force "./powercontext-dsh-dev[cli,server]"
+powercontext setup dsh --source ./powercontext-dsh-dev
+```
+
+To update, run `git -C powercontext-dsh-dev pull --ff-only`, record the new commit, and repeat both installation
+commands. A local source must contain the checked-in built `lib/index.js`.
+`setup dsh --source oceanbase/powercontext --ref master` reuses a valid cached checkout without fetching:
+repeating that command does not update a moving branch. A broken checkout is replaced.
+
+`setup dsh` calls `dsh plugin --profile web add`; it does not start the Server. Restart DSH after installation.
+
+## Start the Server and the host
+
+For automatic Source-to-Memory extraction, generate and validate a Server configuration:
+
+```bash
+powercontext config init --output powercontext.env
+powercontext config validate --env-file powercontext.env
+powercontext server run --env-file powercontext.env
+```
+
+The Server runs in the foreground; keep this terminal open. Enable generation and scheduled processing.
+Embedding enables vector/hybrid retrieval; it is not required for explicit Memory writes or full-text search.
+A model-free Server can be healthy while extraction is disabled and recall is empty.
+See [the complete Memory loop](full-capability-runtime.md) for provider and processing configuration.
+
+In another terminal, point DSH at that Server and launch the host:
+
+```bash
+export POWERCONTEXT_DSH_BASE_URL=http://127.0.0.1:8000
+dsh web
+```
+
+In PowerShell, use `$env:POWERCONTEXT_DSH_BASE_URL = "http://127.0.0.1:8000"` before `dsh web`.
+If the Server listens elsewhere, change the URL accordingly. Use `POWERCONTEXT_DSH_AUTHORIZATION` for authentication.
+Do not copy Server model credentials into the plugin configuration. Leave `POWERCONTEXT_DSH_SCOPE_ID` unset for
+the Server default/workspace binding, or set it to an existing Scope intentionally.
+
+Environment overrides take precedence over plugin patch values, which take precedence over defaults. They must be
+present in the process launching DSH; changing another terminal's environment does not update a running host.
+
+## Diagnose the running configuration
+
+Run `/pc doctor` inside the affected DSH session. Its report identifies configuration provenance and checks
+liveness, readiness, capabilities, declared routes, the current Scope, and a read-only prepare operation independently.
+A Scope failure leaves health results available. The endpoint summary shows only its origin, configuration source
+and whether a path prefix exists; credentials, prefix text, query strings and fragments are not printed.
+
+Each failed check identifies the operation, a stable code, HTTP status/request ID when available, and a recovery
+action. Protocol errors also include `protocol_issue`, identifying the violated JSON, status or PreparedContext field rule.
+Readiness retains recognized dependency statuses, including a 503 response. It never forwards raw Server
+messages or recalled content. `ok: true` means these read-only checks passed, not that capture or processing occurred.
+
+| Check/result | Meaning and next action |
+| --- | --- |
+| `invalid_endpoint` | Correct the effective HTTP(S) base URL; remove userinfo, query and fragment. Use Authorization for credentials. |
+| `connection_refused` / `dns_lookup_failed` | Check the configured listener or hostname respectively. |
+| `request_timeout` | Inspect the named operation's Server latency/dependencies and the effective request timeout. |
+| `connection_failed` | Transport failed without a more specific reason; check the endpoint, proxy, network and Server logs. |
+| `authentication_failed` / `authorization_failed` | Check the host credential or the principal's operation/Scope permissions respectively. |
+| `not_ready` / `degraded` | Inspect the reported dependency, such as `database` or `inference.generation`; use its recovery action. |
+| `required_route_missing` | The named operation returned untyped 404. Inspect its proxy route/base path and matching versions; 404 alone does not prove a version mismatch. |
+| `required_route_undeclared` | The Server OpenAPI document lacks the listed operation declarations. |
+| `contract_unavailable` | Declarations are unchecked; expose `/openapi.json` through the same base path or verify the contract separately. |
+| `scope_not_found` / `unscoped` | Check the explicit Scope override, workspace binding, and Server default. Doctor does not alter them. |
+| `invalid_response` | The response fails protocol checks, even if HTTP status was 200. |
+| `extraction_disabled` / prepare `empty` | Valid limited capability/empty result; neither proves a hook or Server failure. |
+
+The route check reads the Server's existing `/openapi.json` and distinguishes declarations from live probes.
+Doctor never executes capture, remember, flush, binding changes or injection. A missing contract is unchecked, and
+a missing Scope skips prepare with an explicit reason. Write/processing verification belongs to acceptance below.
+
+Standalone `powercontext doctor dsh` checks Web-profile registration only and reports that the running host
+configuration and Server checks were not observed. Exit success means registration checks passed.
+`powercontext doctor` uses its own `--server-url` / `POWERCONTEXT_CLIENT_SERVER_URL`; use it for the existing
+service/health diagnostics after aligning that URL, without assuming it observes DSH overrides.
+
+## Verify capture, processing and fresh-session recall
+
+This explicit check writes test evidence. With the matching installation and extraction configuration above:
+
+1. Run `/pc doctor`. Confirm health, Scope and prepare checks pass and extraction is enabled.
+2. Send a distinctive project fact, for example: “The aurora deployment color is violet-cedar-1457.”
+3. Verify Source acceptance separately from processing. Wait for the configured Scheduler, or explicitly run
+   `/pc flush`. Using the [Memory-loop API checks](full-capability-runtime.md), verify the processed cursor reaches
+   the Source position and a Memory entry cites that Source. A completed flush with no generated entry does not
+   prove successful extraction.
+4. Open a new session with the same workspace/Scope and ask for the aurora deployment color. Inspect the recalled
+   snapshot and confirm it contains the fact. A model answer alone is insufficient evidence of recall.
+
+For deterministic, provider-free acceptance from the same checkout, run `make dsh-runtime-test`.
+The pinned real-host fixture checks Source acceptance, processing, fresh-session recall and persisted snapshot
+metadata. Its model responses are deterministic; it does not establish external inference-service behavior.
+See the [runtime test procedure](https://github.com/oceanbase/powercontext/blob/master/integrations/dsh/plugins/powercontext/tests/runtime/README.md).
 
 ## Understand what the plugin does
 
@@ -44,7 +141,7 @@ per-request timeout also apply to Scope resolution.
 
 Inside DeepSeek Harness:
 
-- `/pc doctor` checks liveness and readiness independently of Scope resolution and reports both results.
+- `/pc doctor` checks health, capabilities, routes and Scope independently; a Scope failure preserves other results and skips prepare.
 - `/pc capabilities` queries the Server capabilities without resolving a Scope.
 - Unknown subcommands and missing arguments return local usage help without contacting the Server.
 - Bare `/pc` shows the resolved Scope and Server origin. If resolution fails, it returns an error while still showing

--- a/docs/zh/docs/how-to/configure-dsh.md
+++ b/docs/zh/docs/how-to/configure-dsh.md
@@ -5,23 +5,117 @@ description: 安装 PowerContext DeepSeek Harness 插件并控制其本地行为
 
 # 配置 DeepSeek Harness
 
-## 安装或刷新插件
+## 安装匹配的 Server 和插件
 
-先安装 DeepSeek Harness，并确保 web profile 可用。然后执行：
+先安装 DeepSeek Harness，并确保 Web profile 可用。真实宿主验收固定使用 DSH 0.1.2-rc.1。
+选择以下一种 PowerContext 安装方式，让 Server 和插件保持匹配。
 
-```bash
-powercontext setup dsh --source oceanbase/powercontext --ref master
-```
-
-该命令会从 `integrations/dsh/plugins/powercontext` 安装插件，并创建用户数据目录。该目录必须包含已构建的 `lib/index.js`。重复执行是安全的：有效 checkout 会复用，同一 ref 下的残缺 checkout 会被替换。`--ref` 应与安装 PowerContext 工具时使用的 ref 一致。`--source` 可以是 GitHub slug，也可以是 `https://github.com/...` URL。
-
-本地 checkout 同样可以：
+正式版 PowerContext 0.2.0：
 
 ```bash
-powercontext setup dsh --source .
+uv tool install --force "powercontext[cli,server]==0.2.0"
+powercontext setup dsh --source oceanbase/powercontext --ref powercontext-v0.2.0
 ```
 
-`setup dsh` 内部会执行 `dsh plugin --profile web add`。配置完成后重新打开 `dsh web`。
+0.2.0 已包含直接操作的 Scope 错误边界。下文的分层 Doctor 和自动 snapshot 展示需要当前开发版 checkout，
+不能将这些行为视为 0.2.0 已发布的能力。
+
+开发版从同一个 checkout 安装两个组件，并记录 commit：
+
+```bash
+git clone --branch master https://github.com/oceanbase/powercontext.git powercontext-dsh-dev
+git -C powercontext-dsh-dev rev-parse HEAD
+uv tool install --force "./powercontext-dsh-dev[cli,server]"
+powercontext setup dsh --source ./powercontext-dsh-dev
+```
+
+更新时执行 `git -C powercontext-dsh-dev pull --ff-only`，记录新的 commit，再重复两个安装命令。
+本地目录必须包含仓库提交的已构建文件 `lib/index.js`。
+`setup dsh --source oceanbase/powercontext --ref master` 会直接复用有效缓存 checkout，不会 fetch；
+重复运行不代表更新了移动分支。只有残缺 checkout 会被替换。
+
+`setup dsh` 调用 `dsh plugin --profile web add`，不会启动 Server。安装完成后重启 DSH。
+
+## 启动 Server 和宿主
+
+需要自动将 Source 提取为 Memory 时，生成并校验 Server 配置：
+
+```bash
+powercontext config init --output powercontext.env
+powercontext config validate --env-file powercontext.env
+powercontext server run --env-file powercontext.env
+```
+
+Server 是前台进程，保持这个终端运行。配置 generation 和定时处理；embedding 用于向量和混合检索，
+显式写入 Memory 和全文检索不依赖 embedding。无模型的 Server 可以健康运行，同时关闭自动提取并返回空召回。
+模型与处理配置参见[完整 Memory 闭环](full-capability-runtime.md)。
+
+在另一个终端指定同一个 Server，然后启动 DSH：
+
+```bash
+export POWERCONTEXT_DSH_BASE_URL=http://127.0.0.1:8000
+dsh web
+```
+
+PowerShell 使用 `$env:POWERCONTEXT_DSH_BASE_URL = "http://127.0.0.1:8000"`，然后运行 `dsh web`。
+Server 使用其他监听地址时同步修改 URL。鉴权使用 `POWERCONTEXT_DSH_AUTHORIZATION`，
+不要把 Server 的模型凭据复制到插件配置。使用 workspace binding 或 Server 默认 Scope 时不设置
+`POWERCONTEXT_DSH_SCOPE_ID`；需要覆盖时，指定一个已经存在的 Scope。
+
+环境变量优先于插件 patch 配置，patch 配置优先于默认值。环境变量必须存在于启动 DSH 的进程中；
+在其他终端修改变量不会更新已经运行的宿主。
+
+## 诊断运行中的配置
+
+在出现问题的 DSH 会话内运行 `/pc doctor`。报告显示配置来源，分别检查 liveness、readiness、运行能力、
+路由声明、当前 Scope 和只读 prepare 操作。Scope 失败不会遮蔽健康检查。
+端点摘要仅显示 origin、配置来源和是否存在路径前缀，不打印凭据、前缀正文、查询参数或 fragment。
+
+失败项提供操作名、稳定 code、可用的 HTTP status/request ID 和具体恢复操作。
+协议错误还提供 `protocol_issue`，指出 JSON、状态码或 PreparedContext 字段违反的具体规则。
+Readiness 保留已识别的依赖状态，包括 HTTP 503 的检查结果，不透传 Server 原始错误文字和召回内容。
+`ok: true` 表示这些只读检查通过，并不代表已经采集或处理了数据。
+
+| 结果 | 含义和处理方式 |
+| --- | --- |
+| `invalid_endpoint` | 修正实际使用的 HTTP(S) base URL，移除 userinfo、query 和 fragment，凭据改用 Authorization。 |
+| `connection_refused` / `dns_lookup_failed` | 分别检查监听地址是否启动、配置的主机名能否解析。 |
+| `request_timeout` | 检查指定操作的 Server 延迟、依赖和实际请求超时设置。 |
+| `connection_failed` | 传输失败且未提供更具体原因；检查端点、代理、网络和 Server 日志。 |
+| `authentication_failed` / `authorization_failed` | 分别检查宿主凭据、当前主体对该操作和 Scope 的权限。 |
+| `not_ready` / `degraded` | 检查报告指出的依赖，例如 `database` 或 `inference.generation`，按该项恢复提示处理。 |
+| `required_route_missing` | 指定操作返回无业务码的 404；检查代理路由、base path 和版本匹配，404 本身不能确定是版本问题。 |
+| `required_route_undeclared` | Server 的 OpenAPI 文档缺少列出的操作声明。 |
+| `contract_unavailable` | 无法核对路由声明；通过同一 base path 提供 `/openapi.json`，或单独核对部署的契约。 |
+| `scope_not_found` / `unscoped` | 检查显式 Scope 覆盖、workspace binding 和 Server 默认 Scope；Doctor 不修改它们。 |
+| `invalid_response` | 响应未通过协议校验，即使 HTTP status 是 200。 |
+| `extraction_disabled` / prepare `empty` | 正常的受限能力或空结果，不能据此判断 hook 或 Server 故障。 |
+
+路由检查读取 Server 已有的 `/openapi.json`，区分“声明支持”和“实际探测通过”。
+Doctor 不执行 capture、remember、flush、binding 修改或注入。契约不可读时标为未检查；
+Scope 不可用时跳过 prepare 并说明原因。实际写入与处理由下方显式验收负责。
+
+独立 CLI 的 `powercontext doctor dsh` 仅检查 Web profile 注册，并明确报告没有观察到运行中宿主的配置，
+没有执行 Server 检查。退出成功只表示注册检查通过。
+`powercontext doctor` 使用自己的 `--server-url` / `POWERCONTEXT_CLIENT_SERVER_URL`；
+对齐 URL 后可复用它的 service/health 诊断，但不能认为它观察到了 DSH 的覆盖配置。
+
+## 验证采集、处理和新会话召回
+
+这是会写入测试证据的显式验收。完成上述匹配安装和提取配置后：
+
+1. 运行 `/pc doctor`，确认健康、Scope 和 prepare 检查通过，自动提取已启用。
+2. 发送一个独特的项目事实，例如：“The aurora deployment color is violet-cedar-1457.”
+3. 分别核实 Source 接收和处理。等待已配置的 Scheduler，或显式运行 `/pc flush`。
+   按[Memory 闭环 API 检查](full-capability-runtime.md)确认处理游标达到 Source position，
+   并找到引用该 Source 的 Memory entry。flush 完成但没有生成 entry，不能证明提取成功。
+4. 在同一 workspace/Scope 下打开新会话，询问 aurora 的部署颜色，展开实际召回的 snapshot 检查事实。
+   仅凭模型回答正确，不能证明发生了召回。
+
+在同一 checkout 执行 `make dsh-runtime-test`，可运行不依赖外部模型服务的确定性验收。
+固定版本的真实宿主 fixture 分别检查 Source 接收、处理、新会话召回和 snapshot 持久化。
+模型响应是测试 fixture，不能证明外部推理服务的行为。
+详见[运行时验收说明](https://github.com/oceanbase/powercontext/blob/master/integrations/dsh/plugins/powercontext/tests/runtime/README.md)。
 
 ## 理解插件行为
 
@@ -43,7 +137,7 @@ Scope 解析失败时，具名工具和依赖 Scope 的 `/pc` 命令会返回受
 
 在 DeepSeek Harness 内：
 
-- `/pc doctor` 不依赖 Scope 解析，继续检查 liveness 和 readiness，并保留两个检查结果。
+- `/pc doctor` 独立检查健康、能力、路由和 Scope；Scope 解析失败时保留其他层的结果，并跳过 prepare。
 - `/pc capabilities` 直接查询 Server 能力，无需解析 Scope。
 - 未知子命令或缺少参数时，在本地返回用法说明，不访问 Server。
 - 裸 `/pc` 显示已解析的 Scope 和 Server origin。解析失败时返回错误，但仍显示 `scope=unresolved`、受控错误信息

--- a/integrations/dsh/plugins/powercontext/README.md
+++ b/integrations/dsh/plugins/powercontext/README.md
@@ -2,22 +2,43 @@
 
 This plugin is a thin DeepSeek Harness integration for a running PowerContext Server. It does not embed storage or start the Server.
 
-Install it from a PowerContext checkout so the Server and plugin stay on the same ref:
+Install the released Server and plugin together:
 
 ```bash
-powercontext setup dsh --source oceanbase/powercontext --ref master
-powercontext server run
-dsh web
+uv tool install --force "powercontext[cli,server]==0.2.0"
+powercontext setup dsh --source oceanbase/powercontext --ref powercontext-v0.2.0
 ```
 
-`setup dsh` calls `dsh plugin --profile web add` on this directory. The plugin talks HTTP only. It does not use MCP.
+`setup dsh` calls `dsh plugin --profile web add`. The plugin talks HTTP only. It does not use MCP.
+For development, install the CLI/Server and this built plugin from the same checkout and record its commit:
+
+```bash
+uv tool install --force ".[cli,server]"
+powercontext setup dsh --source .
+```
+
+Run those development commands from the PowerContext repository root. Repeating remote setup with `--ref master`
+reuses the cached checkout without fetching; update a local checkout and reinstall both components to refresh it.
+
+Use [the DSH setup guide](../../../../docs/en/docs/how-to/configure-dsh.md) for generation/processing configuration.
+Run `powercontext server run --env-file powercontext.env` in one terminal, then set
+`POWERCONTEXT_DSH_BASE_URL` in another terminal and run `dsh web`. Restart DSH after changing installation or environment.
+Release 0.2.0 includes direct-operation Scope failure handling; the layered Doctor and snapshot behavior below
+require the current development checkout.
 
 Before each model step it:
 
 1. recalls bounded context with `POST /v1/context/prepare`;
 2. captures the current user input with `POST /v1/sources/content`.
 
-Named `pc_*` tools expose the agent-safe Memory, handoff, experience, skill, and read-only review operations. DSH requests one-time user approval before named mutations run. Review mutations remain explicit human `/pc review` commands; destructive and administrative OpenAPI operations are not model tools. `/pc doctor` checks Server liveness and readiness.
+Named `pc_*` tools expose the agent-safe Memory, handoff, experience, skill, and read-only review operations. DSH requests one-time user approval before named mutations run. Review mutations remain explicit human `/pc review` commands; destructive and administrative OpenAPI operations are not model tools.
+
+`/pc doctor` checks the running plugin configuration, health, capabilities, declared routes, current Scope and
+read-only prepare independently. Failures identify the operation, a specific code, available HTTP status/request ID,
+safe dependency statuses and recovery actions. The endpoint summary omits credentials and path text. A successful
+report does not prove capture or processing: write routes are declared by OpenAPI but never executed by Doctor.
+Standalone `powercontext doctor dsh` verifies Web-profile registration and explicitly cannot observe the running
+host's overrides. A healthy Server with extraction disabled may return valid empty recall.
 
 The operations table in `src/operations.generated.ts` is generated from the repository `openapi/powercontext.yaml`. From the PowerContext root:
 

--- a/integrations/dsh/plugins/powercontext/lib/index.d.ts
+++ b/integrations/dsh/plugins/powercontext/lib/index.d.ts
@@ -28,17 +28,6 @@ interface PluginConfig {
   flushOnCapture?: boolean;
   flushMaxCalls?: number;
 }
-interface ResolvedConfig {
-  baseUrl: string;
-  authorization: string | undefined;
-  scopeId: string | undefined;
-  timeoutMs: number;
-  requestTimeoutMs: number;
-  maxBytes: number;
-  capturePrompts: boolean;
-  flushOnCapture: boolean;
-  flushMaxCalls: number;
-}
 //#endregion
 //#region src/index.d.ts
 declare const name = "powercontext-dsh";
@@ -49,7 +38,7 @@ declare const Config: {
     version: 1;
     vendor: string;
     validate(value: unknown): {
-      value: ResolvedConfig;
+      value: PluginConfig;
       issues?: undefined;
     } | {
       issues: {

--- a/integrations/dsh/plugins/powercontext/lib/index.js
+++ b/integrations/dsh/plugins/powercontext/lib/index.js
@@ -30,10 +30,10 @@ const PLUGIN_VERSION = "0.0.2";
 const PLUGIN_USER_AGENT = `${PLUGIN_NAME}/${PLUGIN_VERSION}`;
 var ClientError = class extends Error {
 	requestId;
-	constructor(message, requestId) {
+	constructor(message, requestId$1) {
 		super(message);
 		this.name = new.target.name;
-		this.requestId = requestId;
+		this.requestId = requestId$1;
 	}
 };
 var TransportError = class extends ClientError {
@@ -45,11 +45,33 @@ var TransportError = class extends ClientError {
 	}
 };
 var UnavailableError = class extends TransportError {};
+const RESPONSE_ISSUES = {
+	invalid_json: "The response body is not valid JSON.",
+	redirect: "The operation returned a redirect; the client does not follow redirects.",
+	response_too_large: "The response body exceeds the 1 MiB client limit.",
+	unexpected_body: "This status requires an empty response body.",
+	prepared_object: "PreparedContext must be a JSON object.",
+	prepared_fields: "PreparedContext must contain exactly schema, status, content and content_bytes.",
+	prepared_schema: "PreparedContext.schema must be powercontext.prepared-context.v1.",
+	prepared_size: "PreparedContext.content_bytes must be a non-negative integer.",
+	prepared_empty: "An empty PreparedContext must have null content and content_bytes equal to zero.",
+	prepared_content: "A ready PreparedContext must contain non-empty text.",
+	prepared_bytes: "PreparedContext.content_bytes must match the UTF-8 content size and stay within the requested budget.",
+	liveness: "Liveness requires HTTP 200 and a JSON object with status equal to ok.",
+	readiness: "Readiness requires status ready/degraded with HTTP 200, or not_ready with HTTP 503, and a checks object of string values.",
+	capabilities: "Capabilities requires HTTP 200, boolean memory_extraction/handoff_generation, and string arrays for source_types/artifact_families/search_modes/context_versions.",
+	openapi: "API discovery requires HTTP 200, an OpenAPI 3.x version and a paths object.",
+	prepare_status: "PreparedContext requires HTTP 200."
+};
 var InvalidResponseError = class extends ClientError {
 	path;
-	constructor(path, requestId) {
-		super(`response from ${path} violated the API schema`, requestId);
+	statusCode;
+	issue;
+	constructor(path, requestId$1, statusCode, issue) {
+		super(`response from ${path} violated the API schema`, requestId$1);
 		this.path = path;
+		this.statusCode = statusCode;
+		this.issue = issue;
 	}
 };
 var UnknownOperationError = class extends ClientError {
@@ -1201,7 +1223,7 @@ function responsePath(response) {
 async function readLimitedBody(response, maxBytes = MAX_RESPONSE_BYTES) {
 	if (!response.body) {
 		const buffer = new Uint8Array(await response.arrayBuffer());
-		if (buffer.byteLength > maxBytes) throw new InvalidResponseError(responsePath(response));
+		if (buffer.byteLength > maxBytes) throw new InvalidResponseError(responsePath(response), void 0, void 0, "response_too_large");
 		return buffer;
 	}
 	const reader = response.body.getReader();
@@ -1213,7 +1235,7 @@ async function readLimitedBody(response, maxBytes = MAX_RESPONSE_BYTES) {
 		total += value.byteLength;
 		if (total > maxBytes) {
 			await reader.cancel();
-			throw new InvalidResponseError(responsePath(response));
+			throw new InvalidResponseError(responsePath(response), void 0, void 0, "response_too_large");
 		}
 		chunks.push(value);
 	}
@@ -1292,18 +1314,37 @@ var PowerContextClient = class {
 		this.requestTimeoutMs = options.requestTimeoutMs;
 		this.fetchImpl = options.fetch ?? fetch;
 	}
-	async request(id, payload, signal) {
+	async request(id, payload, signal, options = {}) {
 		if (!(id in OPERATIONS)) throw new UnknownOperationError(id);
 		const spec = OPERATIONS[id];
 		const prepared = prepareRequest(spec, payload);
 		const url = `${this.baseUrl}${prepared.path}${prepared.query}`;
 		try {
 			const response = await this.fetchImpl(url, this.buildInit(spec, prepared, signal));
-			return await this.parseResponse(id, spec, payload, response);
+			return await this.parseResponse(id, spec, payload, response, options.readinessResponse === true);
 		} catch (error) {
 			if (error instanceof ServerResponseError || error instanceof InvalidResponseError) throw error;
 			if (error instanceof UnknownOperationError) throw error;
 			throw this.wrapTransport(prepared.path, error);
+		}
+	}
+	async readOpenApi(signal) {
+		const path = "/openapi.json";
+		const spec = OPERATIONS.get_liveness;
+		try {
+			const response = await this.fetchImpl(this.baseUrl + path, this.buildInit(spec, {
+				path,
+				query: "",
+				headers: {},
+				body: void 0
+			}, signal));
+			return await this.parseResponse("openapi_document", {
+				...spec,
+				path
+			}, void 0, response);
+		} catch (error) {
+			if (error instanceof ServerResponseError || error instanceof InvalidResponseError) throw error;
+			throw this.wrapTransport(path, error);
 		}
 	}
 	buildInit(spec, request, signal) {
@@ -1330,19 +1371,25 @@ var PowerContextClient = class {
 		if (error instanceof DOMException && error.name === "AbortError") return new UnavailableError(path, error);
 		return new UnavailableError(path, error);
 	}
-	async parseResponse(id, spec, payload, response) {
-		const success = response.status >= 200 && response.status < 300 || hasStatus(spec.successStatuses, response.status);
-		if (isRedirect(response.status) && !success) throw new InvalidResponseError(spec.path);
-		const bytes = await readLimitedBody(response);
-		const requestId = response.headers.get(REQUEST_ID_HEADER) ?? void 0;
-		if (!success) throw this.httpError(response.status, spec.path, requestId, bytes);
+	async parseResponse(id, spec, payload, response, readinessResponse = false) {
+		const success = response.status >= 200 && response.status < 300 || hasStatus(spec.successStatuses, response.status) || readinessResponse && id === "get_readiness" && response.status === 503;
+		const requestId$1 = response.headers.get(REQUEST_ID_HEADER) ?? void 0;
+		if (isRedirect(response.status) && !success) throw new InvalidResponseError(spec.path, requestId$1, response.status, "redirect");
+		let bytes;
+		try {
+			bytes = await readLimitedBody(response);
+		} catch (error) {
+			if (error instanceof InvalidResponseError) throw new InvalidResponseError(spec.path, requestId$1, response.status, error.issue);
+			throw error;
+		}
+		if (!success) throw this.httpError(response.status, spec.path, requestId$1, bytes);
 		if (hasStatus(spec.emptyStatuses, response.status)) {
-			if (bytes.byteLength !== 0) throw new InvalidResponseError(spec.path, requestId);
+			if (bytes.byteLength !== 0) throw new InvalidResponseError(spec.path, requestId$1, response.status, "unexpected_body");
 			return {
 				kind: "json",
 				value: null,
 				status: response.status,
-				requestId,
+				requestId: requestId$1,
 				etag: response.headers.get("ETag") ?? void 0
 			};
 		}
@@ -1350,32 +1397,32 @@ var PowerContextClient = class {
 			kind: "bytes",
 			value: bytes,
 			status: response.status,
-			requestId
+			requestId: requestId$1
 		};
 		if (id === "get_handoff_report" && payload?.format !== "json") return {
 			kind: "text",
 			value: Buffer.from(bytes).toString("utf8"),
 			status: response.status,
-			requestId
+			requestId: requestId$1
 		};
 		try {
 			return {
 				kind: "json",
 				value: JSON.parse(Buffer.from(bytes).toString("utf8")),
 				status: response.status,
-				requestId,
+				requestId: requestId$1,
 				etag: response.headers.get("ETag") ?? void 0
 			};
 		} catch {
-			throw new InvalidResponseError(spec.path, requestId);
+			throw new InvalidResponseError(spec.path, requestId$1, response.status, "invalid_json");
 		}
 	}
-	httpError(status, path, requestId, bytes) {
+	httpError(status, path, requestId$1, bytes) {
 		const decoded = decodeError(bytes);
 		return new ServerResponseError({
 			statusCode: status,
 			path,
-			requestId,
+			requestId: requestId$1,
 			code: decoded.code,
 			message: decoded.message
 		});
@@ -1531,6 +1578,350 @@ function createDiagnosticEmitter(write, now = Date.now, cooldownMs = 6e4) {
 }
 
 //#endregion
+//#region src/prepared-context.ts
+const PREPARED_CONTEXT_SCHEMA = "powercontext.prepared-context.v1";
+const PREPARED_FIELDS = new Set([
+	"schema",
+	"status",
+	"content",
+	"content_bytes"
+]);
+function isRecord(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function validatePreparedContext(response, path = "/v1/context/prepare", maxBytes = MAX_CONTEXT_BYTES) {
+	if (!isRecord(response)) throw new InvalidResponseError(path, void 0, void 0, "prepared_object");
+	const keys = Object.keys(response);
+	if (keys.length !== PREPARED_FIELDS.size || keys.some((key) => !PREPARED_FIELDS.has(key))) throw new InvalidResponseError(path, void 0, void 0, "prepared_fields");
+	if (response.schema !== PREPARED_CONTEXT_SCHEMA) throw new InvalidResponseError(path, void 0, void 0, "prepared_schema");
+	const status = response.status;
+	const content = response.content;
+	const contentBytes = response.content_bytes;
+	if (typeof contentBytes !== "number" || !Number.isInteger(contentBytes) || contentBytes < 0) throw new InvalidResponseError(path, void 0, void 0, "prepared_size");
+	if (status === "empty") {
+		if (content !== null || contentBytes !== 0) throw new InvalidResponseError(path, void 0, void 0, "prepared_empty");
+		return {
+			schema: PREPARED_CONTEXT_SCHEMA,
+			status,
+			content: null,
+			content_bytes: 0
+		};
+	}
+	if (status !== "ready" || typeof content !== "string" || !content.trim()) throw new InvalidResponseError(path, void 0, void 0, "prepared_content");
+	if (Buffer.from(content, "utf8").byteLength !== contentBytes || contentBytes > maxBytes) throw new InvalidResponseError(path, void 0, void 0, "prepared_bytes");
+	return {
+		schema: PREPARED_CONTEXT_SCHEMA,
+		status,
+		content,
+		content_bytes: contentBytes
+	};
+}
+
+//#endregion
+//#region src/doctor.ts
+const CORE_OPERATIONS = [
+	"get_liveness",
+	"get_readiness",
+	"get_capabilities",
+	"resolve_scope_binding",
+	"prepare_context",
+	"capture_content_source",
+	"remember_memory",
+	"search_memory"
+];
+const DEPENDENCY_RECOVERY = {
+	runtime: "Inspect the running Server startup and service logs for Runtime initialization failures.",
+	database: "Check the running Server database URL, database availability and database credentials.",
+	"inference.generation": "Check POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL, its Base URL and provider credentials.",
+	"inference.embedding": "Check the embedding model, Base URL, credentials, profile ID and dimension.",
+	"inference.rerank": "Check the rerank model, Base URL and provider credentials.",
+	authentication_provider: "Check the running Server authentication provider and its token configuration.",
+	access_provider: "Check the running Server access-control provider configuration and readiness."
+};
+const CONFIGURATION_CODES = new Set([
+	"dependency",
+	"model-instance",
+	"instructions",
+	"schema",
+	"input-type",
+	"serialize",
+	"embedder-instance",
+	"embedding-model",
+	"embedding-batch-size",
+	"dimension-positive",
+	"profile-identifiers",
+	"provider-rejected",
+	"pydantic-rejected"
+]);
+function record(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function check(operation, code, message, recovery, state = "failed") {
+	return {
+		state,
+		code,
+		operation,
+		message,
+		...recovery ? { recovery } : {}
+	};
+}
+function observed(operation, response, code, message) {
+	return {
+		...check(operation, code, message, void 0, "ok"),
+		http_status: response.status,
+		...requestId(response.requestId)
+	};
+}
+function requestId(value) {
+	return value && /^[a-zA-Z0-9._:-]{1,128}$/.test(value) ? { request_id: value } : {};
+}
+function invalid(operation, response, issue) {
+	throw new InvalidResponseError(operation, response.requestId, response.status, issue);
+}
+function transportFailure(error) {
+	const cause = error instanceof TransportError ? error.cause : error;
+	if (cause instanceof Error && cause.name === "TimeoutError") return [
+		"request_timeout",
+		"The request exceeded its deadline.",
+		"Check the effective requestTimeoutMs and the running Server latency; inspect the failing dependency before increasing the timeout."
+	];
+	if (cause instanceof Error && cause.name === "AbortError") return [
+		"cancelled",
+		"The diagnostic request was cancelled.",
+		"Run /pc doctor again when the current cancellation has completed."
+	];
+	const detail = record(cause) && record(cause.cause) ? cause.cause : cause;
+	const code = record(detail) ? detail.code : void 0;
+	if (code === "ECONNREFUSED") return [
+		"connection_refused",
+		"The configured endpoint refused the connection.",
+		"Start the intended Server and verify its listening host and port against the running plugin configuration."
+	];
+	if (code === "ENOTFOUND" || code === "EAI_AGAIN") return [
+		"dns_lookup_failed",
+		"The configured endpoint hostname could not be resolved.",
+		"Check the hostname in POWERCONTEXT_DSH_BASE_URL or the plugin baseUrl and the host DNS configuration."
+	];
+	if (typeof code === "string" && [
+		"CERT_HAS_EXPIRED",
+		"DEPTH_ZERO_SELF_SIGNED_CERT",
+		"UNABLE_TO_VERIFY_LEAF_SIGNATURE"
+	].includes(code)) return [
+		"tls_verification_failed",
+		"TLS certificate verification failed.",
+		"Correct the Server certificate chain, trust configuration or hostname; do not disable certificate verification."
+	];
+	return [
+		"connection_failed",
+		"The HTTP transport failed before a usable response was received.",
+		"Check the effective endpoint host/port, proxy, network and Server service logs. The transport did not identify a narrower cause."
+	];
+}
+function failure(operation, error) {
+	if (error instanceof ServerResponseError) {
+		const code = publicErrorCode(error.code);
+		let result;
+		if (error.statusCode === 401) result = check(operation, "authentication_failed", "The Server rejected authentication for this operation.", "Set POWERCONTEXT_DSH_AUTHORIZATION to the intended Server credential and restart the DSH process so it receives the override.");
+		else if (error.statusCode === 403) result = check(operation, "authorization_failed", "The authenticated principal is not allowed to perform this operation.", "Check the principal permissions for this operation and selected Scope on the running Server.");
+		else if (error.statusCode === 404 && error.code === void 0) result = check(operation, "required_route_missing", "The required operation returned HTTP 404 without a domain error code.", "Check this operation in the Server API and proxy route table, the plugin base-path setting, and the installed Server/plugin refs. A 404 alone cannot identify which configuration is wrong.");
+		else if (error.statusCode === 404 && code === "scope_not_found") result = check(operation, code, "The Server could not find the requested Scope.", "Check POWERCONTEXT_DSH_SCOPE_ID first, then the session workspace binding and Server default Scope. Select an existing Scope explicitly; Doctor does not change bindings.");
+		else if (error.statusCode === 404) result = code ? check(operation, code, "The Server returned a recognized domain-level HTTP 404 for this operation.", "Inspect the selected resource and Scope in the Server. This domain response does not establish a missing HTTP route.") : check(operation, "unclassified_not_found", "The operation returned HTTP 404 with an unrecognized error code.", "Use the operation and request ID in the Server logs. This response cannot distinguish a missing resource from a missing route; inspect the contract check separately.");
+		else if (error.statusCode === 503) result = check(operation, code ?? "service_unavailable", "The Server returned HTTP 503 for this operation.", "Inspect the separate readiness dependency results and the running Server logs for this operation.");
+		else result = check(operation, code ?? "http_error", "The Server rejected this diagnostic operation.", "Use this operation, HTTP status and request ID to locate the request in the Server logs.");
+		return {
+			...result,
+			http_status: error.statusCode,
+			...requestId(error.requestId)
+		};
+	}
+	if (error instanceof InvalidResponseError) return {
+		...check(operation, "invalid_response", error.issue ? RESPONSE_ISSUES[error.issue] : "The response does not satisfy this operation protocol.", "Verify the effective endpoint and proxy target serve PowerContext, and use matching Server/plugin refs. Inspect Server logs using the request ID."),
+		...requestId(error.requestId),
+		...error.issue ? { protocol_issue: error.issue } : {},
+		...error.statusCode === void 0 ? {} : { http_status: error.statusCode }
+	};
+	if (error instanceof TransportError || error instanceof Error && ["AbortError", "TimeoutError"].includes(error.name)) {
+		const [code, message, recovery] = transportFailure(error);
+		return check(operation, code, message, recovery);
+	}
+	return check(operation, "diagnostic_error", "A local diagnostic operation failed before its result could be validated.", "Inspect the DSH plugin logs for this operation and report the installed plugin commit. No Server root cause was established.");
+}
+function configuration(config, cwd) {
+	let origin;
+	let pathPrefix = false;
+	let valid = false;
+	try {
+		const url = new URL(config.baseUrl);
+		valid = ["http:", "https:"].includes(url.protocol) && !url.username && !url.password && !url.search && !url.hash;
+		if (valid) {
+			origin = url.origin;
+			pathPrefix = url.pathname !== "/";
+		}
+	} catch {}
+	return {
+		valid,
+		timeoutValid: Number.isInteger(config.requestTimeoutMs) && config.requestTimeoutMs > 0 && config.requestTimeoutMs <= 4294967295,
+		summary: {
+			observation: "running_plugin",
+			endpoint: {
+				...origin ? { origin } : {},
+				source: config.sources.baseUrl,
+				path_prefix: pathPrefix
+			},
+			authorization: {
+				configured: Boolean(config.authorization),
+				source: config.sources.authorization
+			},
+			scope: {
+				source: config.sources.scopeId,
+				selection: config.scopeId ? "explicit" : cwd?.trim() ? "workspace_then_default" : "server_default"
+			},
+			request_timeout_ms: config.requestTimeoutMs
+		}
+	};
+}
+function dependencyStatus(value) {
+	if ([
+		"ready",
+		"not_ready",
+		"disabled",
+		"unavailable",
+		"timeout",
+		"misconfigured"
+	].includes(value)) return value;
+	const configured = /^misconfigured: ([a-z-]+)(?: \(HTTP ([45][0-9]{2})\))?$/.exec(value);
+	if (configured && CONFIGURATION_CODES.has(configured[1])) return value;
+	return value.startsWith("misconfigured:") ? "misconfigured" : "unrecognized";
+}
+function readiness(response) {
+	const operation = "get_readiness";
+	const body = response.value;
+	if (!record(body) || !record(body.checks) || ![
+		"ready",
+		"degraded",
+		"not_ready"
+	].includes(String(body.status)) || Object.values(body.checks).some((value) => typeof value !== "string") || response.status === 503 !== (body.status === "not_ready") || ![200, 503].includes(response.status)) invalid(operation, response, "readiness");
+	const dependencies = {};
+	for (const name$1 of Object.keys(DEPENDENCY_RECOVERY)) {
+		const value = body.checks[name$1];
+		if (typeof value === "string") dependencies[name$1] = dependencyStatus(value);
+	}
+	const failed = Object.keys(dependencies).filter((name$1) => !["ready", "disabled"].includes(dependencies[name$1]));
+	const result = observed(operation, response, String(body.status), "Validated the Server readiness response.");
+	if (body.status !== "ready" || failed.length) {
+		result.state = body.status === "degraded" ? "degraded" : "failed";
+		result.code = body.status === "ready" ? "inconsistent_readiness" : String(body.status);
+		result.message = failed.length ? "Readiness dependency checks failed: " + failed.join(", ") + "." : "The Server reports " + String(body.status) + "; no recognized failing dependency was provided.";
+		result.recovery = failed.length ? failed.map((name$1) => DEPENDENCY_RECOVERY[name$1]).join(" ") : "Inspect the running Server readiness and service logs; unrecognized dependency details are withheld.";
+	}
+	return {
+		...result,
+		dependencies
+	};
+}
+function capabilities(response) {
+	const operation = "get_capabilities";
+	const body = response.value;
+	if (response.status !== 200 || !record(body) || typeof body.memory_extraction !== "boolean" || typeof body.handoff_generation !== "boolean" || ![
+		"source_types",
+		"artifact_families",
+		"search_modes",
+		"context_versions"
+	].every((key) => Array.isArray(body[key]) && body[key].every((value) => typeof value === "string"))) invalid(operation, response, "capabilities");
+	if (!body.context_versions.includes(PREPARED_CONTEXT_SCHEMA)) return {
+		...check(operation, "unsupported_context_schema", "The Server does not advertise the PreparedContext schema required by this plugin.", "Install Server and plugin from the same supported release tag or checkout commit."),
+		http_status: response.status,
+		...requestId(response.requestId)
+	};
+	return observed(operation, response, body.memory_extraction ? "extraction_enabled" : "extraction_disabled", body.memory_extraction ? "Memory extraction is configured. A processing/recall acceptance check is still required to prove the complete loop." : "Automatic Memory extraction is disabled. Source acceptance and a healthy Server can legitimately coexist with empty recall.");
+}
+function routes(response, flush) {
+	const operation = "openapi_document";
+	const body = response.value;
+	if (response.status !== 200 || !record(body) || typeof body.openapi !== "string" || !body.openapi.startsWith("3.") || !record(body.paths)) invalid(operation, response, "openapi");
+	const required = [...CORE_OPERATIONS, ...flush ? ["flush_memory"] : []];
+	const paths = body.paths;
+	const missing = required.filter((id) => {
+		const spec = OPERATIONS[id];
+		const path = paths[spec.path];
+		if (!record(path)) return true;
+		const declaration = path[spec.method.toLowerCase()];
+		return !record(declaration) || declaration.operationId !== id;
+	});
+	return missing.length ? {
+		...check(operation, "required_route_undeclared", "The Server contract is missing required operation declarations.", "Compare the listed operations with the Server release and proxy contract endpoint; install matching Server/plugin refs."),
+		operations: missing,
+		http_status: response.status,
+		...requestId(response.requestId)
+	} : {
+		...observed(operation, response, "routes_declared", "The Server contract declares the listed core Memory operations. Write routes were not executed."),
+		operations: required
+	};
+}
+async function diagnoseServer(runtime, cwd, signal) {
+	const config = configuration(runtime.config, cwd);
+	const checks = { configuration: !config.timeoutValid ? check("configuration", "invalid_timeout", "The plugin requestTimeoutMs is not a positive supported millisecond duration.", "Set requestTimeoutMs in the plugin patch to an integer between 1 and 4294967295, then restart DSH.") : config.valid ? check("configuration", "effective_configuration", "Using the running plugin resolved configuration.", void 0, "ok") : check("configuration", "invalid_endpoint", "The plugin base URL is not an HTTP(S) base URL without userinfo, query or fragment.", "Correct POWERCONTEXT_DSH_BASE_URL or plugin baseUrl. Put credentials in POWERCONTEXT_DSH_AUTHORIZATION and restart DSH.") };
+	async function probe(operation, run$1) {
+		if (!config.valid || !config.timeoutValid) return check(operation, "invalid_configuration", "Not checked because the plugin configuration is invalid.", "Correct the configuration check first.", "skipped");
+		try {
+			signal?.throwIfAborted();
+			const result = await run$1();
+			signal?.throwIfAborted();
+			return result;
+		} catch (error) {
+			if (signal?.aborted) return failure(operation, signal.reason instanceof Error && signal.reason.name === "TimeoutError" ? signal.reason : new DOMException("Diagnostic cancelled", "AbortError"));
+			return failure(operation, error);
+		}
+	}
+	checks.liveness = await probe("get_liveness", async () => {
+		const response = await runtime.client.request("get_liveness", {}, signal);
+		if (response.status !== 200 || !record(response.value) || response.value.status !== "ok") invalid("get_liveness", response, "liveness");
+		return observed("get_liveness", response, "live", "The PowerContext liveness response is valid.");
+	});
+	checks.readiness = await probe("get_readiness", async () => readiness(await runtime.client.request("get_readiness", {}, signal, { readinessResponse: true })));
+	checks.capabilities = await probe("get_capabilities", async () => capabilities(await runtime.client.request("get_capabilities", {}, signal)));
+	checks.routes = await probe("openapi_document", async () => {
+		try {
+			return routes(await runtime.client.readOpenApi(signal), runtime.config.flushOnCapture);
+		} catch (error) {
+			if (error instanceof ServerResponseError && error.statusCode === 404) return {
+				...check("openapi_document", "contract_unavailable", "The Server contract endpoint returned HTTP 404; declared route support is unverified.", "Expose the Server /openapi.json through the configured base path or verify the installed contract separately.", "skipped"),
+				http_status: 404,
+				...requestId(error.requestId)
+			};
+			throw error;
+		}
+	});
+	let scopeId;
+	checks.scope = await probe("resolve_scope_binding", async () => {
+		scopeId = await runtime.resolveScope(cwd, signal);
+		return scopeId ? check("resolve_scope_binding", "scope_resolved", "The Server resolved the current session Scope.", void 0, "ok") : check("resolve_scope_binding", "unscoped", "Scope resolution returned no usable Scope.", "Check the explicit Scope override, workspace binding and Server default Scope. Doctor does not create bindings.");
+	});
+	checks.prepare = scopeId ? await probe("prepare_context", async () => {
+		const response = await runtime.client.request("prepare_context", {
+			scope_id: scopeId,
+			query: "PowerContext diagnostic recall check",
+			max_bytes: 512
+		}, signal);
+		let prepared;
+		try {
+			prepared = validatePreparedContext(response.value, "/v1/context/prepare", 512);
+			if (response.status !== 200) invalid("prepare_context", response, "prepare_status");
+		} catch (error) {
+			if (error instanceof InvalidResponseError) invalid("prepare_context", response, error.issue);
+			throw error;
+		}
+		return observed("prepare_context", response, prepared.status, prepared.status === "empty" ? "The prepare route returned a valid empty result." : "The prepare route returned valid context; Doctor discarded the content without injecting it.");
+	}) : check("prepare_context", "scope_unavailable", "Not checked because the current Scope could not be resolved.", "Resolve the Scope check first.", "skipped");
+	return {
+		ok: Object.values(checks).every((value) => value.state === "ok"),
+		configuration: config.summary,
+		checks,
+		coverage: "Read-only checks of the current configuration. Write routes are declared by the contract but not executed; processing, capture and injection are not verified by Doctor."
+	};
+}
+
+//#endregion
 //#region src/secrets.ts
 const SECRET_MARKERS = [
 	"sk-",
@@ -1575,8 +1966,8 @@ function renderToolResult(_args, value) {
 		text: JSON.stringify(value)
 	}];
 }
-function requestIdField(requestId) {
-	return requestId === void 0 ? {} : { request_id: requestId };
+function requestIdField(requestId$1) {
+	return requestId$1 === void 0 ? {} : { request_id: requestId$1 };
 }
 function mapServerError(error) {
 	const code = publicErrorCode(error.code);
@@ -1802,29 +2193,14 @@ async function handleReview(tokens, runtime, cwd, signal) {
 		text: "Usage: /pc review [approve|reject] ..."
 	};
 }
-async function handleDoctor(runtime, signal) {
-	const onFailure = (error) => reportDirectFailure(runtime, "command", error);
-	const live = await invokeOperation(runtime.client, "get_liveness", {}, "", signal, onFailure);
-	const ready = await invokeOperation(runtime.client, "get_readiness", {}, "", signal, onFailure);
-	return {
-		kind: live.ok && ready.ok ? "success" : "error",
-		text: formatResult({
-			ok: live.ok && ready.ok,
-			data: {
-				live,
-				ready
-			}
-		})
-	};
-}
-function statusResult(runtime, scopeId, failure) {
+function statusResult(runtime, scopeId, failure$1) {
 	let endpoint = "(invalid URL)";
 	try {
 		endpoint = new URL(runtime.config.baseUrl).origin;
 	} catch {}
 	return {
-		kind: failure ? "error" : "success",
-		text: `scope=${scopeId ?? "unresolved"}\nbaseUrl=${endpoint}\nUse /pc doctor to check Server readiness.` + (failure ? `\n${formatResult(failure)}` : "")
+		kind: failure$1 ? "error" : "success",
+		text: `scope=${scopeId ?? "unresolved"}\nbaseUrl=${endpoint}\nUse /pc doctor to check Server readiness.` + (failure$1 ? `\n${formatResult(failure$1)}` : "")
 	};
 }
 async function handlePcCommand(rawInput, runtime, cwd, signal) {
@@ -1840,7 +2216,13 @@ async function handlePcCommand(rawInput, runtime, cwd, signal) {
 	} catch (error) {
 		return statusResult(runtime, void 0, await reportDirectFailure(runtime, "command", error));
 	}
-	if (command === "doctor") return handleDoctor(runtime, signal);
+	if (command === "doctor") {
+		const report = await diagnoseServer(runtime, cwd, signal);
+		return {
+			kind: report.ok ? "success" : "error",
+			text: JSON.stringify(report, null, 2)
+		};
+	}
 	if (command === "search") {
 		const query = tokens.slice(1).join(" ");
 		if (!query) return {
@@ -1892,6 +2274,11 @@ function registerCommands(ctx, runtime) {
 //#endregion
 //#region src/config.ts
 const DEFAULTS = {
+	sources: {
+		baseUrl: "default",
+		authorization: "default",
+		scopeId: "default"
+	},
 	baseUrl: "http://127.0.0.1:8000",
 	authorization: void 0,
 	scopeId: void 0,
@@ -1933,6 +2320,11 @@ function resolveConfig(config = {}, env = process.env) {
 	const maxBytes = config.maxBytes ?? DEFAULTS.maxBytes;
 	if (maxBytes < 512 || maxBytes > 32768) throw new Error("maxBytes must be between 512 and 32768");
 	return {
+		sources: {
+			baseUrl: envString(env, "POWERCONTEXT_DSH_BASE_URL") ? "environment" : config.baseUrl ? "plugin" : "default",
+			authorization: envString(env, "POWERCONTEXT_DSH_AUTHORIZATION") ? "environment" : optionalText(config.authorization) ? "plugin" : "default",
+			scopeId: envString(env, "POWERCONTEXT_DSH_SCOPE_ID") ? "environment" : optionalText(config.scopeId) ? "plugin" : "default"
+		},
 		baseUrl: stripSlash(envString(env, "POWERCONTEXT_DSH_BASE_URL") ?? config.baseUrl ?? DEFAULTS.baseUrl),
 		authorization: envString(env, "POWERCONTEXT_DSH_AUTHORIZATION") ?? optionalText(config.authorization),
 		scopeId: envString(env, "POWERCONTEXT_DSH_SCOPE_ID") ?? optionalText(config.scopeId),
@@ -2030,46 +2422,6 @@ async function captureUserPrompt(input) {
 	} catch (error) {
 		reportFailure(input.log, "flush_memory", error);
 	}
-}
-
-//#endregion
-//#region src/prepared-context.ts
-const PREPARED_CONTEXT_SCHEMA = "powercontext.prepared-context.v1";
-const PREPARED_FIELDS = new Set([
-	"schema",
-	"status",
-	"content",
-	"content_bytes"
-]);
-function isRecord(value) {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-function validatePreparedContext(response, path = "/v1/context/prepare", maxBytes = MAX_CONTEXT_BYTES) {
-	if (!isRecord(response)) throw new InvalidResponseError(path);
-	const keys = Object.keys(response);
-	if (keys.length !== PREPARED_FIELDS.size || keys.some((key) => !PREPARED_FIELDS.has(key))) throw new InvalidResponseError(path);
-	if (response.schema !== PREPARED_CONTEXT_SCHEMA) throw new InvalidResponseError(path);
-	const status = response.status;
-	const content = response.content;
-	const contentBytes = response.content_bytes;
-	if (typeof contentBytes !== "number" || !Number.isInteger(contentBytes) || contentBytes < 0) throw new InvalidResponseError(path);
-	if (status === "empty") {
-		if (content !== null || contentBytes !== 0) throw new InvalidResponseError(path);
-		return {
-			schema: PREPARED_CONTEXT_SCHEMA,
-			status,
-			content: null,
-			content_bytes: 0
-		};
-	}
-	if (status !== "ready" || typeof content !== "string" || !content.trim()) throw new InvalidResponseError(path);
-	if (Buffer.from(content, "utf8").byteLength !== contentBytes || contentBytes > maxBytes) throw new InvalidResponseError(path);
-	return {
-		schema: PREPARED_CONTEXT_SCHEMA,
-		status,
-		content,
-		content_bytes: contentBytes
-	};
 }
 
 //#endregion
@@ -2763,7 +3115,9 @@ const Config = { "~standard": {
 	vendor: "powercontext-dsh",
 	validate(value) {
 		try {
-			return { value: resolveConfig(value && typeof value === "object" ? value : {}) };
+			const input = value && typeof value === "object" ? value : {};
+			resolveConfig(input);
+			return { value: input };
 		} catch (error) {
 			return { issues: [{ message: error instanceof Error ? error.message : String(error) }] };
 		}

--- a/integrations/dsh/plugins/powercontext/src/client.ts
+++ b/integrations/dsh/plugins/powercontext/src/client.ts
@@ -83,7 +83,7 @@ function responsePath(response: Response): string {
 export async function readLimitedBody(response: Response, maxBytes = MAX_RESPONSE_BYTES): Promise<Uint8Array> {
   if (!response.body) {
     const buffer = new Uint8Array(await response.arrayBuffer())
-    if (buffer.byteLength > maxBytes) throw new InvalidResponseError(responsePath(response))
+    if (buffer.byteLength > maxBytes) throw new InvalidResponseError(responsePath(response), undefined, undefined, 'response_too_large')
     return buffer
   }
   const reader = response.body.getReader()
@@ -95,7 +95,7 @@ export async function readLimitedBody(response: Response, maxBytes = MAX_RESPONS
     total += value.byteLength
     if (total > maxBytes) {
       await reader.cancel()
-      throw new InvalidResponseError(responsePath(response))
+      throw new InvalidResponseError(responsePath(response), undefined, undefined, 'response_too_large')
     }
     chunks.push(value)
   }
@@ -200,6 +200,7 @@ export class PowerContextClient {
     id: string,
     payload?: JsonObject,
     signal?: AbortSignal,
+    options: { readinessResponse?: boolean } = {},
   ): Promise<ClientSuccess> {
     if (!(id in OPERATIONS)) throw new UnknownOperationError(id)
     const spec = OPERATIONS[id as OperationId]
@@ -207,11 +208,25 @@ export class PowerContextClient {
     const url = `${this.baseUrl}${prepared.path}${prepared.query}`
     try {
       const response = await this.fetchImpl(url, this.buildInit(spec, prepared, signal))
-      return await this.parseResponse(id, spec, payload, response)
+      return await this.parseResponse(id, spec, payload, response, options.readinessResponse === true)
     } catch (error) {
       if (error instanceof ServerResponseError || error instanceof InvalidResponseError) throw error
       if (error instanceof UnknownOperationError) throw error
       throw this.wrapTransport(prepared.path, error)
+    }
+  }
+
+  async readOpenApi(signal?: AbortSignal): Promise<ClientSuccess> {
+    const path = '/openapi.json'
+    const spec = OPERATIONS.get_liveness
+    try {
+      const response = await this.fetchImpl(this.baseUrl + path, this.buildInit(spec, {
+        path, query: '', headers: {}, body: undefined,
+      }, signal))
+      return await this.parseResponse('openapi_document', { ...spec, path }, undefined, response)
+    } catch (error) {
+      if (error instanceof ServerResponseError || error instanceof InvalidResponseError) throw error
+      throw this.wrapTransport(path, error)
     }
   }
 
@@ -243,20 +258,28 @@ export class PowerContextClient {
 
   private async parseResponse(
     id: string,
-    spec: OperationSpec,
+    spec: Omit<OperationSpec, 'path'> & { path: string },
     payload: JsonObject | undefined,
     response: Response,
+    readinessResponse = false,
   ): Promise<ClientSuccess> {
     const success = (response.status >= 200 && response.status < 300)
       || hasStatus(spec.successStatuses as readonly number[], response.status)
-    if (isRedirect(response.status) && !success) throw new InvalidResponseError(spec.path)
-    const bytes = await readLimitedBody(response)
+      || (readinessResponse && id === 'get_readiness' && response.status === 503)
     const requestId = response.headers.get(REQUEST_ID_HEADER) ?? undefined
+    if (isRedirect(response.status) && !success) throw new InvalidResponseError(spec.path, requestId, response.status, 'redirect')
+    let bytes: Uint8Array
+    try {
+      bytes = await readLimitedBody(response)
+    } catch (error) {
+      if (error instanceof InvalidResponseError) throw new InvalidResponseError(spec.path, requestId, response.status, error.issue)
+      throw error
+    }
     if (!success) {
       throw this.httpError(response.status, spec.path, requestId, bytes)
     }
     if (hasStatus(spec.emptyStatuses as readonly number[], response.status)) {
-      if (bytes.byteLength !== 0) throw new InvalidResponseError(spec.path, requestId)
+      if (bytes.byteLength !== 0) throw new InvalidResponseError(spec.path, requestId, response.status, 'unexpected_body')
       return { kind: 'json', value: null, status: response.status, requestId, etag: response.headers.get('ETag') ?? undefined }
     }
     if (id === 'get_handoff_report' && payload?.download === true) {
@@ -268,7 +291,7 @@ export class PowerContextClient {
     try {
       return { kind: 'json', value: JSON.parse(Buffer.from(bytes).toString('utf8')), status: response.status, requestId, etag: response.headers.get('ETag') ?? undefined }
     } catch {
-      throw new InvalidResponseError(spec.path, requestId)
+      throw new InvalidResponseError(spec.path, requestId, response.status, 'invalid_json')
     }
   }
 

--- a/integrations/dsh/plugins/powercontext/src/commands.ts
+++ b/integrations/dsh/plugins/powercontext/src/commands.ts
@@ -16,6 +16,7 @@
 
 import type { JsonObject } from './client.ts'
 import { requireService } from './dsh-service.ts'
+import { diagnoseServer } from './doctor.ts'
 import { invokeOperation, reportDirectFailure, type PluginRuntime, type ToolResult } from './invoke.ts'
 import { UNSCOPED_MESSAGE } from './scope.ts'
 
@@ -79,13 +80,6 @@ async function handleReview(
   return { kind: 'error', text: 'Usage: /pc review [approve|reject] ...' }
 }
 
-async function handleDoctor(runtime: PluginRuntime, signal?: AbortSignal): Promise<CommandResult> {
-  const onFailure = (error: unknown) => reportDirectFailure(runtime, 'command', error)
-  const live = await invokeOperation(runtime.client, 'get_liveness', {}, '', signal, onFailure)
-  const ready = await invokeOperation(runtime.client, 'get_readiness', {}, '', signal, onFailure)
-  return { kind: live.ok && ready.ok ? 'success' : 'error', text: formatResult({ ok: live.ok && ready.ok, data: { live, ready } }) }
-}
-
 function statusResult(runtime: PluginRuntime, scopeId?: string, failure?: ToolResult): CommandResult {
   let endpoint = '(invalid URL)'
   try {
@@ -116,7 +110,10 @@ export async function handlePcCommand(
       return statusResult(runtime, undefined, await reportDirectFailure(runtime, 'command', error))
     }
   }
-  if (command === 'doctor') return handleDoctor(runtime, signal)
+  if (command === 'doctor') {
+    const report = await diagnoseServer(runtime, cwd, signal)
+    return { kind: report.ok ? 'success' : 'error', text: JSON.stringify(report, null, 2) }
+  }
   if (command === 'search') {
     const query = tokens.slice(1).join(' ')
     if (!query) return { kind: 'error', text: 'Usage: /pc search <query>' }

--- a/integrations/dsh/plugins/powercontext/src/config.ts
+++ b/integrations/dsh/plugins/powercontext/src/config.ts
@@ -27,6 +27,7 @@ export interface PluginConfig {
 }
 
 export interface ResolvedConfig {
+  sources: { baseUrl: ConfigSource; authorization: ConfigSource; scopeId: ConfigSource }
   baseUrl: string
   authorization: string | undefined
   scopeId: string | undefined
@@ -38,7 +39,10 @@ export interface ResolvedConfig {
   flushMaxCalls: number
 }
 
+export type ConfigSource = 'environment' | 'plugin' | 'default'
+
 const DEFAULTS: ResolvedConfig = {
+  sources: { baseUrl: 'default', authorization: 'default', scopeId: 'default' },
   baseUrl: 'http://127.0.0.1:8000',
   authorization: undefined,
   scopeId: undefined,
@@ -81,6 +85,11 @@ export function resolveConfig(
     throw new Error('maxBytes must be between 512 and 32768')
   }
   return {
+    sources: {
+      baseUrl: envString(env, 'POWERCONTEXT_DSH_BASE_URL') ? 'environment' : config.baseUrl ? 'plugin' : 'default',
+      authorization: envString(env, 'POWERCONTEXT_DSH_AUTHORIZATION') ? 'environment' : optionalText(config.authorization) ? 'plugin' : 'default',
+      scopeId: envString(env, 'POWERCONTEXT_DSH_SCOPE_ID') ? 'environment' : optionalText(config.scopeId) ? 'plugin' : 'default',
+    },
     baseUrl: stripSlash(envString(env, 'POWERCONTEXT_DSH_BASE_URL') ?? config.baseUrl ?? DEFAULTS.baseUrl),
     authorization: envString(env, 'POWERCONTEXT_DSH_AUTHORIZATION') ?? optionalText(config.authorization),
     scopeId: envString(env, 'POWERCONTEXT_DSH_SCOPE_ID') ?? optionalText(config.scopeId),

--- a/integrations/dsh/plugins/powercontext/src/doctor.ts
+++ b/integrations/dsh/plugins/powercontext/src/doctor.ts
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ClientSuccess } from './client.ts'
+import type { ResolvedConfig } from './config.ts'
+import { publicErrorCode } from './diagnostics.ts'
+import { InvalidResponseError, RESPONSE_ISSUES, ServerResponseError, TransportError } from './errors.ts'
+import type { PluginRuntime } from './invoke.ts'
+import { OPERATIONS, type OperationId } from './operations.generated.ts'
+import { PREPARED_CONTEXT_SCHEMA, validatePreparedContext } from './prepared-context.ts'
+
+export interface DoctorCheck {
+  state: 'ok' | 'failed' | 'degraded' | 'skipped'
+  code: string
+  operation: string
+  message: string
+  recovery?: string
+  http_status?: number
+  request_id?: string
+  protocol_issue?: keyof typeof RESPONSE_ISSUES
+  dependencies?: Record<string, string>
+  operations?: string[]
+}
+
+const CORE_OPERATIONS: OperationId[] = [
+  'get_liveness', 'get_readiness', 'get_capabilities', 'resolve_scope_binding',
+  'prepare_context', 'capture_content_source', 'remember_memory', 'search_memory',
+]
+const DEPENDENCY_RECOVERY: Record<string, string> = {
+  runtime: 'Inspect the running Server startup and service logs for Runtime initialization failures.',
+  database: 'Check the running Server database URL, database availability and database credentials.',
+  'inference.generation': 'Check POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL, its Base URL and provider credentials.',
+  'inference.embedding': 'Check the embedding model, Base URL, credentials, profile ID and dimension.',
+  'inference.rerank': 'Check the rerank model, Base URL and provider credentials.',
+  authentication_provider: 'Check the running Server authentication provider and its token configuration.',
+  access_provider: 'Check the running Server access-control provider configuration and readiness.',
+}
+const CONFIGURATION_CODES = new Set([
+  'dependency', 'model-instance', 'instructions', 'schema', 'input-type', 'serialize',
+  'embedder-instance', 'embedding-model', 'embedding-batch-size', 'dimension-positive',
+  'profile-identifiers', 'provider-rejected', 'pydantic-rejected',
+])
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function check(operation: string, code: string, message: string, recovery?: string,
+  state: DoctorCheck['state'] = 'failed'): DoctorCheck {
+  return { state, code, operation, message, ...(recovery ? { recovery } : {}) }
+}
+
+function observed(operation: string, response: ClientSuccess, code: string, message: string): DoctorCheck {
+  return { ...check(operation, code, message, undefined, 'ok'), http_status: response.status,
+    ...requestId(response.requestId) }
+}
+
+function requestId(value: string | undefined): { request_id?: string } {
+  return value && /^[a-zA-Z0-9._:-]{1,128}$/.test(value) ? { request_id: value } : {}
+}
+
+function invalid(operation: string, response: ClientSuccess, issue?: keyof typeof RESPONSE_ISSUES): never {
+  throw new InvalidResponseError(operation, response.requestId, response.status, issue)
+}
+
+function transportFailure(error: unknown): [string, string, string] {
+  const cause = error instanceof TransportError ? error.cause : error
+  if (cause instanceof Error && cause.name === 'TimeoutError') {
+    return ['request_timeout', 'The request exceeded its deadline.',
+      'Check the effective requestTimeoutMs and the running Server latency; inspect the failing dependency before increasing the timeout.']
+  }
+  if (cause instanceof Error && cause.name === 'AbortError') {
+    return ['cancelled', 'The diagnostic request was cancelled.', 'Run /pc doctor again when the current cancellation has completed.']
+  }
+  const detail = record(cause) && record(cause.cause) ? cause.cause : cause
+  const code = record(detail) ? detail.code : undefined
+  if (code === 'ECONNREFUSED') return ['connection_refused', 'The configured endpoint refused the connection.',
+    'Start the intended Server and verify its listening host and port against the running plugin configuration.']
+  if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') return ['dns_lookup_failed', 'The configured endpoint hostname could not be resolved.',
+    'Check the hostname in POWERCONTEXT_DSH_BASE_URL or the plugin baseUrl and the host DNS configuration.']
+  if (typeof code === 'string' && ['CERT_HAS_EXPIRED', 'DEPTH_ZERO_SELF_SIGNED_CERT', 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'].includes(code)) {
+    return ['tls_verification_failed', 'TLS certificate verification failed.',
+      'Correct the Server certificate chain, trust configuration or hostname; do not disable certificate verification.']
+  }
+  return ['connection_failed', 'The HTTP transport failed before a usable response was received.',
+    'Check the effective endpoint host/port, proxy, network and Server service logs. The transport did not identify a narrower cause.']
+}
+
+function failure(operation: string, error: unknown): DoctorCheck {
+  if (error instanceof ServerResponseError) {
+    const code = publicErrorCode(error.code)
+    let result: DoctorCheck
+    if (error.statusCode === 401) result = check(operation, 'authentication_failed', 'The Server rejected authentication for this operation.',
+      'Set POWERCONTEXT_DSH_AUTHORIZATION to the intended Server credential and restart the DSH process so it receives the override.')
+    else if (error.statusCode === 403) result = check(operation, 'authorization_failed', 'The authenticated principal is not allowed to perform this operation.',
+      'Check the principal permissions for this operation and selected Scope on the running Server.')
+    else if (error.statusCode === 404 && error.code === undefined) result = check(operation, 'required_route_missing', 'The required operation returned HTTP 404 without a domain error code.',
+      'Check this operation in the Server API and proxy route table, the plugin base-path setting, and the installed Server/plugin refs. A 404 alone cannot identify which configuration is wrong.')
+    else if (error.statusCode === 404 && code === 'scope_not_found') result = check(operation, code, 'The Server could not find the requested Scope.',
+      'Check POWERCONTEXT_DSH_SCOPE_ID first, then the session workspace binding and Server default Scope. Select an existing Scope explicitly; Doctor does not change bindings.')
+    else if (error.statusCode === 404) result = code
+      ? check(operation, code, 'The Server returned a recognized domain-level HTTP 404 for this operation.',
+        'Inspect the selected resource and Scope in the Server. This domain response does not establish a missing HTTP route.')
+      : check(operation, 'unclassified_not_found', 'The operation returned HTTP 404 with an unrecognized error code.',
+        'Use the operation and request ID in the Server logs. This response cannot distinguish a missing resource from a missing route; inspect the contract check separately.')
+    else if (error.statusCode === 503) result = check(operation, code ?? 'service_unavailable', 'The Server returned HTTP 503 for this operation.',
+      'Inspect the separate readiness dependency results and the running Server logs for this operation.')
+    else result = check(operation, code ?? 'http_error', 'The Server rejected this diagnostic operation.',
+      'Use this operation, HTTP status and request ID to locate the request in the Server logs.')
+    return { ...result, http_status: error.statusCode, ...requestId(error.requestId) }
+  }
+  if (error instanceof InvalidResponseError) return {
+    ...check(operation, 'invalid_response', error.issue ? RESPONSE_ISSUES[error.issue] : 'The response does not satisfy this operation protocol.',
+      'Verify the effective endpoint and proxy target serve PowerContext, and use matching Server/plugin refs. Inspect Server logs using the request ID.'),
+    ...requestId(error.requestId),
+    ...(error.issue ? { protocol_issue: error.issue } : {}),
+    ...(error.statusCode === undefined ? {} : { http_status: error.statusCode }),
+  }
+  if (error instanceof TransportError || (error instanceof Error && ['AbortError', 'TimeoutError'].includes(error.name))) {
+    const [code, message, recovery] = transportFailure(error)
+    return check(operation, code, message, recovery)
+  }
+  return check(operation, 'diagnostic_error', 'A local diagnostic operation failed before its result could be validated.',
+    'Inspect the DSH plugin logs for this operation and report the installed plugin commit. No Server root cause was established.')
+}
+
+function configuration(config: ResolvedConfig, cwd?: string) {
+  let origin: string | undefined
+  let pathPrefix = false
+  let valid = false
+  try {
+    const url = new URL(config.baseUrl)
+    valid = ['http:', 'https:'].includes(url.protocol) && !url.username && !url.password && !url.search && !url.hash
+    if (valid) {
+      origin = url.origin
+      pathPrefix = url.pathname !== '/'
+    }
+  } catch { /* An invalid URL may contain credentials; never echo it. */ }
+  return {
+    valid,
+    timeoutValid: Number.isInteger(config.requestTimeoutMs) && config.requestTimeoutMs > 0 && config.requestTimeoutMs <= 4_294_967_295,
+    summary: {
+      observation: 'running_plugin',
+      endpoint: { ...(origin ? { origin } : {}), source: config.sources.baseUrl, path_prefix: pathPrefix },
+      authorization: { configured: Boolean(config.authorization), source: config.sources.authorization },
+      scope: { source: config.sources.scopeId, selection: config.scopeId ? 'explicit' : cwd?.trim() ? 'workspace_then_default' : 'server_default' },
+      request_timeout_ms: config.requestTimeoutMs,
+    },
+  }
+}
+
+function dependencyStatus(value: string): string {
+  if (['ready', 'not_ready', 'disabled', 'unavailable', 'timeout', 'misconfigured'].includes(value)) return value
+  const configured = /^misconfigured: ([a-z-]+)(?: \(HTTP ([45][0-9]{2})\))?$/.exec(value)
+  if (configured && CONFIGURATION_CODES.has(configured[1])) return value
+  return value.startsWith('misconfigured:') ? 'misconfigured' : 'unrecognized'
+}
+
+function readiness(response: ClientSuccess): DoctorCheck {
+  const operation = 'get_readiness'
+  const body = response.value
+  if (!record(body) || !record(body.checks) || !['ready', 'degraded', 'not_ready'].includes(String(body.status))
+    || Object.values(body.checks).some(value => typeof value !== 'string')
+    || (response.status === 503) !== (body.status === 'not_ready')
+    || ![200, 503].includes(response.status)) invalid(operation, response, 'readiness')
+  const dependencies: Record<string, string> = {}
+  for (const name of Object.keys(DEPENDENCY_RECOVERY)) {
+    const value = body.checks[name]
+    if (typeof value === 'string') dependencies[name] = dependencyStatus(value)
+  }
+  const failed = Object.keys(dependencies).filter(name => !['ready', 'disabled'].includes(dependencies[name]))
+  const result = observed(operation, response, String(body.status), 'Validated the Server readiness response.')
+  if (body.status !== 'ready' || failed.length) {
+    result.state = body.status === 'degraded' ? 'degraded' : 'failed'
+    result.code = body.status === 'ready' ? 'inconsistent_readiness' : String(body.status)
+    result.message = failed.length ? 'Readiness dependency checks failed: ' + failed.join(', ') + '.'
+      : 'The Server reports ' + String(body.status) + '; no recognized failing dependency was provided.'
+    result.recovery = failed.length ? failed.map(name => DEPENDENCY_RECOVERY[name]).join(' ')
+      : 'Inspect the running Server readiness and service logs; unrecognized dependency details are withheld.'
+  }
+  return { ...result, dependencies }
+}
+
+function capabilities(response: ClientSuccess): DoctorCheck {
+  const operation = 'get_capabilities'
+  const body = response.value
+  if (response.status !== 200 || !record(body) || typeof body.memory_extraction !== 'boolean'
+    || typeof body.handoff_generation !== 'boolean'
+    || !['source_types', 'artifact_families', 'search_modes', 'context_versions'].every(key =>
+      Array.isArray(body[key]) && (body[key] as unknown[]).every(value => typeof value === 'string'))) invalid(operation, response, 'capabilities')
+  if (!(body.context_versions as string[]).includes(PREPARED_CONTEXT_SCHEMA)) return { ...check(operation, 'unsupported_context_schema',
+    'The Server does not advertise the PreparedContext schema required by this plugin.',
+    'Install Server and plugin from the same supported release tag or checkout commit.'),
+    http_status: response.status, ...requestId(response.requestId) }
+  return observed(operation, response, body.memory_extraction ? 'extraction_enabled' : 'extraction_disabled',
+    body.memory_extraction
+      ? 'Memory extraction is configured. A processing/recall acceptance check is still required to prove the complete loop.'
+      : 'Automatic Memory extraction is disabled. Source acceptance and a healthy Server can legitimately coexist with empty recall.')
+}
+
+function routes(response: ClientSuccess, flush: boolean): DoctorCheck {
+  const operation = 'openapi_document'
+  const body = response.value
+  if (response.status !== 200 || !record(body) || typeof body.openapi !== 'string' || !body.openapi.startsWith('3.')
+    || !record(body.paths)) invalid(operation, response, 'openapi')
+  const required = [...CORE_OPERATIONS, ...flush ? ['flush_memory' as const] : []]
+  const paths = body.paths
+  const missing = required.filter(id => {
+    const spec = OPERATIONS[id]
+    const path = paths[spec.path]
+    if (!record(path)) return true
+    const declaration = path[spec.method.toLowerCase()]
+    return !record(declaration) || declaration.operationId !== id
+  })
+  return missing.length
+    ? { ...check(operation, 'required_route_undeclared', 'The Server contract is missing required operation declarations.',
+      'Compare the listed operations with the Server release and proxy contract endpoint; install matching Server/plugin refs.'),
+      operations: missing, http_status: response.status, ...requestId(response.requestId) }
+    : { ...observed(operation, response, 'routes_declared', 'The Server contract declares the listed core Memory operations. Write routes were not executed.'),
+      operations: required }
+}
+
+export async function diagnoseServer(runtime: PluginRuntime, cwd?: string, signal?: AbortSignal) {
+  const config = configuration(runtime.config, cwd)
+  const checks: Record<string, DoctorCheck> = {
+    configuration: !config.timeoutValid
+      ? check('configuration', 'invalid_timeout', 'The plugin requestTimeoutMs is not a positive supported millisecond duration.',
+        'Set requestTimeoutMs in the plugin patch to an integer between 1 and 4294967295, then restart DSH.')
+      : config.valid
+      ? check('configuration', 'effective_configuration', 'Using the running plugin resolved configuration.', undefined, 'ok')
+      : check('configuration', 'invalid_endpoint', 'The plugin base URL is not an HTTP(S) base URL without userinfo, query or fragment.',
+        'Correct POWERCONTEXT_DSH_BASE_URL or plugin baseUrl. Put credentials in POWERCONTEXT_DSH_AUTHORIZATION and restart DSH.'),
+  }
+  async function probe(operation: string, run: () => Promise<DoctorCheck>): Promise<DoctorCheck> {
+    if (!config.valid || !config.timeoutValid) return check(operation, 'invalid_configuration', 'Not checked because the plugin configuration is invalid.',
+      'Correct the configuration check first.', 'skipped')
+    try {
+      signal?.throwIfAborted()
+      const result = await run()
+      signal?.throwIfAborted()
+      return result
+    } catch (error) {
+      if (signal?.aborted) {
+        const reason = signal.reason instanceof Error && signal.reason.name === 'TimeoutError'
+          ? signal.reason : new DOMException('Diagnostic cancelled', 'AbortError')
+        return failure(operation, reason)
+      }
+      return failure(operation, error)
+    }
+  }
+  checks.liveness = await probe('get_liveness', async () => {
+    const response = await runtime.client.request('get_liveness', {}, signal)
+    if (response.status !== 200 || !record(response.value) || response.value.status !== 'ok') invalid('get_liveness', response, 'liveness')
+    return observed('get_liveness', response, 'live', 'The PowerContext liveness response is valid.')
+  })
+  checks.readiness = await probe('get_readiness', async () => readiness(
+    await runtime.client.request('get_readiness', {}, signal, { readinessResponse: true })))
+  checks.capabilities = await probe('get_capabilities', async () => capabilities(
+    await runtime.client.request('get_capabilities', {}, signal)))
+  checks.routes = await probe('openapi_document', async () => {
+    try { return routes(await runtime.client.readOpenApi(signal), runtime.config.flushOnCapture) } catch (error) {
+      if (error instanceof ServerResponseError && error.statusCode === 404) return {
+        ...check('openapi_document', 'contract_unavailable', 'The Server contract endpoint returned HTTP 404; declared route support is unverified.',
+          'Expose the Server /openapi.json through the configured base path or verify the installed contract separately.', 'skipped'),
+        http_status: 404, ...requestId(error.requestId),
+      }
+      throw error
+    }
+  })
+  let scopeId: string | undefined
+  checks.scope = await probe('resolve_scope_binding', async () => {
+    scopeId = await runtime.resolveScope(cwd, signal)
+    return scopeId ? check('resolve_scope_binding', 'scope_resolved', 'The Server resolved the current session Scope.', undefined, 'ok')
+      : check('resolve_scope_binding', 'unscoped', 'Scope resolution returned no usable Scope.',
+        'Check the explicit Scope override, workspace binding and Server default Scope. Doctor does not create bindings.')
+  })
+  checks.prepare = scopeId ? await probe('prepare_context', async () => {
+    const response = await runtime.client.request('prepare_context', {
+      scope_id: scopeId, query: 'PowerContext diagnostic recall check', max_bytes: 512,
+    }, signal)
+    let prepared: ReturnType<typeof validatePreparedContext>
+    try {
+      prepared = validatePreparedContext(response.value, '/v1/context/prepare', 512)
+      if (response.status !== 200) invalid('prepare_context', response, 'prepare_status')
+    } catch (error) {
+      if (error instanceof InvalidResponseError) invalid('prepare_context', response, error.issue)
+      throw error
+    }
+    return observed('prepare_context', response, prepared.status,
+      prepared.status === 'empty' ? 'The prepare route returned a valid empty result.'
+        : 'The prepare route returned valid context; Doctor discarded the content without injecting it.')
+  }) : check('prepare_context', 'scope_unavailable', 'Not checked because the current Scope could not be resolved.',
+    'Resolve the Scope check first.', 'skipped')
+  return {
+    ok: Object.values(checks).every(value => value.state === 'ok'),
+    configuration: config.summary, checks,
+    coverage: 'Read-only checks of the current configuration. Write routes are declared by the contract but not executed; processing, capture and injection are not verified by Doctor.',
+  }
+}

--- a/integrations/dsh/plugins/powercontext/src/errors.ts
+++ b/integrations/dsh/plugins/powercontext/src/errors.ts
@@ -44,12 +44,35 @@ export class TransportError extends ClientError {
 
 export class UnavailableError extends TransportError {}
 
+export const RESPONSE_ISSUES = {
+  invalid_json: 'The response body is not valid JSON.',
+  redirect: 'The operation returned a redirect; the client does not follow redirects.',
+  response_too_large: 'The response body exceeds the 1 MiB client limit.',
+  unexpected_body: 'This status requires an empty response body.',
+  prepared_object: 'PreparedContext must be a JSON object.',
+  prepared_fields: 'PreparedContext must contain exactly schema, status, content and content_bytes.',
+  prepared_schema: 'PreparedContext.schema must be powercontext.prepared-context.v1.',
+  prepared_size: 'PreparedContext.content_bytes must be a non-negative integer.',
+  prepared_empty: 'An empty PreparedContext must have null content and content_bytes equal to zero.',
+  prepared_content: 'A ready PreparedContext must contain non-empty text.',
+  prepared_bytes: 'PreparedContext.content_bytes must match the UTF-8 content size and stay within the requested budget.',
+  liveness: 'Liveness requires HTTP 200 and a JSON object with status equal to ok.',
+  readiness: 'Readiness requires status ready/degraded with HTTP 200, or not_ready with HTTP 503, and a checks object of string values.',
+  capabilities: 'Capabilities requires HTTP 200, boolean memory_extraction/handoff_generation, and string arrays for source_types/artifact_families/search_modes/context_versions.',
+  openapi: 'API discovery requires HTTP 200, an OpenAPI 3.x version and a paths object.',
+  prepare_status: 'PreparedContext requires HTTP 200.',
+} as const
+
 export class InvalidResponseError extends ClientError {
   readonly path: string
+  readonly statusCode: number | undefined
+  readonly issue: keyof typeof RESPONSE_ISSUES | undefined
 
-  constructor(path: string, requestId?: string) {
+  constructor(path: string, requestId?: string, statusCode?: number, issue?: keyof typeof RESPONSE_ISSUES) {
     super(`response from ${path} violated the API schema`, requestId)
     this.path = path
+    this.statusCode = statusCode
+    this.issue = issue
   }
 }
 

--- a/integrations/dsh/plugins/powercontext/src/index.ts
+++ b/integrations/dsh/plugins/powercontext/src/index.ts
@@ -40,7 +40,9 @@ export const Config = {
     validate(value: unknown) {
       try {
         const input = value && typeof value === 'object' ? value as PluginConfig : {}
-        return { value: resolveConfig(input) }
+        resolveConfig(input)
+        // Keep original inputs so runtime resolution can identify defaults and overrides.
+        return { value: input }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         return { issues: [{ message }] }

--- a/integrations/dsh/plugins/powercontext/src/prepared-context.ts
+++ b/integrations/dsh/plugins/powercontext/src/prepared-context.ts
@@ -36,28 +36,28 @@ export function validatePreparedContext(
   path = '/v1/context/prepare',
   maxBytes = MAX_CONTEXT_BYTES,
 ): PreparedContext {
-  if (!isRecord(response)) throw new InvalidResponseError(path)
+  if (!isRecord(response)) throw new InvalidResponseError(path, undefined, undefined, 'prepared_object')
   const keys = Object.keys(response)
   if (keys.length !== PREPARED_FIELDS.size || keys.some((key) => !PREPARED_FIELDS.has(key))) {
-    throw new InvalidResponseError(path)
+    throw new InvalidResponseError(path, undefined, undefined, 'prepared_fields')
   }
-  if (response.schema !== PREPARED_CONTEXT_SCHEMA) throw new InvalidResponseError(path)
+  if (response.schema !== PREPARED_CONTEXT_SCHEMA) throw new InvalidResponseError(path, undefined, undefined, 'prepared_schema')
   const status = response.status
   const content = response.content
   const contentBytes = response.content_bytes
   if (typeof contentBytes !== 'number' || !Number.isInteger(contentBytes) || contentBytes < 0) {
-    throw new InvalidResponseError(path)
+    throw new InvalidResponseError(path, undefined, undefined, 'prepared_size')
   }
   if (status === 'empty') {
-    if (content !== null || contentBytes !== 0) throw new InvalidResponseError(path)
+    if (content !== null || contentBytes !== 0) throw new InvalidResponseError(path, undefined, undefined, 'prepared_empty')
     return { schema: PREPARED_CONTEXT_SCHEMA, status, content: null, content_bytes: 0 }
   }
   if (status !== 'ready' || typeof content !== 'string' || !content.trim()) {
-    throw new InvalidResponseError(path)
+    throw new InvalidResponseError(path, undefined, undefined, 'prepared_content')
   }
   const encoded = Buffer.from(content, 'utf8')
   if (encoded.byteLength !== contentBytes || contentBytes > maxBytes) {
-    throw new InvalidResponseError(path)
+    throw new InvalidResponseError(path, undefined, undefined, 'prepared_bytes')
   }
   return { schema: PREPARED_CONTEXT_SCHEMA, status, content, content_bytes: contentBytes }
 }

--- a/integrations/dsh/plugins/powercontext/tests/direct-failures.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/direct-failures.spec.ts
@@ -223,20 +223,25 @@ describe('registered /pc command routing', () => {
   it('checks health and capabilities without a working Scope endpoint', async () => {
     const h = fixture(async url => new URL(url).pathname === RESOLVE_PATH
       ? Response.json({ detail: 'Not Found' }, { status: 404 })
-      : Response.json({ status: 'ready' }))
-    expect((await h.command('doctor')).kind).toBe('success')
+      : Response.json(new URL(url).pathname === '/health/live' ? { status: 'ok' } : { status: 'ready', checks: {} }))
+    const doctor = await h.command('doctor')
+    expect(doctor.kind).toBe('error')
+    expect(JSON.parse(doctor.text).checks).toMatchObject({
+      liveness: { state: 'ok' }, readiness: { state: 'ok' },
+      scope: { code: 'required_route_missing' },
+    })
     expect((await h.command('capabilities')).kind).toBe('success')
-    expect(h.calls.map(call => call.path)).toEqual(['/health/live', '/health/ready', '/v1/capabilities'])
+    expect(h.calls.some(call => call.path === '/v1/capabilities')).toBe(true)
   })
 
   it('keeps both Doctor results when one health endpoint fails', async () => {
     const h = fixture(async url => new URL(url).pathname === '/health/ready'
-      ? domainResponse(503, 'runtime_not_ready')
-      : Response.json({ status: 'alive' }))
+      ? Response.json({ status: 'not_ready', checks: { runtime: 'not_ready' } }, { status: 503 })
+      : Response.json({ status: 'ok' }))
     const result = await h.command('doctor')
     expect(result.kind).toBe('error')
-    expect(JSON.parse(result.text).data).toMatchObject({
-      live: { ok: true }, ready: { ok: false, code: 'unavailable' },
+    expect(JSON.parse(result.text).checks).toMatchObject({
+      liveness: { state: 'ok' }, readiness: { state: 'failed', code: 'not_ready' },
     })
   })
 

--- a/integrations/dsh/plugins/powercontext/tests/doctor.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/doctor.spec.ts
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { PowerContextClient, type FetchFn } from '../src/client.ts'
+import { handlePcCommand } from '../src/commands.ts'
+import { resolveConfig, type PluginConfig } from '../src/config.ts'
+import { OPERATIONS } from '../src/operations.generated.ts'
+import { resolveScopeId } from '../src/scope.ts'
+
+const PRIVATE = 'private-response-marker'
+const EMPTY = { schema: 'powercontext.prepared-context.v1', status: 'empty', content: null, content_bytes: 0 }
+const CAPABILITIES = {
+  source_types: ['content'], artifact_families: ['memory'], memory_extraction: false,
+  handoff_generation: false, search_modes: ['auto', 'fts'], context_versions: [EMPTY.schema],
+}
+function contract() {
+  const paths: Record<string, Record<string, unknown>> = {}
+  for (const [operationId, spec] of Object.entries(OPERATIONS)) {
+    (paths[spec.path] ??= {})[spec.method.toLowerCase()] = { operationId }
+  }
+  return { openapi: '3.1.0', paths }
+}
+function healthy(path: string) {
+  if (path === '/health/live') return Response.json({ status: 'ok' })
+  if (path === '/health/ready') return Response.json({ status: 'ready', checks: { runtime: 'ready', database: 'ready' } })
+  if (path === '/openapi.json') return Response.json(contract())
+  if (path === '/v1/capabilities') return Response.json(CAPABILITIES)
+  if (path === '/v1/scope-bindings/resolve') return Response.json({ scope_id: 'scp_fixture' })
+  if (path === '/v1/context/prepare') return Response.json(EMPTY)
+  throw new Error('Doctor attempted an unexpected operation: ' + path)
+}
+function fixture(override?: FetchFn, config: PluginConfig = {}, env: NodeJS.ProcessEnv = {}) {
+  const calls: Array<{ path: string; init: RequestInit }> = []
+  const resolved = resolveConfig(config, env)
+  const client = new PowerContextClient({ ...resolved, fetch: async (url, init) => {
+    const path = new URL(url).pathname
+    calls.push({ path, init })
+    return override ? override(url, init) : healthy(path)
+  } })
+  const runtime = {
+    config: resolved, client,
+    resolveScope: (cwd?: string, signal?: AbortSignal) => resolveScopeId(client, cwd, resolved.scopeId, signal),
+    log: () => {},
+  }
+  return {
+    calls, runtime,
+    async doctor(signal?: AbortSignal) {
+      const result = await handlePcCommand('doctor', runtime, '/fixture/workspace', signal)
+      return { kind: result.kind, ...JSON.parse(result.text) }
+    },
+  }
+}
+
+describe('read-only DSH Doctor', () => {
+  it('separates model-disabled capabilities and empty prepare from failed infrastructure', async () => {
+    const h = fixture()
+    const result = await h.doctor()
+    expect(result).toMatchObject({
+      ok: true, kind: 'success',
+      checks: {
+        liveness: { state: 'ok', code: 'live' }, readiness: { state: 'ok', code: 'ready' },
+        routes: { state: 'ok', code: 'routes_declared' }, scope: { state: 'ok', code: 'scope_resolved' },
+        capabilities: { state: 'ok', code: 'extraction_disabled' },
+        prepare: { state: 'ok', code: 'empty' },
+      },
+    })
+    expect(result.coverage).toContain('not executed')
+    expect(h.calls.every(({ path }) => [
+      '/health/live', '/health/ready', '/openapi.json', '/v1/capabilities',
+      '/v1/scope-bindings/resolve', '/v1/context/prepare',
+    ].includes(path))).toBe(true)
+    const payload = JSON.parse(String(h.calls.find(c => c.path.endsWith('/prepare'))!.init.body))
+    expect(payload.scope_id).toBe('scp_fixture')
+    expect(payload.query).not.toContain('/fixture/workspace')
+  })
+
+  it.each([
+    [401, 'unauthorized', 'authentication_failed'],
+    [403, 'forbidden', 'authorization_failed'],
+    [404, 'scope_not_found', 'scope_not_found'],
+    [404, undefined, 'required_route_missing'],
+    [404, PRIVATE, 'unclassified_not_found'],
+  ])('identifies Scope resolution HTTP %s / %s without hiding health', async (status, code, expected) => {
+    const h = fixture(async url => new URL(url).pathname.endsWith('/resolve')
+      ? Response.json({ error: { code, message: PRIVATE } }, { status: status as number, headers: { 'X-PowerContext-Request-ID': 'req-scope' } })
+      : healthy(new URL(url).pathname))
+    const result = await h.doctor()
+    expect(result).toMatchObject({
+      ok: false, kind: 'error', checks: {
+        liveness: { state: 'ok' }, readiness: { state: 'ok' },
+        scope: { state: 'failed', code: expected, operation: 'resolve_scope_binding', http_status: status, request_id: 'req-scope' },
+        prepare: { state: 'skipped', code: 'scope_unavailable' },
+      },
+    })
+    expect(result.checks.scope.recovery.length).toBeGreaterThan(0)
+    expect(JSON.stringify(result)).not.toContain(PRIVATE)
+    expect(h.calls.some(c => c.path.endsWith('/prepare'))).toBe(false)
+  })
+
+  it('locates a missing prepare route even when health and the published contract pass', async () => {
+    const h = fixture(async url => new URL(url).pathname.endsWith('/prepare')
+      ? Response.json({ detail: PRIVATE }, { status: 404 }) : healthy(new URL(url).pathname))
+    expect(await h.doctor()).toMatchObject({
+      ok: false, checks: { routes: { state: 'ok' }, prepare: { code: 'required_route_missing', operation: 'prepare_context' } },
+    })
+  })
+
+  it('identifies a missing declared write route without executing it', async () => {
+    const document = contract()
+    delete document.paths['/v1/sources/content']
+    const h = fixture(async url => new URL(url).pathname === '/openapi.json'
+      ? Response.json(document) : healthy(new URL(url).pathname))
+    const result = await h.doctor()
+    expect(result).toMatchObject({ ok: false, checks: { routes: { code: 'required_route_undeclared' } } })
+    expect(result.checks.routes.operations).toContain('capture_content_source')
+    expect(h.calls.some(c => c.path === '/v1/sources/content')).toBe(false)
+  })
+
+  it('keeps missing discovery evidence unchecked, rather than claiming compatibility', async () => {
+    const h = fixture(async url => new URL(url).pathname === '/openapi.json'
+      ? Response.json({ detail: PRIVATE }, { status: 404 }) : healthy(new URL(url).pathname))
+    expect(await h.doctor()).toMatchObject({
+      ok: false, checks: { routes: { state: 'skipped', code: 'contract_unavailable' }, prepare: { state: 'ok' } },
+    })
+  })
+
+  it.each([
+    [503, 'not_ready', 'unavailable', 'failed'],
+    [200, 'degraded', 'timeout', 'degraded'],
+  ])('preserves readiness %s dependency failures', async (status, readiness, dependency, state) => {
+    const h = fixture(async url => new URL(url).pathname === '/health/ready'
+      ? Response.json({ status: readiness, checks: { runtime: 'ready', database: 'ready', 'inference.generation': dependency,
+        [PRIVATE]: PRIVATE } }, { status: status as number }) : healthy(new URL(url).pathname))
+    const result = await h.doctor()
+    expect(result).toMatchObject({ ok: false, checks: {
+      liveness: { state: 'ok' }, readiness: { state, code: readiness, dependencies: { 'inference.generation': dependency } },
+    } })
+    expect(result.checks.readiness.recovery).toContain('POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL')
+    expect(JSON.stringify(result)).not.toContain(PRIVATE)
+  })
+
+  it.each([{ service: PRIVATE }, { status: 'not_ready', checks: {} }])('rejects HTTP 200 with invalid health semantics', async body => {
+    const h = fixture(async url => new URL(url).pathname.startsWith('/health/')
+      ? Response.json(body) : healthy(new URL(url).pathname))
+    expect(await h.doctor()).toMatchObject({ ok: false, checks: {
+      liveness: { code: 'invalid_response' }, readiness: { code: 'invalid_response' },
+    } })
+  })
+
+  it('uses the effective environment configuration without revealing credentials or path prefixes', async () => {
+    const h = fixture(async (url, init) => {
+      expect(new URL(url).origin).toBe('http://127.0.0.1:9009')
+      expect(new Headers(init.headers).get('Authorization')).toBe('Bearer ' + PRIVATE)
+      return healthy(new URL(url).pathname.replace('/' + PRIVATE, ''))
+    }, { baseUrl: 'http://127.0.0.1:8000' }, {
+      POWERCONTEXT_DSH_BASE_URL: 'http://127.0.0.1:9009/' + PRIVATE,
+      POWERCONTEXT_DSH_AUTHORIZATION: 'Bearer ' + PRIVATE,
+    })
+    const result = await h.doctor()
+    expect(result.configuration).toMatchObject({
+      observation: 'running_plugin',
+      endpoint: { origin: 'http://127.0.0.1:9009', source: 'environment', path_prefix: true },
+      authorization: { configured: true, source: 'environment' },
+    })
+    expect(JSON.stringify(result)).not.toContain(PRIVATE)
+  })
+
+  it('rejects malformed endpoint configuration without making requests', async () => {
+    const h = fixture(undefined, { baseUrl: 'http://user:' + PRIVATE + '@localhost/?token=' + PRIVATE })
+    const result = await h.doctor()
+    expect(result).toMatchObject({ ok: false, checks: { configuration: { code: 'invalid_endpoint' } } })
+    expect(JSON.stringify(result)).not.toContain(PRIVATE)
+    expect(h.calls).toEqual([])
+  })
+
+  it.each([
+    [() => new TypeError(PRIVATE), 'connection_failed'],
+    [() => new DOMException(PRIVATE, 'TimeoutError'), 'request_timeout'],
+    [() => new TypeError(PRIVATE, { cause: { code: 'ECONNREFUSED' } }), 'connection_refused'],
+    [() => new TypeError(PRIVATE, { cause: { code: 'ENOTFOUND' } }), 'dns_lookup_failed'],
+    [() => new TypeError(PRIVATE, { cause: { code: 'CERT_HAS_EXPIRED' } }), 'tls_verification_failed'],
+  ])('identifies transport failures without returning their raw messages', async (error, code) => {
+    const h = fixture(async () => { throw error() })
+    const result = await h.doctor()
+    expect(result).toMatchObject({ ok: false, checks: { liveness: { code, operation: 'get_liveness' } } })
+    expect(JSON.stringify(result)).not.toContain(PRIVATE)
+  })
+
+  it('honors cancellation without starting later requests', async () => {
+    const h = fixture()
+    const controller = new AbortController()
+    controller.abort()
+    const result = await h.doctor(controller.signal)
+    expect(result).toMatchObject({ ok: false, checks: { liveness: { code: 'cancelled' } } })
+    expect(h.calls).toEqual([])
+  })
+
+  it('stops after cancellation during an active request, including a non-Error abort reason', async () => {
+    const controller = new AbortController()
+    const h = fixture(async () => {
+      controller.abort(PRIVATE)
+      return Response.json({ status: 'ok' })
+    })
+    const result = await h.doctor(controller.signal)
+    expect(result).toMatchObject({ ok: false, checks: { liveness: { code: 'cancelled' } } })
+    expect(h.calls.map(c => c.path)).toEqual(['/health/live'])
+    expect(JSON.stringify(result)).not.toContain(PRIVATE)
+  })
+
+  it.each([
+    ['/health/live', 'liveness', '<html>private-response-marker</html>', 'invalid_json'],
+    ['/v1/context/prepare', 'prepare', JSON.stringify({ ...EMPTY, content_bytes: 100 }), 'prepared_empty'],
+  ])('retains request identity when %s returns malformed data', async (path, layer, body, issue) => {
+    const h = fixture(async url => new URL(url).pathname === path
+      ? new Response(body, { status: 200, headers: { 'X-PowerContext-Request-ID': 'req-malformed' } })
+      : healthy(new URL(url).pathname))
+    const result = await h.doctor()
+    expect(result.checks[layer]).toMatchObject({ code: 'invalid_response', protocol_issue: issue, http_status: 200, request_id: 'req-malformed' })
+    expect(JSON.stringify(result)).not.toContain(PRIVATE)
+  })
+
+  it('does not turn ordinary readiness tool failures into successful results', async () => {
+    const h = fixture(async () => Response.json({ status: 'not_ready', checks: { database: 'unavailable' } }, { status: 503 }))
+    await expect(h.runtime.client.request('get_readiness')).rejects.toMatchObject({ statusCode: 503 })
+  })
+
+  it('identifies a Server context schema that the plugin cannot consume', async () => {
+    const h = fixture(async url => new URL(url).pathname === '/v1/capabilities'
+      ? Response.json({ ...CAPABILITIES, context_versions: ['unsupported'] }) : healthy(new URL(url).pathname))
+    expect(await h.doctor()).toMatchObject({ ok: false, checks: { capabilities: { code: 'unsupported_context_schema', http_status: 200 } } })
+  })
+
+  it('never returns recalled content or injects a snapshot from a diagnostic probe', async () => {
+    const h = fixture(async url => new URL(url).pathname.endsWith('/prepare')
+      ? Response.json({ ...EMPTY, status: 'ready', content: PRIVATE, content_bytes: Buffer.byteLength(PRIVATE) })
+      : healthy(new URL(url).pathname))
+    const result = await h.doctor()
+    expect(result.checks.prepare).toMatchObject({ state: 'ok', code: 'ready' })
+    expect(JSON.stringify(result)).not.toContain(PRIVATE)
+  })
+})

--- a/integrations/dsh/plugins/powercontext/tests/e2e/unscoped-session.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/e2e/unscoped-session.spec.ts
@@ -236,12 +236,14 @@ describe('plugin runtime with header.cwd === undefined', () => {
     expect(status.kind).toBe('error')
     expect(status.text).toContain('scope=unresolved')
     const doctor = await command({ ...invocation(), rawInput: 'doctor' })
-    expect(doctor.kind).toBe('success')
-    expect(JSON.parse(doctor.text).data).toMatchObject({ live: { ok: true }, ready: { ok: true } })
+    expect(doctor.kind).toBe('error')
+    expect(JSON.parse(doctor.text).checks).toMatchObject({
+      liveness: { state: 'ok' }, readiness: { state: 'ok' },
+      scope: { state: 'failed', code: 'scope_not_found' },
+      prepare: { state: 'skipped', code: 'scope_unavailable' },
+    })
     expect((await command({ ...invocation(), rawInput: 'capabilities' })).kind).toBe('success')
-    expect(calls.map(call => call.path)).toEqual([
-      '/v1/scope-bindings/resolve', '/v1/scope-bindings/resolve', '/v1/scope-bindings/resolve',
-      '/health/live', '/health/ready', '/v1/capabilities',
-    ])
+    expect(calls.some(call => call.path === '/v1/context/prepare')).toBe(false)
+    expect(calls.some(call => call.path === '/v1/sources/content')).toBe(false)
   })
 })

--- a/integrations/dsh/plugins/powercontext/tests/recall-fail-open.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/recall-fail-open.spec.ts
@@ -21,6 +21,7 @@ import { runRecallPreStep, type RecallInput } from '../src/recall.ts'
 import type { ResolvedConfig } from '../src/config.ts'
 
 const config: ResolvedConfig = {
+  sources: { baseUrl: 'plugin', authorization: 'default', scopeId: 'plugin' },
   baseUrl: 'http://127.0.0.1:8000',
   authorization: undefined,
   scopeId: 'project:demo',

--- a/integrations/dsh/plugins/powercontext/tests/runtime/README.md
+++ b/integrations/dsh/plugins/powercontext/tests/runtime/README.md
@@ -27,6 +27,13 @@ construction, model request assembly, and session persistence are not replaced. 
 scripted OpenAI-compatible streaming replies and Server inference decisions. A loopback proxy can inject HTTP
 failures at individual PowerContext endpoints.
 
+The setup scenario first runs `powercontext setup dsh --source <this checkout>` with the pinned DSH executable
+and a clean DSH home. It verifies Web-profile registration through `powercontext doctor dsh --json`, then loads
+that installed package's distributable files into the SDK profile. The Server and plugin use the same checkout.
+A test-only loopback adapter invokes the real host command service because the pinned SDK protocol only exposes
+prompts. It verifies `/pc doctor` with an environment URL overriding an unusable patch URL, preserves health when
+Scope authentication fails, and confirms that Doctor makes no capture or flush requests.
+
 A test observer subscribes to the real Cordis logger's public exporter API and writes only PowerContext diagnostics
 to the isolated home. This verifies native logging without replacing the logger. Default host profiles need an
 exporter with warning level enabled before these records appear in a terminal.
@@ -34,6 +41,7 @@ exporter with warning level enabled before these records appear in a terminal.
 The scenarios cover:
 
 - automatic Source capture, Server processing into Memory, fresh-session recall, model input, and durable snapshot metadata;
+- clean CLI installation, standalone observation limits, and in-host Doctor configuration/route/authentication checks;
 - Source idempotency, no duplicate snapshot injection, and matching section/content text;
 - Scope business and route failures, authentication failure, unavailable Server, continued conversation, and a real named tool result;
 - independent prepare/capture/flush failure, recovery, host restart, and configured Scope isolation.

--- a/integrations/dsh/plugins/powercontext/tests/runtime/command-observer.mjs
+++ b/integrations/dsh/plugins/powercontext/tests/runtime/command-observer.mjs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createServer } from 'node:http'
+import { writeFileSync } from 'node:fs'
+
+export const inject = ['agents', 'commands']
+
+// The SDK only exposes prompts. Exercise the real command service through a local test adapter.
+export async function apply(ctx, config) {
+  const server = createServer(async (req, res) => {
+    try {
+      const sessionId = new URL(req.url, 'http://localhost').searchParams.get('session')
+      const agent = ctx.agents.get(sessionId)
+      if (!agent) throw new Error('test session is unavailable')
+      const execution = await ctx.commands.execute(agent, '/pc doctor', [], AbortSignal.timeout(30000))
+      if (!execution) throw new Error('installed /pc command is unavailable')
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify(execution.result))
+    } catch (error) {
+      res.writeHead(500)
+      res.end(String(error))
+    }
+  })
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  writeFileSync(config.addressFile, 'http://127.0.0.1:' + server.address().port)
+  ctx.effect(() => () => new Promise((resolve, reject) => {
+    server.closeAllConnections()
+    server.close(error => error ? reject(error) : resolve())
+  }))
+}

--- a/integrations/dsh/plugins/powercontext/tests/runtime/fixture.mjs
+++ b/integrations/dsh/plugins/powercontext/tests/runtime/fixture.mjs
@@ -162,15 +162,18 @@ export async function environment({ realModel } = {}) {
   }
   const { scope_id: scopeId } = await api('/v1/scopes/default')
   const harnesses = []
-  function harness(config = {}) {
+  function harness(config = {}, options = {}) {
     const dshHome = mkdtempSync(join(home, 'host-'))
     const workspace = join(dshHome, 'workspace')
     mkdirSync(workspace)
     // Copy the distributable files, not TypeScript source or development peers.
     const installed = join(dshHome, 'profiles/sdk/node_modules/powercontext-dsh')
     mkdirSync(installed, { recursive: true })
-    for (const entry of ['lib', 'package.json', 'cordis.patch.yml']) cpSync(join(pluginRoot, entry), join(installed, entry), { recursive: true })
+    for (const entry of ['lib', 'package.json', 'cordis.patch.yml']) cpSync(join(options.plugin ?? pluginRoot, entry), join(installed, entry), { recursive: true })
     const patch = join(dshHome, 'test.patch.json')
+    const commandAddress = join(dshHome, 'command-address.txt')
+    const commandObserver = join(dshHome, 'command-observer.mjs')
+    if (options.commands) cpSync(join(import.meta.dirname, 'command-observer.mjs'), commandObserver)
     const diagnosticsFile = join(dshHome, 'diagnostics.jsonl')
     const loggerObserver = join(dshHome, 'logger-observer.mjs')
     // Observe the real Cordis logger through its public exporter API.
@@ -185,6 +188,10 @@ export function apply(ctx) {
 }`)
     writeFileSync(patch, JSON.stringify([
       { insert: [{ id: 'diagnostic-observer', name: pathToFileURL(loggerObserver).href }] },
+      ...options.commands ? [{ insert: [{ id: 'command-observer',
+        name: pathToFileURL(commandObserver).href,
+        config: { addressFile: commandAddress },
+      }] }] : [],
       { id: 'skill-filesystem', config: { includeDefaultRoots: false, watch: false } },
       { id: 'session-persistence-jsonl', config: { root: join(dshHome, 'sessions'), compression: 'none' } },
       { id: 'llm-deepseek', config: { baseURL: model.url + '/v1', apiKeyEnv: 'DEEPSEEK_API_KEY', thinking: 'disabled' } },
@@ -194,7 +201,7 @@ export function apply(ctx) {
     ]))
     const processEnv = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('POWERCONTEXT_DSH_')))
     const env = { ...processEnv, DSH_HOME: dshHome, DSH_PROFILE: 'sdk', DEEPSEEK_API_KEY: 'runtime-fixture',
-      DEEPSEEK_BASE_URL: model.url + '/v1', DSH_TELEMETRY_DISABLED: '1' }
+      DEEPSEEK_BASE_URL: model.url + '/v1', DSH_TELEMETRY_DISABLED: '1', ...options.env }
     const instance = new DeepSeekHarness({
       dshBin: process.env.DSH_TEST_BIN ?? dshBin, dshHome, patches: [patch], cwd: workspace, processCwd: workspace,
       provider: 'deepseek-official', model: realModel?.model ?? 'deepseek-v4-flash', maxTokens: 128,
@@ -204,10 +211,16 @@ export function apply(ctx) {
     harnesses.push(instance)
     const diagnostics = () => existsSync(diagnosticsFile)
       ? readFileSync(diagnosticsFile, 'utf8').trim().split('\n').map(line => JSON.parse(line)) : []
-    return { instance, dshHome, workspace, installed, patch, env, diagnostics }
+    const doctor = async sessionId => {
+      const response = await fetch(readFileSync(commandAddress, 'utf8') + '/?session=' + encodeURIComponent(sessionId))
+      if (!response.ok) throw new Error(await response.text())
+      const result = await response.json()
+      return { kind: result.kind, ...JSON.parse(result.text) }
+    }
+    return { instance, dshHome, workspace, installed, patch, env, diagnostics, doctor }
   }
   return {
-    home, api, scopeId, calls, modelRequests, harness,
+    home, api, scopeId, calls, modelRequests, harness, baseUrl: proxy.url,
     setFault(value) { fault = value },
     async close() {
       const results = await Promise.allSettled(harnesses.map(instance => instance.close()))

--- a/integrations/dsh/plugins/powercontext/tests/runtime/runtime.test.mjs
+++ b/integrations/dsh/plugins/powercontext/tests/runtime/runtime.test.mjs
@@ -19,11 +19,19 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { test } from 'node:test'
 import { environment, injected, CANARY } from './fixture.mjs'
+import { installIntoCleanHome } from './setup-fixture.mjs'
 
-test('real DSH loads the built plugin and recalls processed Source in another session', { timeout: 120000 }, async () => {
+test('documented setup installs the matched plugin, diagnoses the running host and recalls processed Source', { timeout: 240000 }, async () => {
   const env = await environment()
   try {
-    const { instance, dshHome } = env.harness()
+    const installation = await installIntoCleanHome(env.home)
+    assert.ok(installation.setup.includes('powercontext-dsh'))
+    assert.equal(installation.doctor.checks.plugin.checks.registration, 'present')
+    assert.equal(installation.doctor.checks.plugin.checks.running_host_configuration, 'not_observed')
+    const { instance, dshHome, doctor } = env.harness({ baseUrl: 'http://127.0.0.1:1' }, {
+      plugin: installation.plugin, commands: true,
+      env: { POWERCONTEXT_DSH_BASE_URL: env.baseUrl },
+    })
     const first = await instance.run('For this project: ' + CANARY + ' Reply with an acknowledgement.')
     assert.ok(first.finalResponse)
     assert.equal(injected(first).length, 0)
@@ -31,6 +39,25 @@ test('real DSH loads the built plugin and recalls processed Source in another se
     assert.ok(env.calls.some(call => call.path === '/v1/memory/flush' && call.status === 200))
     const memory = await env.api('/v1/memory/entries/list', { scope_id: env.scopeId })
     assert.ok(JSON.stringify(memory).includes(CANARY))
+    const diagnosedAt = env.calls.length
+    const report = await doctor(first.sessionId)
+    assert.equal(report.ok, true, JSON.stringify(report))
+    assert.equal(report.kind, 'success')
+    assert.equal(report.configuration.endpoint.origin, env.baseUrl)
+    assert.equal(report.configuration.endpoint.source, 'environment')
+    assert.equal(report.configuration.authorization.source, 'default')
+    assert.equal(report.configuration.scope.source, 'default')
+    assert.equal(report.checks.capabilities.code, 'extraction_enabled')
+    assert.equal(report.checks.routes.code, 'routes_declared')
+    assert.ok(env.calls.slice(diagnosedAt).every(call => !['/v1/sources/content', '/v1/memory/flush'].includes(call.path)))
+    env.setFault({ path: '/v1/scope-bindings/resolve', status: 401 })
+    const denied = await doctor(first.sessionId)
+    assert.equal(denied.kind, 'error')
+    assert.equal(denied.checks.liveness.state, 'ok')
+    assert.equal(denied.checks.scope.code, 'authentication_failed')
+    assert.equal(denied.checks.scope.operation, 'resolve_scope_binding')
+    assert.equal(denied.checks.prepare.state, 'skipped')
+    env.setFault(undefined)
     const capture = env.calls.find(call => call.path === '/v1/sources/content')
     const replay = await env.api('/v1/sources/content', capture.body)
     assert.equal(replay.position, capture.result.position)

--- a/integrations/dsh/plugins/powercontext/tests/runtime/setup-fixture.mjs
+++ b/integrations/dsh/plugins/powercontext/tests/runtime/setup-fixture.mjs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { execFile } from 'node:child_process'
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs'
+import { delimiter, join } from 'node:path'
+import { promisify } from 'node:util'
+import { defaultPowerContextRoot } from '../../scripts/e2e-server.mjs'
+import { dshBin } from './fixture.mjs'
+
+export async function installIntoCleanHome(home) {
+  const bin = join(home, 'bin')
+  mkdirSync(bin)
+  const windows = process.platform === 'win32'
+  const launcher = join(bin, windows ? 'dsh.cmd' : 'dsh')
+  const quote = value => "'" + value.replaceAll("'", "'\"'\"'") + "'"
+  writeFileSync(launcher, windows
+    ? '@echo off\r\n"' + process.execPath + '" "' + dshBin + '" %*\r\n'
+    : '#!/bin/sh\nexec ' + quote(process.execPath) + ' ' + quote(dshBin) + ' "$@"\n')
+  if (!windows) chmodSync(launcher, 0o755)
+  const root = defaultPowerContextRoot()
+  const env = {
+    ...process.env, CI: 'true', DSH_HOME: join(home, 'installed-dsh'),
+    POWERCONTEXT_HOME: join(home, 'installed-powercontext'),
+    PATH: bin + delimiter + process.env.PATH, DSH_TELEMETRY_DISABLED: '1',
+  }
+  const cli = async args => (await promisify(execFile)(windows ? 'uv.exe' : 'uv',
+    ['run', '--no-sync', 'powercontext', ...args],
+    { cwd: root, env, windowsHide: true, timeout: 150000, maxBuffer: 4 * 1024 * 1024 })).stdout
+  const setup = await cli(['setup', 'dsh', '--source', root])
+  const doctor = await cli(['doctor', 'dsh', '--json'])
+  return { setup, doctor: JSON.parse(doctor), plugin: join(env.DSH_HOME, 'profiles/web/node_modules/powercontext-dsh') }
+}

--- a/src/powercontext/cli/config.py
+++ b/src/powercontext/cli/config.py
@@ -27,6 +27,7 @@ from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from importlib.metadata import version
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Never
 from urllib.parse import urlsplit
@@ -938,7 +939,14 @@ def _print_next_steps(path: Path) -> None:
     quoted = shlex.quote(str(path.resolve()))
     typer.echo(f"\nStart Server:\n  powercontext server run --env-file {quoted}")
     typer.secho("\nSupported Coding Agents (choose one):", bold=True, fg=typer.colors.CYAN)
-    for name, setup, launch in AGENTS.values():
+    for host, (name, setup, launch) in AGENTS.items():
+        if host == "dsh":
+            installed = version("powercontext")
+            setup = (
+                f"powercontext setup dsh --source oceanbase/powercontext --ref powercontext-v{installed}"
+                if re.fullmatch(r"\d+\.\d+\.\d+", installed)
+                else "powercontext setup dsh --source /path/to/matching-powercontext-checkout"
+            )
         typer.echo(f"\n{name}:\n  {setup}\n  set -a; . {quoted}; set +a; {launch}")
 
 

--- a/src/powercontext/cli/dsh.py
+++ b/src/powercontext/cli/dsh.py
@@ -114,8 +114,27 @@ def run_dsh_diagnostics() -> dict[str, Diagnostic]:
     try:
         output = _run_dsh("--profile", DSH_PROFILE, "--dump-config")
     except SetupError as error:
+        cause = error.__cause__
+        checks = {"dump_config": "failed"}
+        detail = "dsh --profile web --dump-config failed"
+        if isinstance(cause, subprocess.TimeoutExpired):
+            checks["dump_config"] = "timeout"
+            detail = "dsh --profile web --dump-config exceeded the 120-second deadline"
+        elif isinstance(cause, subprocess.CalledProcessError):
+            checks["exit_code"] = str(cause.returncode)
+            detail = f"dsh --profile web --dump-config exited with code {cause.returncode}"
+        elif isinstance(cause, OSError):
+            checks["dump_config"] = "launch_failed"
+            detail = "could not launch dsh --profile web --dump-config; verify the executable and its permissions"
         return {
-            "dsh": Diagnostic(status=DiagnosticStatus.FAILED, detail=str(error)),
+            "dsh": Diagnostic(
+                status=DiagnosticStatus.FAILED,
+                detail=(
+                    f"{detail}; inspect the Web profile locally for configuration "
+                    "or plugin-load errors. Raw host output is withheld because it can contain credentials."
+                ),
+                checks=checks,
+            ),
             "plugin": Diagnostic(status=DiagnosticStatus.SKIPPED, detail="plugin list is unavailable"),
         }
     installed = plugin_id_installed(output)
@@ -123,7 +142,20 @@ def run_dsh_diagnostics() -> dict[str, Diagnostic]:
         "dsh": Diagnostic(status=DiagnosticStatus.OK, detail=executable),
         "plugin": Diagnostic(
             status=DiagnosticStatus.OK if installed else DiagnosticStatus.FAILED,
-            detail=(f"{DSH_PLUGIN_NAME} is installed" if installed else "PowerContext DSH plugin is not installed"),
+            detail=(
+                f"{DSH_PLUGIN_NAME} is registered in the Web profile. This standalone check cannot observe "
+                "the running DSH process environment or overrides; run /pc doctor inside that session."
+                if installed
+                else "PowerContext DSH plugin is not registered in the Web profile; run powercontext setup dsh."
+            ),
+            checks={
+                "registration": "present" if installed else "missing",
+                "running_host_configuration": "not_observed",
+                "server_liveness": "not_checked",
+                "server_readiness": "not_checked",
+                "route_compatibility": "not_checked",
+                "session_scope": "not_checked",
+            },
         ),
     }
 
@@ -228,7 +260,9 @@ def _run_dsh(*arguments: str) -> str:
         detail = (
             (completed.stderr or "").strip() or (completed.stdout or "").strip() or f"exit code {completed.returncode}"
         )
-        raise SetupError.command_failed(command, detail)
+        raise SetupError.command_failed(command, detail) from subprocess.CalledProcessError(
+            completed.returncode, command
+        )
     return completed.stdout or ""
 
 

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -45,14 +46,29 @@ def test_init_asks_for_protocol_endpoint_key_and_plain_model_name(tmp_path: Path
     assert "OpenRouter" not in result.output
     assert "Configuration" in result.output
     assert "Supported Coding Agents (choose one)" in result.output
-    for name, setup, launch in config_cli.AGENTS.values():
+    for host, (name, setup, launch) in config_cli.AGENTS.items():
         assert name in result.output
-        assert setup in result.output
+        if host != "dsh":
+            assert setup in result.output
         assert launch in result.output
     values = config_cli.parse_environment(environment.read_text(encoding="utf-8"))
     assert values["OPENAI_API_KEY"] == "shared-secret"
     assert values["OPENAI_BASE_URL"] == "https://api.openai.com/v1"
     assert values["POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL"] == "openai-chat:gpt-4.1-mini"
+
+
+@pytest.mark.parametrize("installed", ["0.2.0", "0.2.1.dev1+g1234567"])
+def test_init_matches_dsh_setup_to_installed_server(installed: str, tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(config_cli, "version", lambda _name: installed)
+    monkeypatch.setattr(config_cli, "collect_configuration", lambda **_kwargs: _configuration())
+    result = CliRunner().invoke(config_cli.app, ["init", "--output", str(tmp_path / "server.env")], input="\n")
+    assert result.exit_code == 0
+    command = next(line.strip() for line in result.output.splitlines() if "powercontext setup dsh" in line)
+    if installed == "0.2.0":
+        assert command.endswith("--ref powercontext-v0.2.0")
+    else:
+        assert "--source /path/to/matching-powercontext-checkout" in command
+    assert "--ref master" not in command
 
 
 def test_arbitrary_model_providers_and_environment_variables_are_not_rejected() -> None:
@@ -106,7 +122,8 @@ def test_init_validate_and_show_round_trip_managed_environment(
     )
 
     assert generated.exit_code == 0
-    assert environment.stat().st_mode & 0o777 == 0o600
+    if os.name != "nt":  # Windows does not implement POSIX owner/group permission bits.
+        assert environment.stat().st_mode & 0o777 == 0o600
     generated_text = environment.read_text(encoding="utf-8")
     assert config_cli.MANAGED_BEGIN in generated_text
     assert "# generation-environment=OPENAI_API_KEY" in generated_text

--- a/tests/test_dsh_cli.py
+++ b/tests/test_dsh_cli.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from subprocess import CompletedProcess
+from subprocess import CompletedProcess, TimeoutExpired
 from unittest.mock import Mock
 
 import pytest
@@ -125,7 +125,7 @@ def test_doctor_dsh_requires_the_plugin_id_field(monkeypatch) -> None:
     result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "dsh"])
 
     assert result.exit_code == 1
-    assert "plugin: failed - PowerContext DSH plugin is not installed" in result.output
+    assert "plugin: failed - PowerContext DSH plugin is not registered" in result.output
 
 
 def test_doctor_dsh_reports_an_installed_plugin(monkeypatch) -> None:
@@ -143,8 +143,64 @@ def test_doctor_dsh_reports_an_installed_plugin(monkeypatch) -> None:
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["ok"] is True
-    assert payload["checks"]["plugin"] == {
-        "ok": True,
-        "status": "ok",
-        "detail": "powercontext-dsh is installed",
-    }
+    plugin = payload["checks"]["plugin"]
+    assert plugin["ok"] is True
+    assert plugin["checks"]["registration"] == "present"
+    assert plugin["checks"]["running_host_configuration"] == "not_observed"
+    assert plugin["checks"]["server_readiness"] == "not_checked"
+    assert "/pc doctor" in plugin["detail"]
+
+
+def test_doctor_dsh_does_not_expose_host_config_or_claim_to_check_its_server(monkeypatch) -> None:
+    import powercontext.cli.dsh as dsh_cli
+
+    marker = "private-dsh-config-marker"
+    monkeypatch.setattr(dsh_cli, "which", lambda _name: "/usr/bin/dsh")
+    monkeypatch.setattr(
+        dsh_cli,
+        "_run_dsh",
+        lambda *_args: f"- id: powercontext-dsh\n  config:\n    baseUrl: http://unreachable/{marker}\n",
+    )
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "dsh", "--json"])
+    assert result.exit_code == 0
+    assert marker not in result.output
+    checks = json.loads(result.output)["checks"]["plugin"]["checks"]
+    assert checks["server_liveness"] == "not_checked"
+    assert checks["route_compatibility"] == "not_checked"
+
+
+def test_doctor_dsh_redacts_config_dump_failures(monkeypatch) -> None:
+    import powercontext.cli.dsh as dsh_cli
+
+    monkeypatch.setattr(dsh_cli, "which", lambda _name: "/usr/bin/dsh")
+    monkeypatch.setattr(
+        dsh_cli,
+        "_run_dsh",
+        Mock(side_effect=SetupError.command_failed(["dsh", "--dump-config"], "private-dsh-config-marker")),
+    )
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "dsh"])
+    assert result.exit_code == 1
+    assert "private-dsh-config-marker" not in result.output
+    assert "dump-config failed" in result.output
+
+
+@pytest.mark.parametrize("timeout", [False, True])
+def test_doctor_dsh_identifies_config_dump_exit_and_timeout(monkeypatch, timeout: bool) -> None:
+    import powercontext.cli.dsh as dsh_cli
+
+    monkeypatch.setattr(dsh_cli, "which", lambda _name: "/usr/bin/dsh")
+    if timeout:
+        subprocess_run = Mock(side_effect=TimeoutExpired("dsh", 120, output="private-config"))
+    else:
+        subprocess_run = Mock(return_value=CompletedProcess(["dsh"], 7, "", "private-config"))
+    monkeypatch.setattr(dsh_cli.subprocess, "run", subprocess_run)
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "dsh", "--json"])
+    assert result.exit_code == 1
+    assert "private-config" not in result.output
+    check = json.loads(result.output)["checks"]["dsh"]
+    if timeout:
+        assert check["checks"]["dump_config"] == "timeout"
+        assert "120-second deadline" in check["detail"]
+    else:
+        assert check["checks"]["exit_code"] == "7"
+        assert "exited with code 7" in check["detail"]

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -1054,4 +1054,4 @@ def test_doctor_dsh_requires_the_installed_plugin(monkeypatch) -> None:
 
     assert result.exit_code == 1
     assert "dsh: ok - /usr/bin/dsh" in result.output
-    assert "plugin: failed - PowerContext DSH plugin is not installed" in result.output
+    assert "plugin: failed - PowerContext DSH plugin is not registered in the Web profile" in result.output


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1493. Implements work package C of #1450; A and B are prerequisites.

# Rationale for this change

`/pc doctor` could succeed when health endpoints returned unrelated JSON or when the same plugin could not resolve its Scope or reach a required business route. Readiness HTTP 503 also lost the dependency evidence needed to diagnose the failure. The installation guide mixed released Server packages with a moving plugin ref.

# What changes are included in this PR?

- Diagnose the running plugin's resolved configuration, liveness, readiness, capabilities, declared core Memory routes, current Scope and a bounded prepare request independently. Preserve recognized readiness dependency states on HTTP 200 and 503.
- Return specific failure codes, the operation, safe HTTP status/request ID, protocol rule and recovery action. Distinguish timeout, connection refusal/DNS/TLS errors, authentication, authorization, missing routes, known domain errors and unclassified 404 responses. Neither health success nor unavailable evidence hides another failed check.
- Preserve read-only behavior and cancellation: no capture, remember, flush, binding changes or context injection. The route report lists the declarations checked and explicitly distinguishes them from live probes. No raw credentials, endpoint prefixes, response messages or recalled content are returned.
- Make standalone DSH Doctor explicitly report its registration-only observation limits, and distinguish dump-config timeouts, launch failures and exit codes without exposing host output.
- Document matched release/development installation, the moving-ref cache limitation, separate Server/DSH startup, processing prerequisites and a known-fixture recall check in English and Chinese. Config initialization recommends a plugin tag matching the installed release, or the matching local checkout for development versions.
- Extend the pinned real DSH runtime acceptance test to execute the actual setup CLI in a clean home, load its installed bundle and invoke the registered `/pc doctor` through the real host command service. Reuse the Source-to-Memory-to-fresh-session snapshot acceptance fixture.

# Are there any user-facing changes?

`/pc doctor` now returns a layered JSON report and an error result when a layer fails or remains unverified. Consumers of the old two-health-field output must use `configuration` and `checks`. A model-disabled Server and valid empty recall remain normal results. `ok: true` only confirms the reported read-only checks; it does not claim capture, processing, write-route execution or injection occurred.

No public HTTP contract, persisted data format, default-Scope semantics or automatic-path failure policy changes. Released PowerContext 0.2.0 remains distinguished from development-only Doctor and snapshot behavior.

# How was this change tested?

All 17 PR checks passed for commit `20fa1b0f`, including the CI runs triggered by marking this PR ready for review. Coverage includes the Python 3.11–3.14 unit/e2e matrix, DSH package and real host, documentation, Linux/macOS/Windows native services, and SQLite/OceanBase deterministic acceptance. See the [PR checks](https://github.com/oceanbase/powercontext/pull/1494/checks).

- DSH unit suite: 176 passed, including 27 Doctor regression cases; bundled distribution rebuilt.
- DSH HTTP integration suite: 9 passed.
- Pinned DSH 0.1.2-rc.1 real-host suite: 4 passed, including actual clean CLI installation, effective environment configuration, command errors, Source processing and durable fresh-session recall.
- Python configuration, DSH/system CLI and DSH HTTP chain tests: 85 passed.
- API contract and JS operation tests: 43 passed; generated API checks passed.
- Integration manifest: 26 passed; documentation generation check passed.
- Repository pre-commit hooks, lock validation and Python type checks passed.
- Website lint and the complete Linux documentation link/build/export CI passed. Local Windows compilation/type checking passed; local export/link validation encounters existing Windows path and CRLF assumptions.

All seven acceptance items in #1493 have been verified and checked.

The model fixture is deterministic and local; this is not an external model-provider acceptance claim. Seventeen existing Windows failures were reproduced again on unmodified upstream master `c9ab8119`: 11 test-platform assumptions, 3 long-cache-path failures with Windows long-path support disabled, 1 unavailable `python3` launcher, 1 OpenCode file-URI diagnostic defect, and 1 Skill ZIP raw-name validation inconsistency. All 3 cache tests pass under sufficiently short test roots. The full local Windows suite is not reported as passing; the CI Python matrix runs on Linux, while Windows CI covers native-service and cursor persistence scenarios. The earlier cursor-key issue #1463 remains fixed (4 current-master regression tests passed).

# AI usage statement

OpenAI Codex assisted with implementation, tests, documentation and code review.
