### PR TITLE
fix(auth): enforce revoked subject scope contribution

### DIFF
--- a/src/powercontext/server/app.py
+++ b/src/powercontext/server/app.py
@@ -2031,7 +2031,10 @@ async def create_subject_source(
         elif access.uses_static_preset(principal):
             # The subject Scope is resolved inside the atomic dual-write transaction,
             # so materialize the fixed static preset through the same connection.
-            await access.with_connection(connection).bootstrap_static_scope(principal, target, context=context)
+            bound = access.with_connection(connection)
+            await bound.bootstrap_static_scope(principal, target, context=context)
+            # Bootstrap is idempotent and must not bypass a previously revoked grant.
+            await bound.require(principal, AccessAction.SCOPE_CONTRIBUTE, ResourceRef.scope(target), context=context)
         else:
             await access.require(principal, AccessAction.SCOPE_CONTRIBUTE, ResourceRef.scope(target), context=context)
 

--- a/src/powercontext/server/authz/service.py
+++ b/src/powercontext/server/authz/service.py
@@ -340,6 +340,10 @@ class BuiltinAuthorizationProvider:
         self._deployment_id = deployment_id
         self._clock = clock or (lambda: datetime.now(UTC))
 
+    def with_repository(self, repository: AccessRepository) -> BuiltinAuthorizationProvider:
+        """Use transaction-local relationships without changing policy semantics."""
+        return BuiltinAuthorizationProvider(repository, deployment_id=self._deployment_id, clock=self._clock)
+
     async def check(self, request: AccessRequest, /) -> AccessDecision:
         decisions = await self.check_batch((request,))
         return decisions[0]
@@ -463,14 +467,17 @@ class AccessControlService:
         self._static_scope_principal = static_scope_principal
 
     def with_connection(self, connection):
-        """Bind internal relationship and audit writes to an existing transaction."""
+        """Bind relationships, builtin authorization reads, and audit to a transaction."""
         from powercontext.server.authz.repository import RelationalAccessRepository
 
         if not isinstance(self.relationships, RelationalAccessRepository) or self.audit is not self.relationships:
             raise AccessUnavailableError("transactional_relationships_unavailable")
         repository = self.relationships.with_connection(connection)
+        provider = self.provider
+        if isinstance(provider, BuiltinAuthorizationProvider):
+            provider = provider.with_repository(repository)
         return AccessControlService(
-            self.provider,
+            provider,
             relationships=repository,
             audit=repository,
             deployment_id=self.deployment_id,

--- a/tests/e2e/test_profile_api.py
+++ b/tests/e2e/test_profile_api.py
@@ -16,6 +16,7 @@
 """Profile and subject convenience operations through the real HTTP stack."""
 
 import asyncio
+import sqlite3
 
 import httpx
 import pytest
@@ -93,6 +94,77 @@ def test_subject_dual_write_preserves_single_scope_api_and_authorization(tmp_pat
                     json={"subject_key": "U2", "subject_scope_id": explicit_scope, "content": "Direct"},
                 )
                 assert direct.status_code == 201, direct.text
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("explicit_target", [False, True])
+def test_subject_dual_write_rejects_revoked_target_contribution(tmp_path, explicit_target):
+    database_path = tmp_path / "revoked-subject.db"
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{database_path}"),
+            auth=BearerAuthConfig(enabled=True, token=SecretStr("test-subject-token")),
+            access=AccessControlConfig(mode="enforced"),
+            mcp=McpConfig(enabled=False),
+        )
+    )
+
+    async def run():
+        async with (
+            app.router.lifespan_context(app),
+            httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+                headers={"Authorization": "Bearer test-subject-token"},
+            ) as client,
+        ):
+            group = (await client.get("/v1/scopes/default")).json()["scope_id"]
+            payload = {"subject_key": "U1", "content": "initial evidence"}
+            if explicit_target:
+                created = await client.post(
+                    "/v1/scopes",
+                    json={"title": "Subject", "summary": "Subject", "idempotency_key": "subject"},
+                )
+                assert created.status_code == 201, created.text
+                payload["subject_scope_id"] = created.json()["scope_id"]
+            path = f"/v1/scopes/{group}/subject-sources"
+            first = await client.post(path, json=payload)
+            assert first.status_code == 201, first.text
+            target = first.json()["subject_scope_id"]
+            # Materialize the static preset before revoking every contribution grant.
+            scope = await client.get(f"/v1/scopes/{target}")
+            assert scope.status_code == 200, scope.text
+            bindings = await client.post(
+                "/v1/access/bindings/list",
+                json={"management_resource": {"type": "scope", "scope_id": target}, "role": "scope.contributor"},
+            )
+            assert bindings.status_code == 200, bindings.text
+            assert bindings.json()["items"]
+            for binding in bindings.json()["items"]:
+                revoked = await client.post(
+                    "/v1/access/bindings/revoke",
+                    json={
+                        "binding_id": binding["binding_id"],
+                        "expected_version": binding["version"],
+                        "idempotency_key": "revoke-" + binding["binding_id"],
+                    },
+                )
+                assert revoked.status_code == 200, revoked.text
+            direct = await client.post(f"/v1/scopes/{target}/sources", json={"content": "forbidden direct"})
+            assert direct.status_code == 403, direct.text
+            with sqlite3.connect(database_path) as connection:
+                before = connection.execute("SELECT * FROM pc_sources ORDER BY scope_id, source_id").fetchall()
+                journal_before = connection.execute(
+                    "SELECT * FROM pc_source_journal_heads ORDER BY scope_id"
+                ).fetchall()
+            denied = await client.post(path, json={**payload, "content": "forbidden dual write"})
+            assert denied.status_code == 403, denied.text
+            with sqlite3.connect(database_path) as connection:
+                after = connection.execute("SELECT * FROM pc_sources ORDER BY scope_id, source_id").fetchall()
+                journal_after = connection.execute("SELECT * FROM pc_source_journal_heads ORDER BY scope_id").fetchall()
+            assert after == before
+            assert journal_after == journal_before
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Which issue or RFC does this PR close?

Closes #1495.
Follow-up fix for merged PR #1487 and https://github.com/oceanbase/powercontext/pull/1487#discussion_r3954128708.

## Rationale for this change

Static preset initialization is idempotent: replaying a revoked grant does not reactivate it. The subject-source endpoint nevertheless skipped its target contribution check after initialization, allowing a dual write where an ordinary Source write correctly returned 403.

## What changes are included in this PR?

- Require scope.contribute on the resolved existing subject Scope after static preset initialization.
- Bind builtin authorization reads, relationship writes, and audit writes to the same transaction so the permission check sees newly created grants on first use.
- Preserve externally supplied authorization providers.
- Add HTTP regression coverage for automatically created and explicitly supplied subject Scopes: after revocation, direct and dual writes return 403; neither Source storage nor either journal advances.
- Retain existing first-use explicit Scope coverage.

## Are there any user-facing changes?

Subject-source writes now correctly return 403 when target contribution has been revoked. First-use initialization remains supported. No API shape, schema, migration, RFC, or dependency changes.

## How was this change tested?

- Reproduced the pre-fix dual-write response of 201 after revocation.
- uv run pytest tests/e2e/test_profile_api.py tests/e2e/test_access_control_regressions.py tests/e2e/test_access_control_http.py tests/test_access_control.py -q — 50 passed.
- uv run prek run -a — all hooks passed, including Ruff and ty.
- git diff --check — passed.

## AI usage statement

Implemented and tested with OpenAI Codex. AI assistance was used for diagnosis, code changes, regression tests, and this PR description.