### PR TITLE
fix(server): honor weak and list forms of If-None-Match on artifact reads

### DIFF
--- a/src/powercontext/server/app.py
+++ b/src/powercontext/server/app.py
@@ -2323,6 +2323,12 @@ async def replace_memory_entry_tags(
     return ArtifactTagSet.model_validate(result.model_dump(mode="json"))
 
 
+def _if_none_match_matches(if_none_match: str | None, etag: str) -> bool:
+    if if_none_match is None:
+        return False
+    return any(value.strip().removeprefix("W/") == etag for value in if_none_match.split(","))
+
+
 def _tag_response(
     result: RuntimeArtifactTagSet,
     response: Response,
@@ -2330,9 +2336,7 @@ def _tag_response(
     if_none_match: str | None,
 ) -> ArtifactTagSet | Response:
     etag = result.etag
-    if if_none_match is not None and any(
-        value.strip().removeprefix("W/") == etag for value in if_none_match.split(",")
-    ):
+    if _if_none_match_matches(if_none_match, etag):
         return Response(status_code=304, headers={"ETag": etag})
     response.headers["ETag"] = etag
     return ArtifactTagSet.model_validate(result.model_dump(mode="json"))
@@ -2368,7 +2372,7 @@ async def get_artifact(
 ) -> ArtifactRevision | Response:
     result = await application.records.for_scope(scope_id).get_artifact(family.value, artifact_id)
     etag = _artifact_etag(result.revision)
-    if if_none_match == etag:
+    if _if_none_match_matches(if_none_match, etag):
         return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers={"ETag": etag})
     response.headers["ETag"] = etag
     return _artifact_revision_response(result)

--- a/tests/e2e/test_base_access_api.py
+++ b/tests/e2e/test_base_access_api.py
@@ -146,6 +146,14 @@ def test_source_and_artifact_api_round_trip(tmp_path: Path) -> None:
                 if_none_match=etag,
             )
             assert not_modified is None
+            weak_match = await transport.get(head_path, headers={"If-None-Match": f"W/{etag}"})
+            assert weak_match.status_code == 304
+            assert weak_match.headers["ETag"] == etag
+            list_match = await transport.get(head_path, headers={"If-None-Match": f'"revision:999", {etag}'})
+            assert list_match.status_code == 304
+            assert list_match.headers["ETag"] == etag
+            stale_match = await transport.get(head_path, headers={"If-None-Match": '"revision:999"'})
+            assert stale_match.status_code == 200
 
             listed = await client.list_artifacts(scope_id, "memory", ListArtifactsRequest())
             assert [item.artifact_id for item in listed.items] == [created.artifact_id]


### PR DESCRIPTION
# Which issue or RFC does this PR close?

No tracking issue; the rationale below is self-contained. The behavior contract is `openapi/powercontext.yaml` (the `304` response documented for `GET /v1/scopes/{scope_id}/artifacts/{family}/{artifact_id}`) and RFC 9110 section 13.1.2.

# Rationale for this change

`GET /v1/scopes/{scope_id}/artifacts/{family}/{artifact_id}` compared the `If-None-Match` header against the current ETag byte-for-byte. Weak validators (`W/"revision:1"`) and comma-separated lists (`"revision:999", "revision:1"`) therefore never matched and always produced a full `200` response, even when the client already held the current revision. RFC 9110 section 13.1.2 requires weak comparison for `GET`, and the endpoint's contract documents the `304` response.

The Memory entry tag endpoints in the same module already implement the correct weak, list-aware comparison; this change extracts that logic into a shared helper so both paths stay aligned.

Reproduction against an in-memory server at master `80d618b`:

```
artifact  exact  -> 304
artifact  weak   -> 200   # expected 304
artifact  list   -> 200   # expected 304
```

# What changes are included in this PR?

- `src/powercontext/server/app.py`: new `_if_none_match_matches()` helper (comma-splitting, whitespace-tolerant, `W/`-prefix-aware); `_tag_response()` now calls it (logic extracted verbatim, no behavior change); `get_artifact()` reuses it instead of an exact string comparison.
- `tests/e2e/test_base_access_api.py`: regression coverage asserting `304` for weak-form and list-form `If-None-Match` on the artifact read path, and `200` for a non-matching validator.

Note: `If-None-Match: *` is still not treated as a match by either the artifact or tag endpoints; aligning on `*` semantics is left as a separate decision for maintainers.

# Are there any user-facing changes?

Yes, one intentional behavior change: requests to the artifact read endpoint that send a weak-form or list-form `If-None-Match` matching the current head now receive `304 Not Modified` with an empty body instead of `200` with the full representation. Callers sending `If-None-Match` already opt into conditional semantics; no public API shape, contract, or persisted format changes.

# How was this change tested?

- `uv run pytest tests/e2e/test_base_access_api.py -q` — the new assertions fail on unmodified master (weak/list forms returned `200`) and pass with the fix.
- `uv run pytest tests/test_api_contract.py tests/test_access_http.py tests/test_server.py tests/builtin/test_tags.py tests/e2e/test_artifact_tags.py tests/test_artifacts.py -q` — 146 passed.
- `make test` — 1541 passed, 26 skipped; the only 3 failures (`tests/client/test_receiver_service.py` systemd cases) reproduce on unmodified master on macOS and are unrelated to this change.
- `uv run prek run --files src/powercontext/server/app.py tests/e2e/test_base_access_api.py` — all hooks pass (ruff check, ruff format, ty).

# AI usage statement

Kimi Code CLI (Kimi) assisted with defect investigation, reproduction, implementation, and test authorship. All findings were verified by running the server and test suite locally.
