### PR TITLE
fix(skill): validate raw archive entry names

### DIFF
--- a/src/powercontext/builtin/artifacts/skill/package.py
+++ b/src/powercontext/builtin/artifacts/skill/package.py
@@ -280,7 +280,12 @@ def _archive_files(archive_bytes: bytes) -> tuple[_PackageFile, ...]:  # noqa: C
         entries: list[tuple[zipfile.ZipInfo, str, int]] = []
         total_bytes = 0
         for info in archive.infolist():
-            path = _validate_relative_path(info.filename.rstrip("/") if info.is_dir() else info.filename)
+            # ZipInfo.filename truncates the name at NUL bytes on every platform
+            # and rewrites backslashes as separators on Windows; only
+            # orig_filename keeps the raw archive name, so validate that before
+            # host-dependent normalization can hide hostile input.
+            name = info.orig_filename
+            path = _validate_relative_path(name.rstrip("/") if info.is_dir() else name)
             collision_key = _path_collision_key(path)
             if collision_key in seen_paths:
                 raise SkillPackageError(f"Agent Skill archive contains duplicate or colliding paths: {path}")

--- a/tests/builtin/artifacts/skill/test_package.py
+++ b/tests/builtin/artifacts/skill/test_package.py
@@ -98,7 +98,6 @@ def test_different_zip_order_converges_on_the_same_canonical_package(tmp_path: P
     [
         ("../outside", b"bad"),
         (".env", b"SECRET=value"),
-        ("nested\\windows", b"bad"),
     ],
 )
 def test_archive_rejects_unsafe_paths(name: str, content: bytes) -> None:
@@ -108,6 +107,23 @@ def test_archive_rejects_unsafe_paths(name: str, content: bytes) -> None:
     ))
 
     with pytest.raises(SkillPackageError):
+        capture_skill_archive(archive)
+
+
+@pytest.mark.parametrize("name", ["nested\\windows", "nested\x00windows"])
+def test_archive_rejects_hostile_raw_entry_names(name: str) -> None:
+    archive = _zip_entries((
+        ("SKILL.md", b"---\nname: safe-skill\ndescription: Safe.\n---\n"),
+        (_raw_entry_name(name), b"bad"),
+    ))
+    # The fixture must keep the hostile bytes in the archive: zipfile
+    # normalizes backslashes on Windows and truncates names at NUL bytes on
+    # every platform while building the ZipInfo, so the names are assigned
+    # after construction and asserted against the raw archive names here.
+    with zipfile.ZipFile(io.BytesIO(archive)) as probe:
+        assert [item.orig_filename for item in probe.infolist()] == ["SKILL.md", name]
+
+    with pytest.raises(SkillPackageError, match="invalid path"):
         capture_skill_archive(archive)
 
 
@@ -259,3 +275,11 @@ def _zip_entries(entries) -> bytes:
         for name, content in entries:
             archive.writestr(name, content)
     return output.getvalue()
+
+
+def _raw_entry_name(name: str) -> zipfile.ZipInfo:
+    """Build an archive entry whose raw name bytes keep ``name`` verbatim."""
+
+    info = zipfile.ZipInfo("placeholder")
+    info.filename = name
+    return info


### PR DESCRIPTION
## Summary

Fixes #1498.

`_archive_files()` validated `ZipInfo.filename`, but the host `zipfile` implementation normalizes that property before the check runs:

- on **Windows**, backslashes are rewritten as forward slashes while constructing the `ZipInfo`, so a raw `nested\windows` entry passed validation and was silently reinterpreted as the POSIX path `nested/windows`;
- on **every platform**, the name is truncated at the first NUL byte, so a `nested\x00evil` entry was accepted under its truncated name — which also made the existing `"\x00"` rejection in `_validate_relative_path` unreachable on the archive path (verified on Linux before this fix).

The raw name is only preserved in `ZipInfo.orig_filename`, so archive validation now checks that instead, before any host-dependent normalization can hide hostile input. Traversal, duplicate/collision, forbidden-name, size, and special-file protections are unchanged.

## Regression coverage

- The existing `test_archive_rejects_unsafe_paths` case for `nested\\windows` was removed: `writestr("nested\\windows", ...)` normalizes the name while building the entry on Windows, so the fixture did not prove the production behavior (as noted in the issue).
- The new `test_archive_rejects_hostile_raw_entry_names` assigns the hostile names (`nested\windows`, `nested\x00windows`) after `ZipInfo` construction so the raw bytes reach the archive on every platform, asserts those bytes are present in the built archive, and verifies both names are rejected. The NUL byte case reproduces the silent reinterpretation on Linux, where the CI runs.

## Testing

- `uv run pytest -q tests/builtin/artifacts/skill/test_package.py` — 13 passed
- `uv run pytest -q tests/builtin/` — 578 passed, 4 skipped
- Full suite `uv run python -m pytest --doctest-modules --ignore=tests/e2e` — 1626 passed, 11 skipped, plus one pre-existing failure of `tests/test_topics_dashboard.py::test_topics_browser_state_regressions_execute_in_node`, which fails identically on unmodified `master` in this environment (Node.js dependent).
- `uv run ruff check`, `uv run ruff format --check`, and `uv run ty check` on the changed files all pass.