### PR TITLE
feat(client): add explicit insecure HTTP opt-in across integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ powercontext doctor codex
 `doctor` verifies integration setup. To verify automatic memory, check that a real prompt becomes a Source,
 produces a Topic, evolves after a related prompt, and can be recalled in a new session using the same Scope.
 
+For a Server on another machine, use HTTPS or follow the
+[remote connection guide](docs/en/docs/operate/connect-remote-server.md). Setup recognizes remote HTTP URLs from
+flags or environment variables and asks for explicit consent; automated setup uses `--allow-insecure-http`.
+
 Codex is `official`; other hosts and Python Agent frameworks are `community`; Bub is `evaluation` only.
 These tags describe PowerContext integration maintenance and use. See the
 [capability matrix](https://frf12.github.io/powercontext/en/docs/integrations/capabilities/) for supported features and availability.

--- a/docs/en/docs/get-started/install-and-run.md
+++ b/docs/en/docs/get-started/install-and-run.md
@@ -1,165 +1,176 @@
 ---
 title: Install and run
-description: Choose a version and storage, generate configuration, and start or update PowerContext.
+description: Install PowerContext from Git and run the local Server.
 ---
 
 # Install and run
 
-For the complete installation → wizard → startup → Agent connection → memory check, follow [Quick Start](quickstart.md).
-This page covers installation roles, storage, and updates. Commands use the default installation from
-`oceanbase/powercontext`.
+For an Agent connecting from another machine, see [Connect to a remote Server](../operate/connect-remote-server.md)
+for guided URL confirmation, unattended setup, and endpoint-bound HTTP consent.
 
-## Platforms and prerequisites
+Start with the [Quick Start](quickstart.md) for your first session. This page covers version selection,
+platforms, installation roles, startup, diagnostics, and updates.
 
-| Item | Requirement |
+## Platform support
+
+| Platform | Status |
 | --- | --- |
-| PowerContext | Python 3.11+, Git, and [uv](https://docs.astral.sh/uv/getting-started/installation/) |
-| macOS and Linux | Supported |
-| Windows | `experimental`; these examples use Bash and cannot be pasted directly into PowerShell |
-| Embedded seekdb | Linux or macOS with a compatible `pylibseekdb` wheel for the Python version and architecture |
-| Agent | Install its CLI on the machine where the Agent runs |
-| Full memory | Working Generation and Embedding model APIs |
+| macOS, Linux | Supported |
+| Windows | `experimental` |
+
+Windows CLI, Server, and personal-service support is experimental. Each Agent Host still has its own platform
+requirements. Examples using Bash syntax require a Bash environment and cannot be pasted directly into PowerShell.
+Embedded seekDB is unavailable on Windows.
 
 ## Choose a version
 
-The guided experience on this site is provided by the current `oceanbase/powercontext` installation. Keep the Server
-tool and Agent plugins on the same installed PowerContext version:
+Keep a released package and integration on the same tag. For example, install `0.2.0`:
+
+```bash
+uv tool install "powercontext[cli,server]==0.2.0"
+```
+
+The following examples use `master`, including unreleased capabilities. Check the
+[capability matrix](../integrations/capabilities.md); `master_only` and `experimental` capabilities
+are not release guarantees.
+
+## Install the application
+
+You need Python 3.11 or newer, Git, and [`uv`](https://docs.astral.sh/uv/) on macOS, Linux, or Windows. Then install
+PowerContext directly from a Git ref:
 
 ```bash
 uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
-powercontext --version
 ```
 
-`uv tool` installs an isolated environment without creating a source checkout in your current directory.
-`--force` refreshes the installed tool. To pin an acceptance run, install a specific existing release or use the same
-source checkout for the Server and plugin. Do not switch only the plugin to another repository or version.
+The command does not leave a repository checkout for you to manage. Git uses its normal credential configuration,
+including credential helpers and SSH settings. For an SSH-based install, replace the HTTPS URL with the Git URL
+approved for your environment. `--force` also refreshes an existing tool from the current commit behind the selected
+Git ref; without it, `uv` may report the same requirement as already installed without fetching a newer `master`.
 
-## Retry dependency downloads with a mirror
+To install a tested branch or tag, replace `master` after the final `@`.
+Follow the [guide for each integration](../integrations/index.md) for Agent installation, connection options, and verification, using the same ref as the Server.
 
-If the GitHub checkout succeeds but downloading Python dependencies from PyPI is slow or fails with a network/TLS error,
-retry this installation using the Aliyun HTTPS index:
+## Run the local Server
 
 ```bash
-uv tool install --force --default-index https://mirrors.aliyun.com/pypi/simple "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+powercontext server run
 ```
 
-This selects the index for this command only; it does not change global uv settings. It applies to Python dependencies,
-including build dependencies, not the GitHub source checkout. If GitHub itself is unreachable, configure working GitHub
-access separately. The mirror uses HTTPS, so this command does not need `--trusted-host` or disabled certificate verification.
-After installation succeeds, continue with the configuration wizard below.
+With no environment variables, the Server:
 
-## Generate configuration and select storage
+- binds to `127.0.0.1:8000`;
+- enables Streamable HTTP MCP at `/mcp`;
+- creates a default Scope;
+- creates a persistent SQLite database in the operating system's user data directory;
+- supports explicit Memory operations without an inference provider.
 
-Run the wizard in a dedicated directory:
+`Ctrl-C` performs a clean shutdown. Restarting the command reopens the same database.
+
+The Dashboard is an optional content viewer for personal use and demonstrations. It is disabled by default and needs
+no separate frontend installation or model configuration. To enable it, put these settings in a protected environment
+file and replace the token example with your own long random credential:
+
+```dotenv
+POWERCONTEXT_SERVER_DASHBOARD_ENABLED=true
+POWERCONTEXT_SERVER_ACCESS_MODE=enforced
+POWERCONTEXT_SERVER_AUTH_TOKEN=replace-with-your-random-token
+```
 
 ```bash
-mkdir -p ~/powercontext-demo
-cd ~/powercontext-demo
-powercontext config init --language en --output .env
+chmod 600 /path/to/powercontext.env
+powercontext config validate --env-file /path/to/powercontext.env
+powercontext server run --env-file /path/to/powercontext.env
 ```
 
-Without `--language`, the wizard detects Chinese or English from the system and falls back to English when unknown
-or unsupported; you can switch at the first prompt. `--template` writes a basic, model-free template without the
-interactive flow. Omit it for the full-memory walkthrough.
+Open `http://127.0.0.1:8000/dashboard/home` and enter the same token. Use the actual port if you change it.
+The token also protects the Server API and MCP, so connected Agents need it too. The CLI does not automatically load
+a directory's `.env` file.
 
-The wizard asks about storage, usage scenario, capabilities, Dashboard/network, models, background schedules,
-and Agents. Existing environment files can be reused or reviewed, with backups when overwritten.
-It does not migrate databases or restore every model credential and deployment setting from an OceanBase connection.
-Keep the original environment file and data path. Inspecting local SQLite metadata does not validate every dependency.
+The first sign-in selects the Server default Scope. Pages are empty until content is saved. Save a Memory through an
+Agent or public API, then refresh Memories in the same Scope. Experiences, skills, handoffs, and usage also come from
+saved records. The Dashboard does not capture sessions, run generation, or approve candidates. The Dashboard and Agent
+must use the same Server and Scope.
 
-| Storage option | Behavior |
-| --- | --- |
-| SQLite | Local file without another database service; suitable for a first check |
-| Embedded seekdb | Local instance; the wizard can install its missing dependency incrementally |
-| OceanBase | Supply an existing service's connection details; check networking, authentication, and readiness after startup |
-| Existing PowerContext Server | Generate client connection settings without creating another local Server |
+All token holders use one identity. Multi-user RBAC deployments should leave the Dashboard disabled and use the API,
+MCP, or host integrations. See [Deploy the Server](../operate/deploy-server.md) for network and credential configuration.
 
-### seekdb dependency installation
+This minimal launch does not enable model-backed extraction or vector search. To generate and validate one explicit
+environment file for those capabilities, continue with the
+[Enable extraction and vector search](configure-models.md).
 
-After you select seekdb, the wizard checks its dependency and asks for permission to install missing packages.
-It reads the constraints declared by the installed PowerContext version and installs incrementally in the background.
-You can answer the remaining questions during the download. If it is unfinished when you save, the wizard waits with
-an activity indicator, without inventing a download percentage.
+## Use embedded seekDB
 
-Explicit `UV_DEFAULT_INDEX` or `UV_INDEX_URL` settings take precedence. Without those overrides, a Chinese timezone
-selects the [Aliyun PyPI mirror](https://mirrors.aliyun.com/pypi/simple/) immediately; other timezones use the default
-index first and fall back to Aliyun after failure. Ordinary failures produce a copyable incremental installation
-command. If no compatible wheel exists, use SQLite/OceanBase or a supported Python/platform combination.
-
-You can also include the dependency during the initial installation:
+Embedded seekDB is available on Linux and macOS when a compatible `pylibseekdb` wheel is available. Windows does not
+support this embedded backend. Install or replace the tool with the optional seekDB extra:
 
 ```bash
 uv tool install --force "powercontext[cli,server,seekdb] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
-seekdb uses a local `POWERCONTEXT_SERVER_DATABASE_PATH`, not a SQLite/SQLAlchemy
-`POWERCONTEXT_SERVER_DATABASE_URL`. When switching from SQLite, remove the old URL from the starting process's
-environment. Selecting another backend does not migrate existing memories.
-
-## Start and check
+When switching from SQLite, remove `POWERCONTEXT_SERVER_DATABASE_URL` from the Server process environment. An explicit
+SQLAlchemy database URL is not valid for seekDB. Then select the backend and start the Server:
 
 ```bash
-powercontext config validate --env-file .env
-powercontext server run --env-file .env
+unset POWERCONTEXT_SERVER_DATABASE_URL
+export POWERCONTEXT_SERVER_DATABASE_KIND=seekdb
+powercontext server run
 ```
 
-`server run` stays in the foreground; stop it with `Ctrl-C`. Load the client file in another terminal and check:
+`server run` loads `.env` from the current directory when present. Export values in the shell to override that file,
+pass `--env-file <path>` to select another file, or pass `--no-env-file` to ignore environment files. Process managers
+and containers should normally provide an explicit environment instead of relying on their working directory.
+
+PowerContext always uses seekDB's built-in `test` database. Leave `POWERCONTEXT_SERVER_DATABASE_PATH` unset to store
+the instance in the `seekdb` subdirectory of the PowerContext user data directory. If `POWERCONTEXT_HOME` is set, the
+default is `$POWERCONTEXT_HOME/seekdb`; set `POWERCONTEXT_SERVER_DATABASE_PATH` only when a different location is
+required.
+
+In another terminal, verify that the Server and database are ready:
 
 ```bash
-set -a
-. ./.env
-set +a
 powercontext doctor
 powercontext ready
 powercontext capabilities
 ```
 
-`server run` automatically reads `.env` in its current directory. Use `--env-file` to choose a file explicitly,
-or `--no-env-file` to disable loading. Exported process variables override file values; check inherited variables
-if editing a file appears to have no effect. Service managers should use an explicit absolute path;
-see [Deploy the Server](../operate/deploy-server.md).
-
-A minimal Server also runs without model configuration: SQLite, `127.0.0.1:8000`, MCP at `/mcp`, and Dashboard disabled.
-It supports explicit Memory writes and reads, but ordinary Sources do not automatically become Topic Memory.
-Use the wizard's configuration for the full experience.
-
-## Agent installation and connection
-
-On the machine running the Agent, first load the shared `.env`, then install the corresponding plugin:
+## Verify the installation
 
 ```bash
-powercontext setup codex
-powercontext doctor codex
+powercontext doctor
+powercontext ready
+powercontext capabilities
 ```
 
-For Claude Code:
+`doctor` checks the installed package, Server liveness, and Server readiness without requiring an integration. Server
+readiness covers the database and each configured inference provider. Runtime or database failures return
+`not_ready`; an inference failure returns `degraded` without removing database-backed operations from traffic.
+`ready` and `capabilities` show the readiness and enabled capabilities of the running service.
+For Agent diagnostics, use the [guide for each integration](../integrations/index.md). For Server status definitions and recovery steps, see [Troubleshoot](../operate/troubleshoot.md).
+
+For a long-running process, Docker, authentication, or remote access, continue with
+[Deploy the Server](../operate/deploy-server.md).
+
+## Update or replace an installation
+
+To replace the installed tool with a chosen ref:
 
 ```bash
-powercontext setup claude-code --server-url "$POWERCONTEXT_CLAUDE_SERVER_URL"
-powercontext doctor claude-code
+uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@<ref>"
 ```
 
-The wizard writes connection files, setup installs plugins, and the Server performs persistence and model processing.
-Complete each step. MCP, Hooks, and the browser must reach the same service; Scope settings use IDs actually returned
-by the Server. Follow [Quick Start](quickstart.md), [Codex](../integrations/codex.md), or [Claude Code](../integrations/claude-code.md).
-
-## Update or reinstall
-
-Repeat the matching installation and plugin commands, then restart the Server and Agent. For a personal service,
-repeat the [service installation](../operate/deploy-server.md#run-a-persistent-personal-server) to register the updated
-program and environment file.
-
-Updating the tool does not intentionally remove data, but changing `POWERCONTEXT_HOME`, the database URL, or the database
-directory opens different storage. Keep configuration and database backups before updates. Do not delete a SQLite file
-as a troubleshooting shortcut.
+Update each installed host using its [integration guide](../integrations/index.md) and the same ref. Restart the Server and open a new host session
+after updating. Existing SQLite data remains in the user data directory unless `POWERCONTEXT_HOME` or the database URL
+changes.
 
 ## Install a Python role
 
-An isolated `uv tool` environment does not expose an importable SDK to another Python project.
-Install the Client SDK in that project's environment:
+An application that imports the async Client SDK should add it to that application's environment:
 
 ```bash
 uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
-Use `builtin` for in-process composition, `server` for a standalone service, `client` for the SDK, and `cli` for commands.
+Use `builtin` for in-process Python composition, `server` for the service, `client` for the Python SDK, or `cli` for
+the Server-backed command line. An extra that is only present in the isolated `uv tool` environment is not importable
+by an unrelated Python project.

--- a/docs/en/docs/get-started/quickstart.md
+++ b/docs/en/docs/get-started/quickstart.md
@@ -27,7 +27,7 @@ powercontext config init --language en --output .env
 For a first local installation:
 
 1. **Storage**: SQLite works without another database dependency. To try embedded seekdb, select it and approve the background dependency installation.
-2. **Usage scenario**: choose “Only on this machine” when your Agent, browser, and Server share a machine. For a remote Server, first read [SSH access](../operate/deploy-server.md#access-from-another-computer-with-ssh).
+2. **Usage scenario**: choose “Only on this machine” when your Agent, browser, and Server share a machine. For a remote Server, first read [Connect to a remote Server](../operate/connect-remote-server.md).
 3. **Memory capabilities**: select full memory and enter Generation and Embedding API details. See [Configure models](configure-models.md) for protocols and dimensions.
 4. **Dashboard**: enable it to inspect Sources and memories. The wizard creates or reuses a Server token.
 5. **Background processing**: start with the recommended schedule for each Artifact. An inspection interval is not a completion deadline; model processing takes additional time.

--- a/docs/en/docs/integrations/agent-plugin.md
+++ b/docs/en/docs/integrations/agent-plugin.md
@@ -41,6 +41,10 @@ The package points compatible agents to:
 http://127.0.0.1:8000/mcp
 ```
 
+For a remote Server, configure the MCP URL in the loading host. This package delegates transport to that host and
+has no PowerContext HTTP client or setup subcommand; `allow_insecure_http` cannot override the host's MCP policy.
+See [Connect to a remote Server](../operate/connect-remote-server.md) for connection and security boundaries.
+
 ## Load it in VS Code
 
 VS Code supports local Agent Plugin directories through `chat.pluginLocations`.

--- a/docs/en/docs/integrations/claude-code.md
+++ b/docs/en/docs/integrations/claude-code.md
@@ -171,8 +171,9 @@ The Hook reads this process environment value directly, while the MCP configurat
 `Authorization` header. The MCP header defaults to an empty value when the variable is absent. Never put the token in
 the Server URL, plugin options, `.mcp.json`, Source metadata, or logs.
 
-Plain HTTP is accepted only for `127.0.0.1`, `localhost`, or `::1`. Use HTTPS when Claude Code connects to a remote
-Server.
+Plain HTTP is allowed on loopback by default. For a non-loopback Server, use HTTPS or explicitly set
+`POWERCONTEXT_CLAUDE_ALLOW_INSECURE_HTTP=true`. Guided setup can save this consent and configure both the Hook and
+native MCP URL; the host's own MCP policy still applies. See [Connect to a remote Server](../operate/connect-remote-server.md).
 
 ## Understand failure behavior
 
@@ -218,6 +219,7 @@ run with `--keep-data`.
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `POWERCONTEXT_CLAUDE_SERVER_URL` | `http://127.0.0.1:8000` | Server base URL used by the Hook |
+| `POWERCONTEXT_CLAUDE_ALLOW_INSECURE_HTTP` | `false` | Explicitly permit non-loopback plaintext HTTP for PowerContext requests |
 | `POWERCONTEXT_CLAUDE_SCOPE_ID` | unset | Override durable bindings and the Server default Scope |
 | `POWERCONTEXT_CLAUDE_AUTHORIZATION` | unset | Complete `Bearer <token>` header for Hook and MCP requests |
 | `POWERCONTEXT_CLAUDE_CAPTURE_PROMPTS` | `true` | Capture user prompts as ordinary Source evidence |
@@ -231,5 +233,5 @@ options. The corresponding `POWERCONTEXT_CLAUDE_*` variables take precedence for
 Authorization is environment-only and must not be added to the Server URL or plugin options.
 
 The outer `UserPromptSubmit` Hook timeout is ten seconds. Recall and capture use one shared wall-clock budget but fail
-independently. Plain HTTP is accepted only for loopback endpoints; use HTTPS for a remote Server. Restart Claude Code
+independently. HTTPS certificate validation remains enabled when HTTP is explicitly permitted. Restart Claude Code
 after changing its environment.

--- a/docs/en/docs/integrations/codex.md
+++ b/docs/en/docs/integrations/codex.md
@@ -184,6 +184,7 @@ does not prove Source capture. Complete the [Source, topic evolution, and cross-
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
+| `POWERCONTEXT_CODEX_ALLOW_INSECURE_HTTP` | `false` | Explicitly permit non-loopback plaintext HTTP for hooks |
 | `POWERCONTEXT_CODEX_SCOPE_ID` | unset | Explicitly select an existing Scope instead of resolving bindings and the Server default |
 | `POWERCONTEXT_CODEX_AUTHORIZATION` | unset | Complete `Bearer <token>` header for Hook and MCP requests |
 | `POWERCONTEXT_CODEX_CAPTURE_PROMPTS` | `true` | Capture user prompts as Source evidence |
@@ -191,6 +192,12 @@ does not prove Source capture. Complete the [Source, topic evolution, and cross-
 | `POWERCONTEXT_CODEX_REQUEST_TIMEOUT_SECONDS` | `1` | Per-request hook timeout |
 | `POWERCONTEXT_CODEX_HTTP_BUDGET_SECONDS` | `4` | Shared hook HTTP budget |
 | `POWERCONTEXT_CODEX_FLUSH_MAX_CALLS` | `4` | Maximum flush calls per prompt |
+
+Hooks allow loopback HTTP by default; remote HTTP requires explicit consent, and HTTPS certificate validation stays
+enabled. Setup saves consent and updates the installed plugin's `.mcp.json`, which supplies the URL for both hooks
+and native MCP. Changing only a Hook URL variable does not change that native endpoint; rerun setup if an upgrade
+replaces `.mcp.json`. Codex's own MCP policy still applies. See
+[Connect to a remote Server](../operate/connect-remote-server.md).
 
 The outer Codex hook timeout is ten seconds. Recall, capture, and flush fail independently and never block Codex when
 the Server is unavailable or rejects authentication. Without an explicit Scope, the plugin resolves the Session

--- a/docs/en/docs/integrations/dsh.md
+++ b/docs/en/docs/integrations/dsh.md
@@ -251,9 +251,15 @@ powercontext doctor dsh
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `POWERCONTEXT_DSH_BASE_URL` | `http://127.0.0.1:8000` | Server base URL used by the plugin |
+| `POWERCONTEXT_DSH_ALLOW_INSECURE_HTTP` | `false` | Explicitly permit non-loopback plaintext HTTP |
 | `POWERCONTEXT_DSH_SCOPE_ID` | unset | Explicit existing Scope before workspace binding and Server default |
 | `POWERCONTEXT_DSH_AUTHORIZATION` | unset | Complete `Bearer <token>` header for plugin HTTP requests |
 | `POWERCONTEXT_DSH_CAPTURE_PROMPTS` | `true` | Capture user prompts as Source evidence |
 | `POWERCONTEXT_DSH_FLUSH_ON_CAPTURE` | `false` | Wait for Source processing after capture |
 
 `timeoutMs`, `requestTimeoutMs`, `maxBytes`, and `flushMaxCalls` are plugin patch settings. Server unavailability fails open for recall and capture; restart `dsh web` after changing these variables.
+
+Plain HTTP is allowed on loopback by default. For remote HTTP, explicitly set
+`POWERCONTEXT_DSH_ALLOW_INSECURE_HTTP=true`; HTTPS certificate validation stays enabled. The host URL aliases are
+checked in the order `BASE_URL`, `SERVER_URL`, then `ENDPOINT`, before `POWERCONTEXT_CLIENT_SERVER_URL`.
+See [Connect to a remote Server](../operate/connect-remote-server.md) for setup and saved consent.

--- a/docs/en/docs/integrations/evaluation.md
+++ b/docs/en/docs/integrations/evaluation.md
@@ -13,6 +13,11 @@ The Bub plugin connects to the Server through the Python Client and provides Mem
 preparation, including context before model calls. Event capture is disabled by default. When enabled, completed
 events become Sources and can be flushed periodically. No Handoff capability is declared.
 
+Loopback HTTP is allowed by default. Non-loopback HTTP requires `POWERCONTEXT_BUB_ALLOW_INSECURE_HTTP=true` or
+`PowerContextSettings(allow_insecure_http=True)`, covering both plugin hooks and tools. HTTPS certificate validation
+stays enabled. See [Connect to a remote Server](../operate/connect-remote-server.md) for shared client settings;
+Bub has no PowerContext setup installer.
+
 See the [Bub integration README](https://github.com/oceanbase/powercontext/blob/master/integrations/bub/README.md) for
 installation and capture settings. See [benchmarks](/en/benchmarks/) for methods, results, and limitations.
 Evaluation results do not imply equal capabilities or stability across Agent integrations.

--- a/docs/en/docs/integrations/hermes.md
+++ b/docs/en/docs/integrations/hermes.md
@@ -72,6 +72,7 @@ the file:
 | --- | --- |
 | `POWERCONTEXT_HERMES_CONFIG` | Config file path; defaults to `$HERMES_HOME/powercontext/config.json` |
 | `POWERCONTEXT_HERMES_BASE_URL` | PowerContext Server URL |
+| `POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP` | Explicitly permit non-loopback plaintext HTTP; defaults to `false` |
 | `POWERCONTEXT_HERMES_AUTHORIZATION` | Complete authorization header, such as `Bearer <token>` |
 | `POWERCONTEXT_HERMES_TOKEN` | Bare-token shorthand used when `AUTHORIZATION` is absent |
 | `POWERCONTEXT_HERMES_SCOPE_ID` | Explicit server-owned Scope ID |
@@ -84,9 +85,10 @@ the file:
 | `POWERCONTEXT_HERMES_EVALUATION_TRACE_PATH` | Override the evaluation trace directory |
 
 Let the Hermes wizard store authorization in its protected `.env` secret store; do not put the token in
-`config.json`. Use plain HTTP only for a loopback Server. See [Deploy the Server](../operate/deploy-server.md) before connecting
-to a remote deployment. Evaluation traces contain prompts and recalled context; keep them local and protect them as
-sensitive data.
+`config.json`. Plain HTTP is allowed on loopback by default; use HTTPS for remote access or explicitly set
+`POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP=true`. This does not disable HTTPS certificate validation. See
+[Connect to a remote Server](../operate/connect-remote-server.md) for guided setup and endpoint-bound saved consent.
+Evaluation traces contain prompts and recalled context; keep them local and protect them as sensitive data.
 
 ## Enable automatic extraction only when needed
 

--- a/docs/en/docs/integrations/index.md
+++ b/docs/en/docs/integrations/index.md
@@ -33,6 +33,9 @@ The 8 Agent Hosts use `official` for PowerContext project maintenance and `commu
 
 Each integration connects to a separately running Server. Follow its guide in the table for installation, connection settings, authentication, and diagnostics.
 
+For remote endpoints, see [Connect to a remote Server](../operate/connect-remote-server.md): PowerContext clients
+allow loopback HTTP by default and require explicit consent for non-loopback HTTP. Host-native MCP policies remain separate.
+
 To select multiple hosts interactively, run:
 
 ```bash

--- a/docs/en/docs/integrations/langchain.md
+++ b/docs/en/docs/integrations/langchain.md
@@ -101,10 +101,16 @@ LangGraph adapter's scope or environment prefix:
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `POWERCONTEXT_LANGCHAIN_BASE_URL` | `http://127.0.0.1:8000` | PowerContext Server URL |
+| `POWERCONTEXT_LANGCHAIN_ALLOW_INSECURE_HTTP` | `false` | Explicitly permit non-loopback plaintext HTTP |
 | `POWERCONTEXT_LANGCHAIN_TOKEN` | unset | Bare bearer token passed to the Client |
 | `POWERCONTEXT_LANGCHAIN_SCOPE_ID` | unset | Existing Server Scope to use instead of the Server default |
 | `POWERCONTEXT_LANGCHAIN_TIMEOUT` | `10` | Client timeout in seconds |
 | `POWERCONTEXT_LANGCHAIN_MAX_BYTES` | `8000` | Prepared-context size limit |
+
+Loopback HTTP is allowed by default; non-loopback HTTP requires explicit consent through the environment variable
+above or `allow_insecure_http=True` on `PowerContextLangChainSettings` or `PowerContextScope`. HTTPS certificate
+validation stays enabled. Common environment settings and endpoint-bound saved consent are described in
+[Connect to a remote Server](../operate/connect-remote-server.md). The framework adapter does not have a setup installer.
 
 An explicit `PowerContextScope` value wins over environment configuration and must identify an existing Server Scope.
 If neither is set, the Server default Scope is used. The adapter never derives a Scope ID from Git, a path, the Agent,

--- a/docs/en/docs/integrations/langgraph.md
+++ b/docs/en/docs/integrations/langgraph.md
@@ -97,6 +97,7 @@ Configuration is read through pydantic-settings with the prefix `POWERCONTEXT_LA
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `POWERCONTEXT_LANGGRAPH_BASE_URL` | `http://127.0.0.1:8000` | PowerContext Server URL |
+| `POWERCONTEXT_LANGGRAPH_ALLOW_INSECURE_HTTP` | `false` | Explicitly permit non-loopback plaintext HTTP |
 | `POWERCONTEXT_LANGGRAPH_TOKEN` | unset | Bare token forwarded to `PowerContextClient` |
 | `POWERCONTEXT_LANGGRAPH_SCOPE_ID` | unset | Existing Server Scope to use instead of the Server default |
 | `POWERCONTEXT_LANGGRAPH_TIMEOUT` | `10` | Client timeout in seconds |
@@ -104,6 +105,11 @@ Configuration is read through pydantic-settings with the prefix `POWERCONTEXT_LA
 
 `PowerContextScope(base_url=..., token=..., timeout=...)` overrides these per run. A field left as `None` on the
 scope falls back to the environment value.
+
+Loopback HTTP is allowed by default; non-loopback HTTP requires explicit consent through the environment variable
+above or `allow_insecure_http=True` on `PowerContextLangGraphSettings` or `PowerContextScope`. HTTPS certificate
+validation stays enabled. Common environment settings and endpoint-bound saved consent are described in
+[Connect to a remote Server](../operate/connect-remote-server.md). The framework adapter does not have a setup installer.
 
 `POWERCONTEXT_LANGGRAPH_TOKEN` carries a **bare token**, not a complete `Authorization` header value. This differs from the
 `POWERCONTEXT_*_AUTHORIZATION` convention used by the Codex, Claude Code, and DeepSeek Harness plugins.

--- a/docs/en/docs/integrations/openclaw.md
+++ b/docs/en/docs/integrations/openclaw.md
@@ -17,7 +17,7 @@ uv tool install --force "powercontext[cli,server] @ git+https://github.com/ocean
 powercontext setup openclaw
 ```
 
-Without `--server-url`, setup configures the plugin for the Server default at `http://127.0.0.1:8000`.
+Without an explicit URL, setup resolves environment and saved client settings; otherwise it uses `http://127.0.0.1:8000`.
 
 A local checkout works as well:
 
@@ -100,9 +100,9 @@ chmod 600 ~/.openclaw/.env
 openclaw gateway restart
 ```
 
-Do not put credentials in the endpoint. The current configuration accepts both HTTP and HTTPS URLs; use plain HTTP
-only for a trusted loopback Server and use HTTPS for every remote Server. This is an operator security requirement,
-not a restriction currently enforced by the CLI or plugin.
+Do not put credentials in the endpoint. The CLI and plugin reject non-loopback HTTP by default. Use HTTPS or explicitly
+set `POWERCONTEXT_OPENCLAW_ALLOW_INSECURE_HTTP=true` (or the plugin's `allowInsecureHttp` setting). HTTPS certificate
+validation stays enabled. See [Connect to a remote Server](../operate/connect-remote-server.md) for setup and saved consent.
 
 ## Verify the installation
 

--- a/docs/en/docs/integrations/opencode.md
+++ b/docs/en/docs/integrations/opencode.md
@@ -56,8 +56,10 @@ workspace binding, then the Server default. The resolved Scope is fixed to the S
 boundary. Set the explicit variable only to an existing Server-owned Scope.
 
 For a Server using optional bearer authentication, set the complete header in
-`POWERCONTEXT_OPENCODE_AUTHORIZATION`. Never put credentials in the URL. Plain HTTP is accepted only for loopback
-hosts. Set `POWERCONTEXT_OPENCODE_CAPTURE_PROMPTS=false` when prompts must not be persisted as Source evidence.
+`POWERCONTEXT_OPENCODE_AUTHORIZATION`. Never put credentials in the URL. Plain HTTP is allowed on loopback by default;
+for non-loopback HTTP, explicitly set `POWERCONTEXT_OPENCODE_ALLOW_INSECURE_HTTP=true`. HTTPS certificate validation
+stays enabled. See [Connect to a remote Server](../operate/connect-remote-server.md) for setup and saved consent.
+Set `POWERCONTEXT_OPENCODE_CAPTURE_PROMPTS=false` when prompts must not be persisted as Source evidence.
 
 ## Verify the installation
 

--- a/docs/en/docs/integrations/pi.md
+++ b/docs/en/docs/integrations/pi.md
@@ -96,8 +96,9 @@ export POWERCONTEXT_PI_AUTHORIZATION="Bearer $POWERCONTEXT_LOCAL_TOKEN"
 pi
 ```
 
-Do not put credentials in `POWERCONTEXT_PI_BASE_URL`. The package accepts plain HTTP only for loopback Servers; use
-HTTPS for any remote Server.
+Do not put credentials in `POWERCONTEXT_PI_BASE_URL`. Plain HTTP is allowed on loopback by default. For a non-loopback
+Server, use HTTPS or explicitly set `POWERCONTEXT_PI_ALLOW_INSECURE_HTTP=true`; HTTPS certificate validation stays enabled.
+See [Connect to a remote Server](../operate/connect-remote-server.md) for setup and saved consent.
 
 ## Verify the installation
 
@@ -113,7 +114,8 @@ changing PowerContext environment variables.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `POWERCONTEXT_PI_BASE_URL` | `http://127.0.0.1:8000` | Server base URL; non-loopback endpoints must use HTTPS |
+| `POWERCONTEXT_PI_BASE_URL` | `http://127.0.0.1:8000` | Server base URL |
+| `POWERCONTEXT_PI_ALLOW_INSECURE_HTTP` | `false` | Explicitly permit non-loopback plaintext HTTP |
 | `POWERCONTEXT_PI_SCOPE_ID` | unset | Explicit existing Scope before workspace binding and Server default |
 | `POWERCONTEXT_PI_AUTHORIZATION` | unset | Complete `Bearer <token>` header for package HTTP requests |
 | `POWERCONTEXT_PI_CAPTURE_PROMPTS` | `true` | Capture eligible user prompts as Source evidence |

--- a/docs/en/docs/integrations/pydantic-ai.md
+++ b/docs/en/docs/integrations/pydantic-ai.md
@@ -65,6 +65,7 @@ export POWERCONTEXT_PYDANTIC_AI_TOKEN=opaque-server-token
 | Variable | Default | Validation and behavior |
 | --- | --- | --- |
 | `POWERCONTEXT_PYDANTIC_AI_BASE_URL` | `http://127.0.0.1:8000` | HTTP(S), without credentials, query, or fragment |
+| `POWERCONTEXT_PYDANTIC_AI_ALLOW_INSECURE_HTTP` | `false` | Explicitly permit non-loopback plaintext HTTP |
 | `POWERCONTEXT_PYDANTIC_AI_TOKEN` | unset | Bare printable token stored as `SecretStr` |
 | `POWERCONTEXT_PYDANTIC_AI_SCOPE_ID` | unset | Existing explicit Server Scope, up to 256 characters; unset selects the Server default |
 | `POWERCONTEXT_PYDANTIC_AI_TIMEOUT` | `10` | Positive seconds |
@@ -75,6 +76,11 @@ export POWERCONTEXT_PYDANTIC_AI_TOKEN=opaque-server-token
 
 Unlike the Codex and Claude Code plugin settings that accept a complete authorization value, this adapter accepts a
 bare token. Do not include `Bearer ` or pass a complete `Authorization` header; the public Client adds the scheme.
+
+Loopback HTTP is allowed by default; non-loopback HTTP requires the opt-in above or
+`PowerContextSettings(allow_insecure_http=True)`. HTTPS certificate validation stays enabled. See
+[Connect to a remote Server](../operate/connect-remote-server.md) for common environment settings and endpoint-bound
+saved consent. The framework adapter does not have a setup installer.
 
 Both `PowerContext` and `PowerContextToolset` accept a `PowerContextSettings` instance, a stable `id` (default
 `powercontext`), and a fixed or callable `scope_id`:

--- a/docs/en/docs/integrations/workbuddy.md
+++ b/docs/en/docs/integrations/workbuddy.md
@@ -218,6 +218,7 @@ changing them.
 | Variable | Purpose |
 | --- | --- |
 | `POWERCONTEXT_WORKBUDDY_SERVER_URL` | PowerContext server URL (default `http://127.0.0.1:8000`) |
+| `POWERCONTEXT_WORKBUDDY_ALLOW_INSECURE_HTTP` | Explicitly permit non-loopback plaintext HTTP for hooks (default `false`) |
 | `POWERCONTEXT_WORKBUDDY_AUTHORIZATION` | Complete authorization header, e.g. `Bearer <token>` |
 | `POWERCONTEXT_WORKBUDDY_SCOPE_ID` | Explicit server-owned Scope ID |
 | `POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS` | Capture user prompts as Sources (default `true`) |
@@ -228,7 +229,10 @@ changing them.
 
 The hook validates its PowerContext MCP URL and derives the HTTP API base by
 removing the final `/mcp` path segment. MCP URLs cannot contain credentials,
-query strings, or fragments; plain HTTP is accepted only for loopback hosts.
+query strings, or fragments. Plain HTTP is allowed on loopback by default; non-loopback HTTP requires
+`POWERCONTEXT_WORKBUDDY_ALLOW_INSECURE_HTTP=true`. Setup configures the Hook and native MCP URL, but WorkBuddy's
+own MCP policy still applies. HTTPS certificate validation stays enabled. See
+[Connect to a remote Server](../operate/connect-remote-server.md).
 
 ## Resolve the project scope
 

--- a/docs/en/docs/operate/connect-remote-server.md
+++ b/docs/en/docs/operate/connect-remote-server.md
@@ -1,0 +1,91 @@
+---
+title: Connect to a remote Server
+description: Configure client endpoints and explicitly opt in to unencrypted HTTP when needed.
+---
+
+# Connect to a remote Server
+
+Remote deployments should use HTTPS. IPv4/IPv6 loopback HTTP (including `localhost`) remains allowed by default.
+PowerContext-owned clients reject other HTTP URLs unless you explicitly opt in. Private IP addresses and VPN
+addresses are still non-loopback: a private network does not itself encrypt HTTP.
+
+## Guided setup
+
+Use the same source/ref for the installed PowerContext tool and the integration. On the machine that runs your agent:
+
+```bash
+powercontext setup claude-code --source oceanbase/powercontext --ref master \
+  --server-url http://192.0.2.10:8000
+```
+
+In an interactive terminal, setup explains the plaintext risk and asks for confirmation; pressing Enter declines.
+Setup resolves the host URL environment variable and `POWERCONTEXT_CLIENT_SERVER_URL` before asking, so the same
+confirmation appears when the address came from the environment rather than `--server-url`.
+
+For automation, `--json` and non-TTY input never prompt. Supply an explicit decision:
+
+```bash
+powercontext setup claude-code --server-url http://192.0.2.10:8000 --allow-insecure-http --json
+```
+
+Replace `claude-code` with `codex`, `dsh`, `openclaw`, `opencode`, `pi`, `hermes`, or `workbuddy`.
+The same options work with `setup select --host ...` for its catalog hosts; WorkBuddy uses its dedicated command.
+A declined or missing consent fails before installation starts. A warning is written to stderr, leaving JSON stdout
+parseable. Successful installation saves the endpoint and consent for new sessions; it does not save credentials.
+
+## Settings and precedence
+
+Setup writes `~/.config/powercontext/clients.json`; override this path with `POWERCONTEXT_CLIENT_CONFIG_FILE`.
+The file has a `version: 1` and a `hosts` map. Each host stores only `server_url` and `allow_insecure_http`.
+Saved consent is tied to that endpoint: changing the effective URL does not inherit permission from a different URL.
+
+For setup, an explicit CLI value takes precedence over the host environment, then the common environment, then
+saved settings. Runtime host-native settings are also supported where available; consult the integration guide
+for its URL source. An explicit false overrides inherited true. Environment boolean values accept
+`true/false`, `1/0`, `yes/no`, and `on/off`; invalid values fail closed.
+
+| Host | Opt-in environment variable |
+| --- | --- |
+| All PowerContext clients | `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP` |
+| Codex | `POWERCONTEXT_CODEX_ALLOW_INSECURE_HTTP` |
+| Claude Code | `POWERCONTEXT_CLAUDE_ALLOW_INSECURE_HTTP` |
+| DSH, Pi, OpenCode | `POWERCONTEXT_DSH_ALLOW_INSECURE_HTTP`, `POWERCONTEXT_PI_ALLOW_INSECURE_HTTP`, `POWERCONTEXT_OPENCODE_ALLOW_INSECURE_HTTP` |
+| OpenClaw, Hermes, WorkBuddy | `POWERCONTEXT_OPENCLAW_ALLOW_INSECURE_HTTP`, `POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP`, `POWERCONTEXT_WORKBUDDY_ALLOW_INSECURE_HTTP` |
+
+For the generic content CLI, the flag is a top-level option:
+
+```bash
+powercontext --server-url http://192.0.2.10:8000 --allow-insecure-http ready
+powercontext doctor --server-url http://192.0.2.10:8000 --allow-insecure-http
+powercontext doctor claude-code --json
+```
+
+Doctor reports explicitly insecure transport as `degraded` (nonzero exit status), not as encrypted or silently
+healthy. This warning alone does not mean installation or connectivity failed.
+
+## MCP, hooks, and upgrade boundaries
+
+Setup configures both the native MCP URL and hook endpoint for Codex, Claude Code, and WorkBuddy.
+Codex hooks intentionally use the installed plugin's `.mcp.json`; rerun setup after a plugin update that replaces
+that file. Do not change only a hook URL environment variable and assume the native MCP URL changed too.
+
+DSH custom `cordis.patch.yml` layers can override setup-managed settings. Setup accepts the standard empty
+profile patch, but stops before installation when custom overlays are present: align the endpoint/consent
+manually or remove those overrides before rerunning setup. Doctor reports unsupported native composition
+(including unsupported JSON5/includes) as unknown/failed instead of claiming a safe loopback connection.
+
+MiniMax and the generic Agent Plugin delegate MCP transport to the host and have no PowerContext setup subcommand
+or independent HTTP client. Their host may have its own restrictions; this flag cannot override host policy.
+LangChain, LangGraph, Pydantic AI, and the Bub evaluation adapter expose client consent without adding a host installer.
+
+## Security boundary
+
+The opt-in allows plaintext HTTP only. It does not disable HTTPS certificate verification, add authentication,
+change the Server bind address, enable the Dashboard, or bypass a host's own MCP policy. Tokens and conversation
+content can be read or modified in transit. IP allowlists limit access but do not encrypt traffic.
+
+Keep Server authentication enabled for remote access. The Server's own binding and Receiver enrollment safety
+checks remain separate; the client opt-in is not a replacement for those settings.
+
+An SSH tunnel is an alternative: run `ssh -N -L 18000:127.0.0.1:8000 your-server` on the agent machine, then configure
+`http://127.0.0.1:18000` without the insecure opt-in. See [Deploy the Server](deploy-server.md).

--- a/docs/en/docs/operate/deploy-server.md
+++ b/docs/en/docs/operate/deploy-server.md
@@ -5,10 +5,6 @@ description: Run PowerContext with persistent data, health checks, authenticatio
 
 # Deploy the Server
 
-First install from the `master` branch of `oceanbase/powercontext` and generate configuration with
-[Quick Start](../get-started/quickstart.md). This page covers persistent operation and remote access.
-When Server and Agent run on different machines, install on each machine and keep the plugin repository and ref matched.
-
 Windows support is `experimental`.
 
 `powercontext server run` is a foreground process. On a personal macOS, Linux, or Windows workstation, PowerContext can register
@@ -20,16 +16,13 @@ container platform or an administrator-owned service manager.
 Install and start the optional current-user service:
 
 ```bash
-powercontext service install --env-file /absolute/path/to/.env
+powercontext service install
 powercontext service status
 ```
 
 On Windows, the command asks whether to enable startup at the current user's next login when neither
 `--start-on-login` nor `--no-start-on-login` is supplied; pressing Enter keeps login auto-start disabled. Use either
 option for a non-interactive choice.
-
-Replace the example with the absolute path to the wizard's `.env`. Stop a foreground Server on the same port with
-`Ctrl-C` before installing the service. Use `service status` to confirm the registered service is actually running.
 
 Linux uses `systemd --user` and writes logs to the user journal. macOS uses a per-user LaunchAgent, and Windows uses a current-user Task Scheduler task; both write stdout and stderr below the PowerContext user data directory. `service status` reports the exact log selector or path.
 
@@ -70,46 +63,8 @@ For access from another machine:
 
 The built-in command serves HTTP and has no TLS options. Terminate HTTPS outside PowerContext.
 
-In “Custom listener address and client URL”, `0.0.0.0` means accept connections on all interfaces. It is not a browser
-address and does not enable HTTPS. PowerContext clients permit plain HTTP only on loopback addresses, so a remote
-`http://server:8000` is not a supported client URL. For a first remote check without a domain, certificate, or HTTPS
-proxy, use SSH forwarding.
-
-## Access from another computer with SSH
-
-On the Server machine, select “Access from other devices” → “SSH port forwarding” in the wizard. Enter your actual
-SSH host or alias and the client's forwarded port. The Server keeps listening on `127.0.0.1:8000`.
-After starting it with the generated configuration, run the printed tunnel command on the client computer, for example:
-
-```bash
-ssh -N -L 18000:127.0.0.1:8000 user@server
-```
-
-Replace `user@server` with your normal SSH address or alias and keep this terminal running. Open
-`http://127.0.0.1:18000/dashboard/home` in the client browser and sign in with the Server token.
-SSH encrypts the tunnel; the HTTP connections use loopback at each endpoint.
-
-An Agent on the Server machine uses `http://127.0.0.1:8000`; an Agent on the client computer uses
-`http://127.0.0.1:18000`. The wizard asks which machine hosts the Agent. Securely transfer the corresponding
-`.env` to that machine and load it. Check `POWERCONTEXT_CLIENT_SERVER_URL` and the Agent-specific URL. Copy it only
-to a trusted machine because it contains the complete installation configuration. Codex's MCP URL must also match its Hook URL;
-see [Codex connection steps](../integrations/codex.md).
-
-If the local port is occupied, choose another port and update the browser/client URLs together. The tunnel stops
-when SSH exits, while the remote Server continues running. Starting a Server inside remote tmux does not establish
-port forwarding to your Mac.
-
-## Use external HTTPS
-
-With an existing Nginx, Caddy, gateway, or load balancer, choose “HTTPS reverse proxy” and enter its complete public URL,
-such as `https://memory.example.com`. A proxy on the Server machine uses `http://127.0.0.1:8000` as its upstream;
-a proxy on another machine needs the corresponding listener and network configuration.
-
-Configure certificates, DNS, TLS, and forwarding in that external component; the wizard does not install them.
-`POWERCONTEXT_SERVER_PUBLIC_URL=https://...` declares the external URL but does not add TLS to the built-in Server.
-The proxy must support streaming `/mcp` connections, preserve `Authorization`, and forward the correct external host
-and scheme for Dashboard sign-in checks. Verify the external `/health/ready`, Dashboard login, and MCP from the client,
-not only the local Server port. Without an existing HTTPS service, use the complete SSH workflow above.
+Configure the Agent on the client machine using [Connect to a remote Server](connect-remote-server.md).
+Its `--allow-insecure-http` option is client-side and does not change the Server listener or authentication.
 
 ## Run from an installed tool
 
@@ -133,25 +88,17 @@ powercontext server run --env-file /etc/powercontext/powercontext.env
 ```
 
 The successful installation summary prints the environment file actually used. If Bearer authentication is enabled,
-read `POWERCONTEXT_SERVER_AUTH_TOKEN` from that file; the command never prints the token value. The basic model-free
-template leaves authentication disabled. The wizard generates a token when Dashboard or authenticated access
-requires one and no existing token is available.
+read `POWERCONTEXT_SERVER_AUTH_TOKEN` from that file; the command never prints the token value. Authentication is
+disabled by default, so no token is generated automatically.
 
 The file may contain provider credentials or a bearer token, so restrict it to the Server operator. For `server run`,
-process environment variables override same-named file values. `config init` opens a bilingual wizard: choose storage,
-usage scenario, and capabilities, then configure Dashboard/access and only the necessary model connections.
-It selects English or Chinese from the system language (`LC_ALL` before `LC_MESSAGES` before `LANG`, then system
-preferences), with English fallback for an unknown or unsupported language. Change the language on the first screen
-or pass `--language en` or `--language zh`; add `--template` to retain the basic model-free template.
-
-The wizard writes configuration and follow-up instructions. It does not start or register services, migrate a
-database, or probe remote storage and model endpoints. Existing local SQLite metadata can be inspected read-only.
-After saving, perform the deployment checks below and, when enabled, the
-[Memory extraction and vector search checks](../get-started/configure-models.md).
+process environment variables override same-named file values. `config init` creates a model-free base configuration; see
+[Enable extraction and vector search](../get-started/configure-models.md)
+when you need to add inference models and enable the full capability set.
 
 Whether the Server runs in the foreground, in Docker, or as a personal service, startup or installation output warns
 that missing models may affect some artifact features and links to the
-[configuration reference](configuration.md).
+[configuration reference](https://powercontext.oceanbase.io/en/docs/reference/configuration/).
 The notice is omitted when both generation and embedding models are configured.
 
 ## Run with Docker

--- a/docs/en/docs/operate/meta.json
+++ b/docs/en/docs/operate/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "deploy-server",
+    "connect-remote-server",
     "artifact-processing-migration",
     "observability",
     "trace-with-phoenix",

--- a/docs/zh/docs/get-started/install-and-run.md
+++ b/docs/zh/docs/get-started/install-and-run.md
@@ -1,152 +1,163 @@
 ---
 title: 安装和运行
-description: 选择安装版本和存储，生成配置，并启动或更新 PowerContext。
+description: 从 Git 安装 PowerContext，并运行本地 Server。
 ---
 
 # 安装和运行
 
-首次使用请按[快速开始](quickstart.md)完成“安装 → 向导 → 启动 → 接入 Agent → 记忆验收”。
-本页补充安装角色、存储与更新，命令使用 `oceanbase/powercontext` 的默认安装来源。
+跨机器连接 Agent 时，请阅读[连接远程 Server](../operate/connect-remote-server.md)，了解地址引导确认、
+非交互安装及绑定地址的明文 HTTP 同意设置。
 
-## 平台与准备
+首次使用请从 [Quick Start](quickstart.md)开始。本页说明版本选择、平台要求、安装角色、启动、诊断和更新。
 
-| 项目 | 要求 |
+## 平台支持
+
+| 平台 | 状态 |
 | --- | --- |
-| PowerContext | Python 3.11+、Git、[uv](https://docs.astral.sh/uv/getting-started/installation/) |
 | macOS、Linux | 支持 |
-| Windows | `experimental`；本文命令使用 Bash，不能直接粘贴到 PowerShell |
-| 嵌入式 seekdb | Linux 或 macOS，且当前 Python/架构有兼容的 `pylibseekdb` wheel |
-| Agent | 在运行 Agent 的机器上安装对应 CLI |
-| 完整记忆 | 可用的 Generation 和 Embedding 模型 API |
+| Windows | `experimental` |
+
+Windows 的 CLI、Server 和个人服务支持为试验性；各 Agent Host 仍需满足自身的平台要求。
+使用 Bash 语法的示例需要 Bash 环境，不可直接粘贴到 PowerShell。嵌入式 seekDB 不支持 Windows。
 
 ## 选择版本
 
-本页的配置向导体验来自指定开发分支，不能假定任意已发布包都包含相同向导。
-安装工具和 Agent 插件时保持仓库及 ref 一致：
+发布版与集成使用相同 tag。例如安装 `0.2.0`：
+
+```bash
+uv tool install "powercontext[cli,server]==0.2.0"
+```
+
+后续示例使用 `master`，包含尚未发布的能力。核对[能力矩阵](../integrations/capabilities.md)，
+不要将 `master_only` 或 `experimental` 能力当作发布版承诺。
+
+## 安装应用
+
+需要在 macOS、Linux 或 Windows 上准备 Python 3.11 或更新版本、Git 和
+[`uv`](https://docs.astral.sh/uv/)，然后从指定 Git ref 直接安装 PowerContext：
 
 ```bash
 uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
-powercontext --version
 ```
 
-`uv tool` 使用隔离环境，不会在当前目录创建源码仓库。`--force` 用于刷新该分支当前对应的安装。
-需要固定验收版本时，可将安装命令中的 ref 和后续 setup 的 `--ref` 同时替换为同一个已存在的 tag；也可使用同一份源码 checkout。
-不要只把插件改成另一个仓库的 `master`。
+该命令不会留下需要自行管理的仓库工作副本。Git 会沿用本机的凭据配置，包括 credential helper 和 SSH 设置。
+如需使用 SSH，请把 HTTPS URL 换成当前环境允许的 Git URL。`--force` 还会从所选 Git ref 当前指向的 commit
+刷新已安装工具；如果不加该参数，`uv` 可能只提示相同 requirement 已安装，而不会获取更新后的 `master`。
 
-## 使用镜像重试依赖下载
+安装指定分支或 tag 时，替换最后一个 `@` 后的 `master`。
+Agent 的安装、连接参数和验证步骤见[各自的集成文档](../integrations/index.md)，并使用与 Server 相同的 ref。
 
-如果 GitHub 源码已拉取成功，但从 PyPI 下载 Python 依赖很慢，或出现网络/TLS 错误，可用阿里云 HTTPS 镜像重试本次安装：
+## 运行本地 Server
 
 ```bash
-uv tool install --force --default-index https://mirrors.aliyun.com/pypi/simple "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+powercontext server run
 ```
 
-这个参数只对本条命令生效，不修改全局 uv 配置；它覆盖 Python 依赖（包括构建依赖）的下载源，不代理 GitHub 源码访问。
-如果失败发生在拉取 GitHub 源码阶段，需要另行解决 GitHub 的连接问题。镜像使用 HTTPS，无需增加 `--trusted-host`
-或关闭证书验证。安装成功后，继续下面的配置向导步骤。
+未设置环境变量时，Server 会：
 
-## 生成配置与选择存储
+- 监听 `127.0.0.1:8000`；
+- 在 `/mcp` 启用 Streamable HTTP MCP；
+- 创建默认 Scope；
+- 在操作系统的用户数据目录中创建持久化 SQLite 数据库；
+- 无需推理服务即可支持显式 Memory 操作。
 
-在专用目录运行向导：
+按 `Ctrl-C` 可正常关闭。再次运行该命令会打开同一个数据库。
+
+Dashboard 是个人使用和演示的可选内容查看器，默认关闭。它不需要单独安装前端或配置模型。
+需要使用时，在受保护的环境文件中设置以下值，并将 token 示例替换为自己的长随机凭据：
+
+```dotenv
+POWERCONTEXT_SERVER_DASHBOARD_ENABLED=true
+POWERCONTEXT_SERVER_ACCESS_MODE=enforced
+POWERCONTEXT_SERVER_AUTH_TOKEN=replace-with-your-random-token
+```
 
 ```bash
-mkdir -p ~/powercontext-demo
-cd ~/powercontext-demo
-powercontext config init --language zh --output .env
+chmod 600 /path/to/powercontext.env
+powercontext config validate --env-file /path/to/powercontext.env
+powercontext server run --env-file /path/to/powercontext.env
 ```
 
-不传 `--language` 时，向导先根据系统语言选择中英文，无法判断或不支持时使用英语；首屏可以切换。
-`--template` 生成无模型基础模板，跳过交互；首次体验完整记忆不要加它。
+打开 `http://127.0.0.1:8000/dashboard/home`，输入同一个 token。更改端口后使用实际端口。
+该 token 同时用于 Server API 和 MCP，已连接的 Agent 也需配置它。CLI 不会自动读取目录中的 `.env` 文件。
 
-向导按存储、使用场景、能力、Dashboard/网络、模型、后台周期和 Agent 顺序收集信息。
-已有环境文件会进入复用或重新确认流程，覆盖时保留备份。它不会迁移旧数据库，也不会从一个 OceanBase 连接
-自动恢复所有模型凭据和部署设置；请保留原环境文件和真实数据路径。检查已有 SQLite 元数据不等于验证全部服务可用。
+首次登录选择 Server 默认 Scope，未保存内容时显示空状态。通过 Agent 或公开 API 保存一条 Memory，
+再刷新同一 Scope 的记忆页即可查看。经验、技能、交接和用量也来自实际保存记录；页面不采集会话、不运行生成，
+也不批准候选。Dashboard 和 Agent 必须连接同一个 Server、使用同一个 Scope。
 
-| 存储选择 | 使用方式 |
-| --- | --- |
-| SQLite | 本地文件，无需额外数据库服务，适合首次验收 |
-| 嵌入式 seekdb | 本机运行；向导可增量安装缺失的 seekdb 依赖 |
-| OceanBase | 提供已有服务的连接参数；启动后检查网络、认证与数据库就绪状态 |
-| 已有 PowerContext Server | 只生成客户端连接配置，不在本机另建 Server |
+所有 token 持有者使用同一个身份。多成员 RBAC 部署应保持 Dashboard 关闭，通过 API、MCP 或宿主集成访问内容。
+网络与凭据配置见[部署 Server](../operate/deploy-server.md)。
 
-### seekdb 依赖安装
+这种最小启动方式不会启用依赖模型的抽取或向量搜索。如需生成并校验一份显式环境文件以启用这些能力，请继续阅读
+[启用提取与向量搜索](configure-models.md)。
 
-选择 seekdb 后，向导会检查依赖，并在征得同意后读取当前安装版本声明的依赖约束进行增量安装。
-下载在后台进行，你可以继续回答其余问题；保存时若仍未完成，会直接显示活动进度并等待，不显示虚构的下载百分比。
+## 使用嵌入式 seekDB
 
-显式设置的 `UV_DEFAULT_INDEX` 或 `UV_INDEX_URL` 优先。没有这两项覆盖时，中国时区直接使用
-[阿里云 PyPI 镜像](https://mirrors.aliyun.com/pypi/simple/)；其他时区先用默认索引，失败后回退阿里云。
-普通安装失败会输出一条可复制的增量安装命令；没有兼容 wheel 时应换用 SQLite/OceanBase 或受支持的 Python/平台。
-
-也可以在首次安装时带上依赖：
+在有兼容 `pylibseekdb` wheel 的 Linux 和 macOS 系统上可以使用嵌入式 seekDB；Windows 不支持该嵌入式
+后端。安装或替换工具时加入可选的 seekDB extra：
 
 ```bash
 uv tool install --force "powercontext[cli,server,seekdb] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
-seekdb 使用 `POWERCONTEXT_SERVER_DATABASE_PATH` 指定本地目录，不接受 SQLite/SQLAlchemy 的
-`POWERCONTEXT_SERVER_DATABASE_URL`。从 SQLite 改为 seekdb 时，不能让旧 URL 留在启动进程的环境中；
-选择新后端不会自动迁移原有记忆。
-
-## 启动与检查
+从 SQLite 切换时，需要从 Server 进程环境中删除 `POWERCONTEXT_SERVER_DATABASE_URL`；seekDB 不接受显式的
+SQLAlchemy 数据库 URL。然后选择 seekDB 后端并启动 Server：
 
 ```bash
-powercontext config validate --env-file .env
-powercontext server run --env-file .env
+unset POWERCONTEXT_SERVER_DATABASE_URL
+export POWERCONTEXT_SERVER_DATABASE_KIND=seekdb
+powercontext server run
 ```
 
-`server run` 是前台服务；按 `Ctrl-C` 正常退出。在另一个终端加载客户端文件后检查：
+当前目录存在 `.env` 时，`server run` 会自动加载该文件。可以在 shell 中导出变量来覆盖文件值，使用
+`--env-file <path>` 选择其他文件，或使用 `--no-env-file` 忽略环境文件。进程管理器和容器通常应提供显式环境，
+不要依赖其工作目录。
+
+PowerContext 固定使用 seekDB 内置的 `test` 数据库。未设置 `POWERCONTEXT_SERVER_DATABASE_PATH` 时，实例保存在
+PowerContext 用户数据目录的 `seekdb` 子目录中；如果设置了 `POWERCONTEXT_HOME`，默认路径为
+`$POWERCONTEXT_HOME/seekdb`。只有需要其他位置时才设置 `POWERCONTEXT_SERVER_DATABASE_PATH`。
+
+在另一个终端确认 Server 和数据库已经就绪：
 
 ```bash
-set -a
-. ./.env
-set +a
 powercontext doctor
 powercontext ready
 powercontext capabilities
 ```
 
-当前目录的 `.env` 会由 `server run` 自动读取，也可显式指定 `--env-file`，或用 `--no-env-file` 禁用。
-进程中已导出的同名变量优先于文件；改了文件却没生效时检查旧终端环境。服务管理器应使用明确的绝对文件路径，
-见[部署 Server](../operate/deploy-server.md)。
-
-不带模型配置的最小 Server 也可以运行：默认 SQLite、`127.0.0.1:8000`、MCP `/mcp`，Dashboard 关闭。
-它支持显式 Memory 写入与读取，但普通 Source 不会自动变成 Topic Memory。完整体验请使用向导生成的配置。
-
-## Agent 安装与配置边界
-
-在运行 Agent 的机器上执行对应命令，且先加载共享的 `.env`：
+## 验证安装
 
 ```bash
-powercontext setup codex
-powercontext doctor codex
+powercontext doctor
+powercontext ready
+powercontext capabilities
 ```
 
-Claude Code 使用：
+`doctor` 检查已安装的包、Server 存活状态和 Server 就绪状态，不要求安装集成。Server 就绪检查涵盖数据库和
+每个已配置的推理服务。Runtime 或数据库故障返回 `not_ready`；推理服务故障返回 `degraded`，不会使数据库
+操作退出流量。`ready` 和 `capabilities` 用于查看运行中服务的就绪状态和已启用能力。
+Agent 诊断见[各自的集成文档](../integrations/index.md)；Server 状态解释和恢复步骤见[排查问题](../operate/troubleshoot.md)。
+
+需要长期运行进程、使用 Docker、启用鉴权或允许远程访问时，请继续阅读[部署 Server](../operate/deploy-server.md)。
+
+## 更新或替换安装
+
+使用指定 ref 替换现有工具：
 
 ```bash
-powercontext setup claude-code --server-url "$POWERCONTEXT_CLAUDE_SERVER_URL"
-powercontext doctor claude-code
+uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@<ref>"
 ```
 
-向导生成客户端文件，setup 安装插件，Server 执行持久化与模型处理；三者需要分别完成。
-MCP、Hook、浏览器应使用同一个服务，Scope 必须使用 Server 实际返回的 ID。
-完整接线见[快速开始](quickstart.md)、[Codex](../integrations/codex.md)和[Claude Code](../integrations/claude-code.md)。
+按[各自的集成文档](../integrations/index.md)更新已安装宿主，并使用同一个 ref。更新后重启 Server，再开启新的宿主会话。只要没有修改
+`POWERCONTEXT_HOME` 或数据库 URL，现有 SQLite 数据会继续保留。
 
-## 更新或重新安装
+## 为 Python 项目安装角色
 
-重新运行上面的同源安装命令，更新匹配的 Agent 插件，再重启 Server 和 Agent。
-使用个人服务时，按[服务安装步骤](../operate/deploy-server.md#运行持久个人-server)重新注册更新后的程序和环境文件。
-
-工具升级不会主动删除数据，但改变 `POWERCONTEXT_HOME`、数据库 URL 或数据库目录，会让服务打开另一份存储。
-更新前保留环境文件和数据库备份；不要为了排错删除 SQLite 文件。
-
-## 在 Python 应用中使用
-
-`uv tool` 的隔离环境不会给另一 Python 项目提供可导入的 SDK。应用需要 Client SDK 时，在应用目录执行：
+如果应用需要导入异步 Client SDK，应把它加入该应用自己的环境：
 
 ```bash
 uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
-进程内组合使用 `builtin`，独立服务使用 `server`，客户端 SDK 使用 `client`，命令行使用 `cli`。
+进程内 Python 组合使用 `builtin`，服务使用 `server`，Python SDK 使用 `client`，基于 Server 的命令行使用
+`cli`。只安装在 `uv tool` 隔离环境中的 extra 不能被另一个 Python 项目直接导入。

--- a/docs/zh/docs/get-started/quickstart.md
+++ b/docs/zh/docs/get-started/quickstart.md
@@ -25,7 +25,7 @@ powercontext config init --language zh --output .env
 首次本机体验可以这样选择：
 
 1. **存储**：SQLite 可直接开始；需要体验嵌入式 seekdb 时选择 seekdb，并同意后台安装缺失依赖。
-2. **使用场景**：Agent、浏览器和 Server 都在这台机器时选“只在当前机器”。Server 在另一台机器时，先看[远程部署](../operate/deploy-server.md#通过-ssh-从另一台电脑访问)。
+2. **使用场景**：Agent、浏览器和 Server 都在这台机器时选“只在当前机器”。Server 在另一台机器时，先看[连接远程 Server](../operate/connect-remote-server.md)。
 3. **记忆能力**：选择“完整记忆能力”，填写 Generation 和 Embedding API；不确定协议与维度时看[模型配置](configure-models.md)。
 4. **Dashboard**：开启，便于观察 Source 和记忆。向导会生成或沿用 Server Token。
 5. **后台处理**：可先使用各制品的推荐周期。检查间隔不是完成时限，模型处理还需要时间。

--- a/docs/zh/docs/integrations/agent-plugin.md
+++ b/docs/zh/docs/integrations/agent-plugin.md
@@ -40,6 +40,10 @@ uv run powercontext server run
 http://127.0.0.1:8000/mcp
 ```
 
+连接远程 Server 时，在加载插件的宿主中配置 MCP 地址。此插件由宿主负责传输，没有独立的 PowerContext HTTP
+Client 或 setup 子命令；`allow_insecure_http` 不能绕过宿主的 MCP 策略。连接和安全边界见
+[连接远程 Server](../operate/connect-remote-server.md)。
+
 ## 在 VS Code 中加载
 
 VS Code 支持通过 `chat.pluginLocations` 加载本地 Agent Plugin 目录。可以用

--- a/docs/zh/docs/integrations/claude-code.md
+++ b/docs/zh/docs/integrations/claude-code.md
@@ -158,7 +158,9 @@ claude
 Hook 会直接读取该进程环境变量，MCP 配置则把它展开到 `Authorization` header。变量不存在时，MCP header
 使用空值。不要把 token 放入 Server URL、插件选项、`.mcp.json`、Source metadata 或日志。
 
-明文 HTTP 只允许连接 `127.0.0.1`、`localhost` 或 `::1`。Claude Code 连接远程 Server 时必须使用 HTTPS。
+环回地址默认允许明文 HTTP。连接非环回 Server 时，使用 HTTPS，或显式设置
+`POWERCONTEXT_CLAUDE_ALLOW_INSECURE_HTTP=true`。引导安装可以保存该同意，并同时配置 Hook 与原生 MCP 地址；
+宿主自身的 MCP 策略仍然生效。参见[连接远程 Server](../operate/connect-remote-server.md)。
 
 ## 理解失败行为
 
@@ -202,6 +204,7 @@ claude plugin marketplace remove powercontext
 | 变量 | 默认值 | 含义 |
 | --- | --- | --- |
 | `POWERCONTEXT_CLAUDE_SERVER_URL` | `http://127.0.0.1:8000` | Hook 使用的 Server base URL |
+| `POWERCONTEXT_CLAUDE_ALLOW_INSECURE_HTTP` | `false` | 显式允许 PowerContext 请求使用非环回明文 HTTP |
 | `POWERCONTEXT_CLAUDE_SCOPE_ID` | 未设置 | 覆盖持久 binding 和 Server 默认 Scope |
 | `POWERCONTEXT_CLAUDE_AUTHORIZATION` | 未设置 | Hook 与 MCP 请求使用的完整 `Bearer <token>` header |
 | `POWERCONTEXT_CLAUDE_CAPTURE_PROMPTS` | `true` | 把用户 prompt 采集为普通 Source 证据 |
@@ -215,4 +218,4 @@ claude plugin marketplace remove powercontext
 Authorization 只能来自环境变量，不能加入 Server URL 或插件选项。
 
 `UserPromptSubmit` Hook 的外层超时为十秒。召回与采集共用一个 wall-clock 时间预算，但会独立降级。
-明文 HTTP 只允许连接 loopback endpoint；远程 Server 必须使用 HTTPS。修改环境变量后需要重启 Claude Code。
+显式允许 HTTP 不会关闭 HTTPS 证书校验。修改环境变量后需要重启 Claude Code。

--- a/docs/zh/docs/integrations/codex.md
+++ b/docs/zh/docs/integrations/codex.md
@@ -171,6 +171,7 @@ Scope 由 Hook 绑定，并注入 MCP 数据操作；不要把规划标题或目
 
 | 变量 | 默认值 | 含义 |
 | --- | --- | --- |
+| `POWERCONTEXT_CODEX_ALLOW_INSECURE_HTTP` | `false` | 显式允许 Hook 使用非环回明文 HTTP |
 | `POWERCONTEXT_CODEX_SCOPE_ID` | 未设置 | 显式选择一个已存在 Scope，不再解析 binding 和 Server 默认 Scope |
 | `POWERCONTEXT_CODEX_AUTHORIZATION` | 未设置 | Hook 与 MCP 请求使用的完整 `Bearer <token>` header |
 | `POWERCONTEXT_CODEX_CAPTURE_PROMPTS` | `true` | 把用户提示词采集为 Source 证据 |
@@ -178,6 +179,10 @@ Scope 由 Hook 绑定，并注入 MCP 数据操作；不要把规划标题或目
 | `POWERCONTEXT_CODEX_REQUEST_TIMEOUT_SECONDS` | `1` | Hook 单次请求超时 |
 | `POWERCONTEXT_CODEX_HTTP_BUDGET_SECONDS` | `4` | Hook 共享 HTTP 时间预算 |
 | `POWERCONTEXT_CODEX_FLUSH_MAX_CALLS` | `4` | 每个提示词最多执行的 flush 次数 |
+
+Hook 默认允许环回 HTTP，远程 HTTP 需要显式同意，HTTPS 证书校验仍然启用。setup 会保存同意并更新已安装插件的
+`.mcp.json`，Hook 和原生 MCP 都从该文件读取地址。只修改 Hook 的 URL 环境变量不会改变原生地址；升级覆盖
+`.mcp.json` 后需重新运行 setup。Codex 自身的 MCP 策略仍然生效。参见[连接远程 Server](../operate/connect-remote-server.md)。
 
 Codex Hook 外层超时为十秒。Server 不可用或拒绝鉴权时，恢复、采集和 flush 独立降级，不会阻塞 Codex。未显式指定
 Scope 时，插件依次解析 Session binding、workspace binding 和 Server 默认 Scope。配置变量必须存在于启动 Codex 的

--- a/docs/zh/docs/integrations/dsh.md
+++ b/docs/zh/docs/integrations/dsh.md
@@ -241,9 +241,14 @@ powercontext doctor dsh
 | 变量 | 默认值 | 含义 |
 | --- | --- | --- |
 | `POWERCONTEXT_DSH_BASE_URL` | `http://127.0.0.1:8000` | 插件使用的 Server 地址 |
+| `POWERCONTEXT_DSH_ALLOW_INSECURE_HTTP` | `false` | 显式允许非环回明文 HTTP |
 | `POWERCONTEXT_DSH_SCOPE_ID` | 未设置 | 在 workspace binding 和 Server 默认值之前显式选择已有 Scope |
 | `POWERCONTEXT_DSH_AUTHORIZATION` | 未设置 | 插件 HTTP 请求使用的完整 `Bearer <token>` header |
 | `POWERCONTEXT_DSH_CAPTURE_PROMPTS` | `true` | 把用户提示词采集为 Source 证据 |
 | `POWERCONTEXT_DSH_FLUSH_ON_CAPTURE` | `false` | 采集后等待 Source 处理 |
 
 `timeoutMs`、`requestTimeoutMs`、`maxBytes` 和 `flushMaxCalls` 是插件 patch 配置。Server 不可用时，召回和采集会降级；修改这些变量后需要重启 `dsh web`。
+
+环回地址默认允许明文 HTTP；远程 HTTP 需要显式设置 `POWERCONTEXT_DSH_ALLOW_INSECURE_HTTP=true`，
+HTTPS 证书校验仍然启用。主机地址变量依次读取 `BASE_URL`、`SERVER_URL`、`ENDPOINT`，然后才读取
+`POWERCONTEXT_CLIENT_SERVER_URL`。安装与持久化同意见[连接远程 Server](../operate/connect-remote-server.md)。

--- a/docs/zh/docs/integrations/evaluation.md
+++ b/docs/zh/docs/integrations/evaluation.md
@@ -13,5 +13,9 @@ Bub 插件通过 Python Client 连接 Server，提供 Memory 搜索、写入和�
 模型调用前可准备上下文。事件采集默认关闭，启用后可将已完成的事件作为 Sources，并定期 flush。
 它没有 Handoff 能力声明。
 
+环回 HTTP 默认可用；非环回 HTTP 需要设置 `POWERCONTEXT_BUB_ALLOW_INSECURE_HTTP=true`，或传入
+`PowerContextSettings(allow_insecure_http=True)`，对插件 Hook 和工具调用都生效。HTTPS 证书校验仍然启用。
+共享客户端配置见[连接远程 Server](../operate/connect-remote-server.md)；Bub 没有 PowerContext setup 安装命令。
+
 安装和采集开关见 [Bub 集成说明](https://github.com/oceanbase/powercontext/blob/master/integrations/bub/README.md)。
 评测方法、结果与限制见[基准测试](/zh/benchmarks/)。评测结果不代表所有 Agent 集成具有相同的能力或稳定性。

--- a/docs/zh/docs/integrations/hermes.md
+++ b/docs/zh/docs/integrations/hermes.md
@@ -70,6 +70,7 @@ binding 和默认 Scope。Hermes 只把 workspace 路径哈希用作外部 bindi
 | --- | --- |
 | `POWERCONTEXT_HERMES_CONFIG` | 配置文件路径；默认为 `$HERMES_HOME/powercontext/config.json` |
 | `POWERCONTEXT_HERMES_BASE_URL` | PowerContext Server URL |
+| `POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP` | 显式允许非环回明文 HTTP；默认为 `false` |
 | `POWERCONTEXT_HERMES_AUTHORIZATION` | 完整 authorization header，例如 `Bearer <token>` |
 | `POWERCONTEXT_HERMES_TOKEN` | 未设置 `AUTHORIZATION` 时使用的裸 token 简写 |
 | `POWERCONTEXT_HERMES_SCOPE_ID` | 显式的服务端 Scope ID |
@@ -81,9 +82,10 @@ binding 和默认 Scope。Hermes 只把 workspace 路径哈希用作外部 bindi
 | `POWERCONTEXT_HERMES_EVALUATION_TRACE` | 把召回上下文记录到敏感的本地 JSONL trace；默认关闭 |
 | `POWERCONTEXT_HERMES_EVALUATION_TRACE_PATH` | 覆盖 evaluation trace 目录 |
 
-应由 Hermes 向导把 authorization 保存到受保护的 `.env` secret store，不要把 token 写入 `config.json`。明文 HTTP
-只用于 loopback Server；连接远程部署前请阅读[部署 Server](../operate/deploy-server.md)。Evaluation trace 包含 prompt 和
-召回上下文，应保留在本机并按敏感数据保护。
+应由 Hermes 向导把 authorization 保存到受保护的 `.env` secret store，不要把 token 写入 `config.json`。环回地址默认
+允许明文 HTTP；远程连接推荐 HTTPS，也可显式设置 `POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP=true`，
+该选项不会关闭 HTTPS 证书校验。引导安装和绑定地址的持久化同意见[连接远程 Server](../operate/connect-remote-server.md)。
+Evaluation trace 包含 prompt 和召回上下文，应保留在本机并按敏感数据保护。
 
 ## 只在需要时启用自动提取
 

--- a/docs/zh/docs/integrations/index.md
+++ b/docs/zh/docs/integrations/index.md
@@ -30,6 +30,9 @@ description: 选择插件、MCP、Skills、Agent Host 或 Python 框架接入。
 
 所有集成都连接独立运行的 Server。安装、连接设置、认证和诊断步骤见上表中的各 Agent 文档。
 
+远程地址配置见[连接远程 Server](../operate/connect-remote-server.md)：PowerContext 客户端默认允许环回 HTTP，
+非环回 HTTP 需要显式同意；宿主原生 MCP 策略独立生效。
+
 需要交互选择多个宿主时，可运行：
 
 ```bash

--- a/docs/zh/docs/integrations/langchain.md
+++ b/docs/zh/docs/integrations/langchain.md
@@ -96,10 +96,15 @@ middleware 自己持有 `PowerContextScope`，并使用独立的 `POWERCONTEXT_L
 | 变量 | 默认值 | 用途 |
 | --- | --- | --- |
 | `POWERCONTEXT_LANGCHAIN_BASE_URL` | `http://127.0.0.1:8000` | PowerContext Server 地址 |
+| `POWERCONTEXT_LANGCHAIN_ALLOW_INSECURE_HTTP` | `false` | 显式允许非环回明文 HTTP |
 | `POWERCONTEXT_LANGCHAIN_TOKEN` | 未设置 | 传给 Client 的裸 bearer token |
 | `POWERCONTEXT_LANGCHAIN_SCOPE_ID` | 未设置 | 用于替代 Server 默认 Scope 的现有 Server Scope |
 | `POWERCONTEXT_LANGCHAIN_TIMEOUT` | `10` | Client 超时（秒） |
 | `POWERCONTEXT_LANGCHAIN_MAX_BYTES` | `8000` | PreparedContext 字节上限 |
+
+环回 HTTP 默认可用；非环回 HTTP 需要通过上表环境变量，或 `PowerContextLangChainSettings`、`PowerContextScope`
+上的 `allow_insecure_http=True` 显式同意。HTTPS 证书校验仍然启用。通用环境变量和绑定地址的持久化同意见
+[连接远程 Server](../operate/connect-remote-server.md)。框架适配器没有对应的 setup 安装命令。
 
 显式传入的 `PowerContextScope` 优先于环境配置，并且必须指向 Server 中已有的 Scope。两者都没有设置时，使用 Server
 默认 Scope。适配器不会根据 Git、路径、Agent 或 prompt 推导 Scope ID。Token 只保留在 Client 配置中，不会进入

--- a/docs/zh/docs/integrations/langgraph.md
+++ b/docs/zh/docs/integrations/langgraph.md
@@ -91,6 +91,7 @@ await graph.ainvoke(state, context=PowerContextScope())
 | 变量 | 默认值 | 用途 |
 | --- | --- | --- |
 | `POWERCONTEXT_LANGGRAPH_BASE_URL` | `http://127.0.0.1:8000` | PowerContext Server 地址 |
+| `POWERCONTEXT_LANGGRAPH_ALLOW_INSECURE_HTTP` | `false` | 显式允许非环回明文 HTTP |
 | `POWERCONTEXT_LANGGRAPH_TOKEN` | 未设置 | 转发给 `PowerContextClient` 的裸 token |
 | `POWERCONTEXT_LANGGRAPH_SCOPE_ID` | 未设置 | 用于替代 Server 默认 Scope 的现有 Server Scope |
 | `POWERCONTEXT_LANGGRAPH_TIMEOUT` | `10` | Client 超时（秒） |
@@ -98,6 +99,10 @@ await graph.ainvoke(state, context=PowerContextScope())
 
 `PowerContextScope(base_url=..., token=..., timeout=...)` 可按单次运行覆盖这些值。scope 上留为 `None` 的字段会回退到
 环境值。
+
+环回 HTTP 默认可用；非环回 HTTP 需要通过上表环境变量，或 `PowerContextLangGraphSettings`、`PowerContextScope`
+上的 `allow_insecure_http=True` 显式同意。HTTPS 证书校验仍然启用。通用环境变量和绑定地址的持久化同意见
+[连接远程 Server](../operate/connect-remote-server.md)。框架适配器没有对应的 setup 安装命令。
 
 `POWERCONTEXT_LANGGRAPH_TOKEN` 承载的是**裸 token**，不是完整的 `Authorization` header 值。这与 Codex、Claude Code 和 DeepSeek Harness
 插件使用的 `POWERCONTEXT_*_AUTHORIZATION` 约定不同。`PowerContextClient` 接收裸 token 并在内部组装成

--- a/docs/zh/docs/integrations/openclaw.md
+++ b/docs/zh/docs/integrations/openclaw.md
@@ -17,7 +17,7 @@ uv tool install --force "powercontext[cli,server] @ git+https://github.com/ocean
 powercontext setup openclaw
 ```
 
-未指定 `--server-url` 时，setup 会把插件 endpoint 配置为 Server 默认地址 `http://127.0.0.1:8000`。
+未显式指定地址时，setup 会读取环境变量和已保存的客户端配置；均未配置时使用 `http://127.0.0.1:8000`。
 
 也可以使用本地 checkout：
 
@@ -96,8 +96,9 @@ chmod 600 ~/.openclaw/.env
 openclaw gateway restart
 ```
 
-不要把凭据放进 endpoint。当前配置同时接受 HTTP 和 HTTPS URL；仅对可信的 loopback Server 使用明文 HTTP，所有远程
-Server 都应使用 HTTPS。这是运维安全要求，目前 CLI 和插件不会强制拒绝非 loopback HTTP URL。
+不要把凭据放进 endpoint。CLI 和插件默认拒绝非环回明文 HTTP；使用 HTTPS，或显式设置
+`POWERCONTEXT_OPENCLAW_ALLOW_INSECURE_HTTP=true`（也可使用插件的 `allowInsecureHttp` 配置）。
+HTTPS 证书校验仍然启用。安装与持久化同意见[连接远程 Server](../operate/connect-remote-server.md)。
 
 ## 验证安装
 

--- a/docs/zh/docs/integrations/opencode.md
+++ b/docs/zh/docs/integrations/opencode.md
@@ -54,7 +54,9 @@ Server 默认 Scope 的顺序解析。解析结果会固定到 Session，resume 
 已存在且由 Server 管理的 Scope。
 
 启用可选 Bearer 鉴权时，将完整请求头写入 `POWERCONTEXT_OPENCODE_AUTHORIZATION`，不要把凭据写入 URL。
-非 loopback 地址必须使用 HTTPS。不应采集当前提示词时，设置 `POWERCONTEXT_OPENCODE_CAPTURE_PROMPTS=false`。
+环回地址默认允许明文 HTTP；非环回地址使用 HTTPS，或显式设置 `POWERCONTEXT_OPENCODE_ALLOW_INSECURE_HTTP=true`，
+HTTPS 证书校验仍然启用。安装与持久化同意见[连接远程 Server](../operate/connect-remote-server.md)。
+不应采集当前提示词时，设置 `POWERCONTEXT_OPENCODE_CAPTURE_PROMPTS=false`。
 
 ## 验证安装
 

--- a/docs/zh/docs/integrations/pi.md
+++ b/docs/zh/docs/integrations/pi.md
@@ -94,8 +94,9 @@ export POWERCONTEXT_PI_AUTHORIZATION="Bearer $POWERCONTEXT_LOCAL_TOKEN"
 pi
 ```
 
-不要把凭据放进 `POWERCONTEXT_PI_BASE_URL`。package 只允许 loopback Server 使用明文 HTTP；远程 Server 必须使用
-HTTPS。
+不要把凭据放进 `POWERCONTEXT_PI_BASE_URL`。环回地址默认允许明文 HTTP；非环回 Server 使用 HTTPS，或显式设置
+`POWERCONTEXT_PI_ALLOW_INSECURE_HTTP=true`，HTTPS 证书校验仍然启用。
+安装与持久化同意见[连接远程 Server](../operate/connect-remote-server.md)。
 
 ## 验证安装
 
@@ -111,7 +112,8 @@ powercontext doctor pi
 
 | 变量 | 默认值 | 含义 |
 | --- | --- | --- |
-| `POWERCONTEXT_PI_BASE_URL` | `http://127.0.0.1:8000` | Server base URL；非 loopback endpoint 必须使用 HTTPS |
+| `POWERCONTEXT_PI_BASE_URL` | `http://127.0.0.1:8000` | Server base URL |
+| `POWERCONTEXT_PI_ALLOW_INSECURE_HTTP` | `false` | 显式允许非环回明文 HTTP |
 | `POWERCONTEXT_PI_SCOPE_ID` | 未设置 | 在 workspace binding 和 Server 默认值之前显式选择已有 Scope |
 | `POWERCONTEXT_PI_AUTHORIZATION` | 未设置 | package HTTP 请求使用的完整 `Bearer <token>` header |
 | `POWERCONTEXT_PI_CAPTURE_PROMPTS` | `true` | 把符合条件的用户提示词采集为 Source 证据 |

--- a/docs/zh/docs/integrations/pydantic-ai.md
+++ b/docs/zh/docs/integrations/pydantic-ai.md
@@ -64,6 +64,7 @@ export POWERCONTEXT_PYDANTIC_AI_TOKEN=opaque-server-token
 | 变量 | 默认值 | 校验与行为 |
 | --- | --- | --- |
 | `POWERCONTEXT_PYDANTIC_AI_BASE_URL` | `http://127.0.0.1:8000` | HTTP(S)，不能含凭证、query 或 fragment |
+| `POWERCONTEXT_PYDANTIC_AI_ALLOW_INSECURE_HTTP` | `false` | 显式允许非环回明文 HTTP |
 | `POWERCONTEXT_PYDANTIC_AI_TOKEN` | 未设置 | 以 `SecretStr` 保存的裸可打印 Token |
 | `POWERCONTEXT_PYDANTIC_AI_SCOPE_ID` | 未设置 | 最多 256 个字符的已有 Server Scope；未设置时选择 Server 默认 Scope |
 | `POWERCONTEXT_PYDANTIC_AI_TIMEOUT` | `10` | 正秒数 |
@@ -74,6 +75,10 @@ export POWERCONTEXT_PYDANTIC_AI_TOKEN=opaque-server-token
 
 Codex 与 Claude Code 插件的相关设置接收完整 authorization 值，而本适配器只接收裸 Token。不要带
 `Bearer `，也不要传完整 `Authorization` Header；公共 Client 会补上 scheme。
+
+环回 HTTP 默认可用；非环回 HTTP 需要通过上表环境变量或 `PowerContextSettings(allow_insecure_http=True)`
+显式同意。HTTPS 证书校验仍然启用。通用环境变量和绑定地址的持久化同意见
+[连接远程 Server](../operate/connect-remote-server.md)。框架适配器没有对应的 setup 安装命令。
 
 `PowerContext` 与 `PowerContextToolset` 都接受 `PowerContextSettings`、稳定的 `id`（默认 `powercontext`），
 以及固定或回调形式的 `scope_id`：

--- a/docs/zh/docs/integrations/workbuddy.md
+++ b/docs/zh/docs/integrations/workbuddy.md
@@ -191,6 +191,7 @@ export POWERCONTEXT_WORKBUDDY_FLUSH_ON_CAPTURE=true
 | 变量 | 用途 |
 | --- | --- |
 | `POWERCONTEXT_WORKBUDDY_SERVER_URL` | PowerContext Server URL（默认 `http://127.0.0.1:8000`） |
+| `POWERCONTEXT_WORKBUDDY_ALLOW_INSECURE_HTTP` | 显式允许 Hook 使用非环回明文 HTTP（默认 `false`） |
 | `POWERCONTEXT_WORKBUDDY_AUTHORIZATION` | 完整的 Authorization header，例如 `Bearer <token>` |
 | `POWERCONTEXT_WORKBUDDY_SCOPE_ID` | 显式的服务端 Scope ID |
 | `POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS` | 是否把用户提示词采集为 Source（默认 `true`） |
@@ -200,7 +201,9 @@ export POWERCONTEXT_WORKBUDDY_FLUSH_ON_CAPTURE=true
 | `POWERCONTEXT_WORKBUDDY_FLUSH_MAX_CALLS` | 最大 flush 调用次数（默认 `4`） |
 
 Hook 会校验其 PowerContext MCP URL，并通过去掉末尾 `/mcp` 路径段推导 HTTP API 基地址。MCP URL
-不能包含凭据、查询串或片段；明文 HTTP 只允许用于 loopback 主机。
+不能包含凭据、查询串或片段。环回地址默认允许明文 HTTP；非环回 HTTP 需要显式设置
+`POWERCONTEXT_WORKBUDDY_ALLOW_INSECURE_HTTP=true`。setup 会配置 Hook 与原生 MCP 地址，但宿主自己的 MCP
+策略仍然生效，HTTPS 证书校验也保持启用。参见[连接远程 Server](../operate/connect-remote-server.md)。
 
 ## 解析项目 scope
 

--- a/docs/zh/docs/operate/connect-remote-server.md
+++ b/docs/zh/docs/operate/connect-remote-server.md
@@ -1,0 +1,84 @@
+---
+title: 连接远程 Server
+description: 配置客户端地址，并在需要时明确允许非环回明文 HTTP。
+---
+
+# 连接远程 Server
+
+远程部署推荐使用 HTTPS。IPv4/IPv6 环回 HTTP（包括 `localhost`）默认可用；PowerContext 自己发起的其他 HTTP
+连接需要显式同意。内网 IP、VPN 地址仍是非环回地址，处于内网不等于 HTTP 已加密。
+
+## 使用引导安装
+
+PowerContext 工具与插件应使用同一份 source/ref。在运行 Agent 的机器上执行：
+
+```bash
+powercontext setup claude-code --source oceanbase/powercontext --ref master \
+  --server-url http://192.0.2.10:8000
+```
+
+交互终端中，setup 会说明明文风险并询问是否允许，直接回车代表拒绝。地址也可以来自该 Agent 的 URL 环境变量或
+`POWERCONTEXT_CLIENT_SERVER_URL`，setup 会先解析实际地址再判断是否需要确认。
+
+`--json` 或非交互终端不会提问。自动安装必须显式给出选择：
+
+```bash
+powercontext setup claude-code --server-url http://192.0.2.10:8000 --allow-insecure-http --json
+```
+
+`claude-code` 可替换为 `codex`、`dsh`、`openclaw`、`opencode`、`pi`、`hermes` 或 `workbuddy`。
+`setup select --host ...` 也支持这两个选项，覆盖其目录中的 Agent；WorkBuddy 使用独立 setup 命令。
+拒绝或未提供同意时，在安装操作前退出。风险警告写入 stderr，不污染 stdout 的 JSON。
+安装成功后保存地址及同意状态，新会话无需重复手贴这两项配置；鉴权凭据仍需单独配置。
+
+## 配置与优先级
+
+配置文件为 `~/.config/powercontext/clients.json`，可用 `POWERCONTEXT_CLIENT_CONFIG_FILE` 指定其他位置。
+格式包含 `version: 1` 与 `hosts` 映射，每个 Agent 只保存 `server_url` 和 `allow_insecure_http`，不保存 Token。
+持久化同意绑定地址；切换到其他地址时，不会自动继承原地址的同意。
+
+setup 的优先级为：显式命令行选项 > Agent 环境变量 > 通用环境变量 > 已保存配置。
+运行时还可能读取宿主原生配置，具体 URL 来源以对应接入文档为准。显式 false 可以覆盖继承的 true。
+布尔环境变量支持 `true/false`、`1/0`、`yes/no`、`on/off`，无效值不会被当成允许。
+
+| 接入端 | 明文 HTTP 同意环境变量 |
+| --- | --- |
+| 所有 PowerContext 客户端 | `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP` |
+| Codex | `POWERCONTEXT_CODEX_ALLOW_INSECURE_HTTP` |
+| Claude Code | `POWERCONTEXT_CLAUDE_ALLOW_INSECURE_HTTP` |
+| DSH、Pi、OpenCode | `POWERCONTEXT_DSH_ALLOW_INSECURE_HTTP`、`POWERCONTEXT_PI_ALLOW_INSECURE_HTTP`、`POWERCONTEXT_OPENCODE_ALLOW_INSECURE_HTTP` |
+| OpenClaw、Hermes、WorkBuddy | `POWERCONTEXT_OPENCLAW_ALLOW_INSECURE_HTTP`、`POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP`、`POWERCONTEXT_WORKBUDDY_ALLOW_INSECURE_HTTP` |
+
+通用内容 CLI 的选项放在子命令前：
+
+```bash
+powercontext --server-url http://192.0.2.10:8000 --allow-insecure-http ready
+powercontext doctor --server-url http://192.0.2.10:8000 --allow-insecure-http
+powercontext doctor claude-code --json
+```
+
+doctor 对已同意的明文连接报告 `degraded`，退出码非零，保留风险提示。这条警告本身不表示安装失败或连接不通。
+
+## MCP、Hook 与升级边界
+
+Codex、Claude Code、WorkBuddy 的 setup 会同时配置原生 MCP 地址与 Hook 地址。
+Codex Hook 特意读取已安装插件中的 `.mcp.json`，插件升级覆盖该文件后需重新运行 setup。
+只修改 Hook 的 URL 环境变量，不能视为宿主原生 MCP 的地址也已修改。
+
+DSH 自定义 `cordis.patch.yml` 可能覆盖 setup 保存的地址与同意状态。标准空白 profile patch 可直接安装；
+检测到自定义覆盖层时，setup 会在安装前退出，请先手动对齐地址及同意设置，或移除覆盖后重试。
+对无法解析的原生配置组合（包括未支持的 JSON5/include），doctor 会报告未知/失败，不会假定连接是安全的环回地址。
+
+MiniMax 和通用 Agent Plugin 由宿主负责 MCP 传输，没有单独的 PowerContext HTTP Client 或 setup 子命令；
+本选项不能绕过宿主自己的限制。LangChain、LangGraph、Pydantic AI 及 Bub 评测适配器支持客户端显式同意，
+但不会因此增加 Agent 安装器。
+
+## 安全边界
+
+该选项只允许明文 HTTP，不会关闭 HTTPS 证书校验，不会配置 Token、修改 Server 监听地址、开启 Dashboard，
+也不会绕过宿主 MCP 安全策略。传输中的 Token 与对话内容可能被读取或篡改；IP 白名单不是传输加密。
+
+远程访问仍应启用 Server 鉴权。Server 的监听安全检查与 Receiver 注册检查是独立机制，客户端选项不能代替它们。
+
+另一种方式是在 Agent 所在机器运行 `ssh -N -L 18000:127.0.0.1:8000 your-server`，再配置
+`http://127.0.0.1:18000`，无需允许非环回明文 HTTP。参见[部署 Server](deploy-server.md)。

--- a/docs/zh/docs/operate/deploy-server.md
+++ b/docs/zh/docs/operate/deploy-server.md
@@ -5,8 +5,8 @@ description: 使用持久化数据、健康检查、鉴权和安全网络边界�
 
 # 部署 Server
 
-先按[快速开始](../get-started/quickstart.md)从 `oceanbase/powercontext` 的 `master` 分支安装并生成配置。
-本页接着说明长期运行和远程访问。Server 与 Agent 位于不同机器时，分别在对应机器完成安装，插件使用同一仓库和 ref。
+远程 Agent 的地址配置与 `--allow-insecure-http` 确认见[连接远程 Server](connect-remote-server.md)。
+这是客户端选项，不会修改 Server 的监听地址或鉴权设置。
 
 Windows 支持为 `experimental`。
 
@@ -17,7 +17,7 @@ Windows 支持为 `experimental`。
 安装并启动可选的当前用户服务：
 
 ```bash
-powercontext service install --env-file /absolute/path/to/.env
+powercontext service install
 powercontext service status
 ```
 
@@ -36,10 +36,8 @@ powercontext config validate --env-file /path/to/powercontext.env
 powercontext service install --env-file /path/to/powercontext.env
 ```
 
-将示例路径替换为向导生成 `.env` 的绝对路径。先用 `Ctrl-C` 停止同端口的前台 Server，再安装服务。
 安装成功后的摘要会显示实际使用的环境文件路径。若启用了 Bearer 鉴权，请从该文件中的
-`POWERCONTEXT_SERVER_AUTH_TOKEN` 读取令牌；命令不会在终端打印令牌值。无模型基础模板关闭鉴权。
-向导选择的 Dashboard 或鉴权访问需要令牌时，会在没有现有令牌的情况下生成令牌。
+`POWERCONTEXT_SERVER_AUTH_TOKEN` 读取令牌；命令不会在终端打印令牌值。默认配置关闭鉴权，因此不会自动生成令牌。
 
 在 Windows 上，校验前需要移除继承权限，只授予当前用户、`SYSTEM` 和本机 `Administrators` 访问权限，例如：
 
@@ -69,43 +67,6 @@ loopback 地址。
 
 内置命令只提供 HTTP，没有 TLS 选项。HTTPS 必须在 PowerContext 外部终止。
 
-“自定义监听地址和客户端 URL”中的 `0.0.0.0` 表示接受所有网卡上的连接，不是浏览器访问地址，
-也不会启用 HTTPS。PowerContext 客户端只允许环回地址使用明文 HTTP；不能将远程 IP 的
-`http://服务器:8000` 当作客户端连接地址。首次跨设备验收且没有域名、证书和 HTTPS 代理时，使用 SSH 转发。
-
-## 通过 SSH 从另一台电脑访问
-
-在服务器运行向导，选择“从其他设备访问”→“SSH 端口转发”，填写真实的 SSH 主机/别名和客户端转发端口。
-Server 仍监听 `127.0.0.1:8000`。按生成配置启动后，在客户端电脑上执行向导打印的命令，例如：
-
-```bash
-ssh -N -L 18000:127.0.0.1:8000 user@server
-```
-
-把 `user@server` 换成你平时 SSH 使用的地址或别名，保持这个终端运行。随后在客户端浏览器打开
-`http://127.0.0.1:18000/dashboard/home`，用 Server Token 登录。
-这条隧道由 SSH 加密；地址中的 HTTP 只在两端本机环回连接上使用。
-
-在服务器上运行的 Agent 使用 `http://127.0.0.1:8000`；在客户端电脑运行的 Agent 使用
-`http://127.0.0.1:18000`。向导会询问 Agent 在哪一台机器运行。把 `.env`
-安全复制到 Agent 所在机器并加载，检查 `POWERCONTEXT_CLIENT_SERVER_URL` 和各 Agent 的 URL。
-由于其中包含完整安装配置，只应复制到可信机器。Codex 的 MCP URL 还需与其 Hook URL 一致，
-具体见[Codex 连接步骤](../integrations/codex.md)。
-
-如果隧道启动提示端口被占用，选择空闲的本地端口，并同步修改浏览器和客户端地址。SSH 退出后转发停止，
-Server 在远端继续运行。仅在远端 tmux 中启动 Server，不会自动建立到 Mac 的端口转发。
-
-## 使用外部 HTTPS
-
-已经有 Nginx、Caddy、网关或负载均衡时，向导可选“使用 HTTPS 反向代理”，填写其实际对外的完整地址，
-例如 `https://memory.example.com`。同机代理的上游为 `http://127.0.0.1:8000`；跨机器代理需要配置相应监听地址和网络边界。
-
-证书、域名解析、TLS 和代理转发需在该外部组件完成，向导不会安装它们。
-`POWERCONTEXT_SERVER_PUBLIC_URL=https://...` 只声明外部访问地址，不给内置 Server 增加 TLS。
-代理需保留 `/mcp` 流式连接、`Authorization`，并正确传递外部 host 和 scheme，以便 Dashboard 登录检查。
-配置完成后，应从客户端检查外部地址的 `/health/ready`、Dashboard 登录及 MCP；不能只检查服务器本机端口。
-没有现成 HTTPS 服务时，先使用上一节完整的 SSH 流程。
-
 ## 从已安装工具运行
 
 按照[安装和运行](../get-started/install-and-run.md)安装 PowerContext，然后选择持久化数据目录：
@@ -127,17 +88,12 @@ powercontext server run --env-file /etc/powercontext/powercontext.env
 ```
 
 文件可能包含 Provider 凭据或 Bearer token，因此只能允许 Server 运维者读取。对于 `server run`，进程环境变量会覆盖
-文件中的同名值。`config init` 默认打开双语向导：先选择存储、使用场景和能力，再配置 Dashboard/访问方式及必需的模型连接。
-默认语言依次读取 `LC_ALL`、`LC_MESSAGES`、`LANG`，再尝试系统语言偏好；无法判断或不支持的语言回退英语。
-可以在首屏切换中英文，或传入 `--language en`、`--language zh`；加上 `--template` 则保留原来的无模型基础模板。
-
-向导生成配置和后续操作说明，不启动或注册服务、不迁移数据库，也不探测远程存储或模型端点。
-已有本地 SQLite 元数据可以只读检查。保存后，仍需完成下文的部署检查；启用模型能力时，还应完成
-[Memory 提取与向量搜索检查](../get-started/configure-models.md)。
+文件中的同名值。`config init` 生成的是不含模型的基础配置；需要启用完整
+推理能力时，请阅读[启用提取与向量搜索](../get-started/configure-models.md)并补充模型配置。
 
 无论使用前台进程、Docker 还是个人服务安装，只要 generation 或 embedding model 未配置，启动或安装输出都会提示
 缺少 model 可能影响部分制品功能，具体影响范围及配置方式请参考
-[配置说明](configuration.md)；两类 model 都已配置时不输出该提示。
+[官网配置说明](https://powercontext.oceanbase.io/en/docs/reference/configuration/)；两类 model 都已配置时不输出该提示。
 
 ## 使用 Docker 运行
 
@@ -225,9 +181,6 @@ curl --fail \
 ```
 
 请求示例见 [HTTP API](../develop/http-api.md)，全部 Server 设置见[配置](configuration.md)。
-
-这些检查证明服务与依赖可用，不证明 Topic Memory 已生成。部署后继续完成
-[Source → Topic 演进 → 新会话召回](../get-started/quickstart.md#4-用普通对话验收-topic-memory)。
 
 ## 保护和备份数据
 

--- a/docs/zh/docs/operate/meta.json
+++ b/docs/zh/docs/operate/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "deploy-server",
+    "connect-remote-server",
     "artifact-processing-migration",
     "observability",
     "trace-with-phoenix",

--- a/e2e/bub/tests/test_bub_capture.py
+++ b/e2e/bub/tests/test_bub_capture.py
@@ -32,8 +32,8 @@ def test_tool_capture_redacts_credentials_before_crossing_the_client_boundary(
     captured_requests: list[Any] = []
 
     class RecordingClient:
-        def __init__(self, base_url: str, *, timeout: float) -> None:
-            del base_url, timeout
+        def __init__(self, base_url: str, *, timeout: float, allow_insecure_http: bool = False) -> None:
+            del base_url, timeout, allow_insecure_http
 
         async def __aenter__(self) -> RecordingClient:
             return self

--- a/e2e/bub/tests/test_bub_scope_binding.py
+++ b/e2e/bub/tests/test_bub_scope_binding.py
@@ -32,8 +32,8 @@ class RecordingClient:
     calls: ClassVar[list[tuple[str, Any]]] = []
     scope_ids: ClassVar[list[str]] = [RESOLVED_SCOPE_ID]
 
-    def __init__(self, base_url: str, *, timeout: float) -> None:
-        del base_url, timeout
+    def __init__(self, base_url: str, *, timeout: float, allow_insecure_http: bool = False) -> None:
+        del base_url, timeout, allow_insecure_http
 
     async def __aenter__(self) -> RecordingClient:
         return self

--- a/e2e/bub/tests/test_bub_transport_trust.py
+++ b/e2e/bub/tests/test_bub_transport_trust.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, ClassVar
@@ -57,12 +58,14 @@ class RecordingClient:
         http_client: httpx.AsyncClient | None = None,
         trust_transport_security: bool = False,
         timeout: float | None = None,
+        allow_insecure_http: bool = False,
     ) -> None:
         RecordingClient.constructions.append({
             "base_url": base_url,
             "http_client": http_client,
             "trust_transport_security": trust_transport_security,
             "timeout": timeout,
+            "allow_insecure_http": allow_insecure_http,
         })
 
     async def __aenter__(self) -> RecordingClient:
@@ -160,3 +163,57 @@ def test_tools_honour_the_operator_transport_vouch(
     assert construction["base_url"] == "http://host-gateway:8000"
     assert isinstance(construction["http_client"], httpx.AsyncClient)
     assert construction["trust_transport_security"] is True
+
+
+def test_plaintext_opt_in_reaches_both_plugin_and_tools(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(tmp_path / "clients.json"))
+    settings = PowerContextSettings(base_url="http://host-gateway:8000", allow_insecure_http=True)
+    plugin = _plugin_with(settings, monkeypatch, tmp_path)
+
+    async def open_clients() -> None:
+        async with plugin._client():
+            pass
+        async with tools_module._client(_tool_settings(plugin)):
+            pass
+
+    asyncio.run(open_clients())
+
+
+def test_bub_host_false_overrides_common_plaintext_opt_in(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(tmp_path / "clients.json"))
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "http://host-gateway:8000")
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", "true")
+    monkeypatch.setenv("POWERCONTEXT_BUB_ALLOW_INSECURE_HTTP", "false")
+    settings = PowerContextSettings()
+    assert str(settings.base_url).rstrip("/") == "http://host-gateway:8000"
+    assert settings.allow_insecure_http is False
+    assert PowerContextSettings(allow_insecure_http=True).allow_insecure_http is True
+    plugin = _plugin_with(settings, monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="non-loopback"):
+        plugin._client()
+
+
+def test_bub_non_transport_settings_keep_bub_environment_precedence(monkeypatch) -> None:
+    monkeypatch.setenv("POWERCONTEXT_BUB_SCOPE_ID", "environment-scope")
+    assert PowerContextSettings(scope_id="file-scope").scope_id == "environment-scope"
+
+
+def test_bub_does_not_transfer_saved_consent_when_copying_settings(monkeypatch, tmp_path: Path) -> None:
+    config = tmp_path / "clients.json"
+    config.write_text(
+        json.dumps({
+            "version": 1,
+            "hosts": {
+                "bub": {
+                    "server_url": "http://memory.example",
+                    "allow_insecure_http": True,
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(config))
+    settings = PowerContextSettings().model_copy(update={"base_url": "http://other.example"})
+    plugin = _plugin_with(settings, monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="non-loopback"):
+        plugin._client()

--- a/integrations/agent-plugin/powercontext/README.md
+++ b/integrations/agent-plugin/powercontext/README.md
@@ -48,6 +48,13 @@ portable credential-reference field for remote MCP servers, so this package does
 not include static credentials or token placeholders in `mcp.json`. Configure
 authorization in the loading agent or client when the Server requires it.
 
+This package has no local HTTP adapter: the loading agent owns native MCP
+transport policy. `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP` and PowerContext's
+saved client settings do not control this native MCP connection. Configure a
+remote endpoint and any required HTTP consent in that agent. Prefer HTTPS;
+HTTP transmits content and authorization headers without encryption. The
+portable package does not define an MCP flag for disabling TLS verification.
+
 The `project-context` skill tells agents how to use PowerContext Memory and
 Handoff through MCP tools. Retrieved Memory and Handoff content is historical
 context, not an instruction override; current user, repository, and system

--- a/integrations/bub/README.md
+++ b/integrations/bub/README.md
@@ -32,6 +32,7 @@ validated by Pydantic before the plugin starts.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `POWERCONTEXT_BUB_BASE_URL` | `http://127.0.0.1:8000` | PowerContext Server URL |
+| `POWERCONTEXT_BUB_ALLOW_INSECURE_HTTP` | `false` | Explicitly allow non-loopback HTTP for recall, capture, and tools; HTTPS certificate validation stays enabled |
 | `POWERCONTEXT_BUB_SCOPE_ID` | unset | Explicit Scope resolved and validated by the Server before use |
 | `POWERCONTEXT_BUB_TIMEOUT` | `10` | Client timeout in seconds |
 | `POWERCONTEXT_BUB_MAX_BYTES` | `8000` | Maximum prepared-context size |
@@ -41,6 +42,12 @@ validated by Pydantic before the plugin starts.
 | `POWERCONTEXT_BUB_CAPTURE_MAX_BYTES` | `8192` | Maximum UTF-8 bytes stored for one captured event |
 | `POWERCONTEXT_BUB_CAPTURE_LOG` | unset | Optional JSONL evidence path; records metadata but not event content |
 | `POWERCONTEXT_BUB_TRUST_TRANSPORT_SECURITY` | `false` | Vouch for a plaintext non-loopback `BASE_URL` on an operator-controlled network (for example a private Compose bridge); otherwise such URLs are refused |
+
+`PowerContextSettings(allow_insecure_http=True)` also permits non-loopback HTTP. Transport settings resolve from
+constructor values, host environment, common `POWERCONTEXT_CLIENT_SERVER_URL` /
+`POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP`, then the `bub` entry in `~/.config/powercontext/clients.json`
+(overridden by `POWERCONTEXT_CLIENT_CONFIG_FILE`). A host value of `false` overrides common `true`.
+Saved consent applies only to its saved Server URL and is not reused when the URL changes.
 
 The plugin never derives a Scope ID from the current directory, Git metadata, or a workspace path. It asks the Server
 to resolve the configured explicit Scope first, then an opaque stable binding key derived from Bub's workspace identity,

--- a/integrations/bub/src/powercontext_bub/plugin.py
+++ b/integrations/bub/src/powercontext_bub/plugin.py
@@ -24,7 +24,7 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import httpx
 from bub import Settings, config, ensure_config, hookimpl
@@ -35,6 +35,7 @@ from pydantic_settings import SettingsConfigDict
 
 from powercontext.client import InvalidResponseError, PowerContextClient, ServerResponseError, TransportError
 from powercontext.client.capture import render_capture_event
+from powercontext.client.transport_policy import ClientTransportSettings
 from powercontext.http import CaptureContentSourceRequest, FlushMemoryRequest, PrepareContextRequest
 
 try:
@@ -57,7 +58,7 @@ CAPTURE_SCHEMA = "powercontext.bub-capture-event/v1"
 
 
 @config(name="powercontext")
-class PowerContextSettings(Settings):
+class PowerContextSettings(ClientTransportSettings, Settings):
     """Validated Bub configuration for the PowerContext plugin."""
 
     model_config = SettingsConfigDict(
@@ -67,6 +68,7 @@ class PowerContextSettings(Settings):
         frozen=True,
     )
 
+    transport_host: ClassVar[str] = "bub"
     base_url: HttpUrl = HttpUrl("http://127.0.0.1:8000")
     scope_id: str | None = Field(default=None, min_length=1)
     timeout: float = Field(default=10, gt=0)
@@ -94,16 +96,19 @@ def open_client(
     *,
     timeout: float,
     trust_transport_security: bool = False,
+    allow_insecure_http: bool = False,
 ) -> AbstractAsyncContextManager[PowerContextClient]:
     """Open a client, vouching for the transport only when the operator opted in."""
 
     if trust_transport_security:
-        return _vouched_client(base_url, timeout)
-    return PowerContextClient(base_url, timeout=timeout)
+        return _vouched_client(base_url, timeout, allow_insecure_http=allow_insecure_http)
+    return PowerContextClient(base_url, timeout=timeout, allow_insecure_http=allow_insecure_http)
 
 
 @asynccontextmanager
-async def _vouched_client(base_url: str, timeout_seconds: float) -> AsyncIterator[PowerContextClient]:
+async def _vouched_client(
+    base_url: str, timeout_seconds: float, *, allow_insecure_http: bool
+) -> AsyncIterator[PowerContextClient]:
     # The operator vouched for the network (e.g. a private Compose bridge), and the
     # client only honours that vouch for a caller-supplied transport.
     async with (
@@ -112,6 +117,7 @@ async def _vouched_client(base_url: str, timeout_seconds: float) -> AsyncIterato
             base_url,
             http_client=transport,
             trust_transport_security=True,
+            allow_insecure_http=allow_insecure_http,
         ) as client,
     ):
         yield client
@@ -122,7 +128,7 @@ class PowerContextPlugin:
 
     def __init__(self, framework: Any) -> None:
         self.settings = ensure_config(PowerContextSettings)
-        self.base_url = str(self.settings.base_url).rstrip("/")
+        self.base_url, self.allow_insecure_http = self.settings.resolve_transport()
         self._framework = framework
         self._scope_lock = asyncio.Lock()
         self._capture_lock = asyncio.Lock()
@@ -140,6 +146,7 @@ class PowerContextPlugin:
                 "binding_keys": binding_keys,
                 "timeout": self.settings.timeout,
                 "trust_transport_security": self.settings.trust_transport_security,
+                "allow_insecure_http": self.allow_insecure_http,
                 "max_bytes": self.settings.max_bytes,
                 "context_assembly": self.settings.context_assembly,
                 "capture_sequence": 0,
@@ -234,6 +241,7 @@ class PowerContextPlugin:
             self.base_url,
             timeout=self.settings.timeout,
             trust_transport_security=self.settings.trust_transport_security,
+            allow_insecure_http=self.allow_insecure_http,
         )
 
     async def _scope_id(self, state: TurnState) -> str | None:

--- a/integrations/bub/src/powercontext_bub/tools.py
+++ b/integrations/bub/src/powercontext_bub/tools.py
@@ -42,6 +42,7 @@ class ToolSettings(TypedDict):
     binding_keys: list[ScopeBindingKey]
     timeout: float
     trust_transport_security: bool
+    allow_insecure_http: bool
     max_bytes: int
     context_assembly: ContextAssembly | None
 
@@ -130,6 +131,7 @@ def _client(settings: ToolSettings) -> AbstractAsyncContextManager[PowerContextC
         settings["base_url"],
         timeout=settings["timeout"],
         trust_transport_security=settings["trust_transport_security"],
+        allow_insecure_http=settings["allow_insecure_http"],
     )
 
 

--- a/integrations/claude-code/plugins/powercontext/.claude-plugin/plugin.json
+++ b/integrations/claude-code/plugins/powercontext/.claude-plugin/plugin.json
@@ -28,6 +28,11 @@
       "title": "Capture user prompts",
       "description": "Store user prompts as ordinary Content Source evidence",
       "default": true
+    },
+    "allow_insecure_http": {
+      "type": "boolean",
+      "title": "Allow unencrypted HTTP",
+      "description": "Explicitly allow HTTP to a non-loopback PowerContext Server; TLS certificate verification remains enabled"
     }
   }
 }

--- a/integrations/claude-code/plugins/powercontext/README.md
+++ b/integrations/claude-code/plugins/powercontext/README.md
@@ -16,6 +16,32 @@ The plugin defaults to `http://127.0.0.1:8000`. Its Hook and MCP transport share
 enabled. Prompt capture can be disabled through the plugin's `capture_prompts`
 option or by setting `POWERCONTEXT_CLAUDE_CAPTURE_PROMPTS=false`.
 
+HTTPS and loopback HTTP work by default. To persist an explicit non-loopback
+HTTP endpoint for this host:
+
+```bash
+powercontext setup claude-code --server-url http://memory.example:8000 --allow-insecure-http
+```
+
+Setup configures the native MCP URL and stores nonsecret settings under
+`hosts.claude-code` in `~/.config/powercontext/clients.json` (override with
+`POWERCONTEXT_CLIENT_CONFIG_FILE`). The hook selects its URL from
+`POWERCONTEXT_CLAUDE_SERVER_URL`, the `server_url` plugin option,
+`POWERCONTEXT_CLIENT_SERVER_URL`, saved settings, then the loopback default.
+Keep the native MCP URL and hook URL aligned when making manual changes.
+
+For HTTP consent, an explicit settings constructor argument takes precedence,
+then `POWERCONTEXT_CLAUDE_ALLOW_INSECURE_HTTP`,
+`POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP`, the optional `allow_insecure_http`
+plugin option, and saved consent. Explicit `false` overrides lower-priority
+consent, and invalid booleans are rejected. Plugin-option and saved consent
+apply only to their configured endpoint after removing trailing slashes and
+`/mcp`; an environment URL change does not authorize another server.
+
+This setting governs the PowerContext hook. Claude Code owns native MCP
+transport policy. HTTP exposes request content and authorization headers on
+the network; the opt-in never disables HTTPS certificate verification.
+
 The Hook fails open on transport, authentication, contract, and capture errors.
 MCP remains available for explicit Memory maintenance and the inspected
 Handoff lifecycle when the Server is reachable.

--- a/integrations/claude-code/plugins/powercontext/claude_code_settings.py
+++ b/integrations/claude-code/plugins/powercontext/claude_code_settings.py
@@ -22,6 +22,8 @@ import os
 from dataclasses import dataclass
 from urllib.parse import urlsplit, urlunsplit
 
+from powercontext_client_config import load_client_settings, parse_boolean, resolve_allow_insecure_http
+
 # Kept in lockstep with powercontext.transport.LOOPBACK_HOSTS; the plugin ships
 # isolated and cannot import powercontext.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
@@ -54,9 +56,25 @@ class ClaudeCodePluginSettings:
     request_timeout_seconds: float = 1.0
     http_budget_seconds: float = 4.0
     flush_max_calls: int = 4
+    allow_insecure_http: bool | None = None
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "server_url", _http_base_url(self.server_url))
+        saved = load_client_settings("claude-code")
+        option = os.environ.get("CLAUDE_PLUGIN_OPTION_ALLOW_INSECURE_HTTP")
+        if option is not None:
+            saved = {
+                "server_url": os.environ.get("CLAUDE_PLUGIN_OPTION_SERVER_URL"),
+                "allow_insecure_http": parse_boolean(option),
+            }
+        allow_insecure_http = resolve_allow_insecure_http(
+            self.server_url,
+            host="claude-code",
+            host_environment="POWERCONTEXT_CLAUDE_ALLOW_INSECURE_HTTP",
+            explicit=self.allow_insecure_http,
+            saved=saved,
+        )
+        object.__setattr__(self, "allow_insecure_http", allow_insecure_http)
+        object.__setattr__(self, "server_url", _http_base_url(self.server_url, allow_insecure_http=allow_insecure_http))
         object.__setattr__(self, "authorization", _authorization_header(self.authorization))
         object.__setattr__(self, "scope_id", _optional_text(self.scope_id))
         if self.request_timeout_seconds <= 0 or self.http_budget_seconds <= 0:
@@ -68,11 +86,14 @@ class ClaudeCodePluginSettings:
     def from_environment(cls) -> ClaudeCodePluginSettings:
         """Load Claude user options and integration-specific environment values."""
 
+        saved = load_client_settings("claude-code")
         return cls(
             server_url=_first_environment(
                 "POWERCONTEXT_CLAUDE_SERVER_URL",
                 "CLAUDE_PLUGIN_OPTION_SERVER_URL",
+                "POWERCONTEXT_CLIENT_SERVER_URL",
             )
+            or saved.get("server_url")
             or "http://127.0.0.1:8000",
             authorization=_first_environment("POWERCONTEXT_CLAUDE_AUTHORIZATION"),
             scope_id=_first_environment("POWERCONTEXT_CLAUDE_SCOPE_ID"),
@@ -167,7 +188,7 @@ def _authorization_header(value: str | None) -> str | None:
     return normalized
 
 
-def _http_base_url(value: str) -> str:
+def _http_base_url(value: str, *, allow_insecure_http: bool = False) -> str:
     normalized = value.strip().rstrip("/")
     parsed = urlsplit(normalized)
     if parsed.username is not None or parsed.password is not None:
@@ -176,7 +197,7 @@ def _http_base_url(value: str) -> str:
         raise ValueError("PowerContext Server URL must use HTTP or HTTPS")  # noqa: TRY003
     if parsed.query or parsed.fragment:
         raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
-    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname):
+    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname) and not allow_insecure_http:
         raise ValueError("unencrypted PowerContext URLs must be loopback addresses")  # noqa: TRY003
     path = parsed.path.rstrip("/")
     if path.endswith("/mcp"):

--- a/integrations/claude-code/plugins/powercontext/powercontext_client_config.py
+++ b/integrations/claude-code/plugins/powercontext/powercontext_client_config.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Endpoint-bound transport settings for an independently installed plugin.
+
+This standard-library helper is distributed with each Python host plugin.
+It must not import the PowerContext package, which need not be installed.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+
+def normalize_server_url(value: str, *, allow_insecure_http: bool = False) -> str:
+    """Validate a Server endpoint and remove the optional MCP suffix."""
+    parsed = urlsplit(value.strip().rstrip("/"))
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("PowerContext Server URL must not contain credentials")  # noqa: TRY003
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        raise ValueError("PowerContext Server URL must use HTTP or HTTPS")  # noqa: TRY003
+    if parsed.query or parsed.fragment:
+        raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
+    # Accessing port also rejects malformed and out-of-range ports.
+    port = parsed.port
+    host = parsed.hostname.lower()
+    try:
+        loopback = ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        loopback = host == "localhost"
+    if parsed.scheme == "http" and not loopback and not allow_insecure_http:
+        raise ValueError(  # noqa: TRY003
+            "unencrypted PowerContext URLs must be loopback addresses unless allow_insecure_http is explicitly enabled"
+        )
+    netloc = f"[{host}]" if ":" in host else host
+    if port is not None and port != (443 if parsed.scheme == "https" else 80):
+        netloc += f":{port}"
+    path = parsed.path.rstrip("/").removesuffix("/mcp")
+    return urlunsplit((parsed.scheme, netloc, path, "", "")).rstrip("/")
+
+
+def load_client_settings(host: str) -> dict[str, Any]:
+    """Read only the nonsecret settings owned by this host."""
+    configured = os.environ.get("POWERCONTEXT_CLIENT_CONFIG_FILE")
+    path = Path(configured).expanduser() if configured else Path.home() / ".config" / "powercontext" / "clients.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, UnicodeError, ValueError):
+        raise ValueError("invalid PowerContext client settings file") from None  # noqa: TRY003
+    if not isinstance(data, dict) or type(data.get("version")) is not int or data["version"] != 1:
+        raise ValueError("invalid PowerContext client settings version")  # noqa: TRY003
+    hosts = data.get("hosts")
+    if not isinstance(hosts, dict):
+        raise ValueError("invalid PowerContext client host settings")  # noqa: TRY003, TRY004
+    entry = hosts.get(host, {})
+    if not isinstance(entry, dict):
+        raise ValueError("invalid PowerContext client host settings")  # noqa: TRY003, TRY004
+    result: dict[str, Any] = {}
+    if "server_url" in entry:
+        if not isinstance(entry["server_url"], str):
+            raise ValueError("invalid PowerContext client server URL")  # noqa: TRY003
+        result["server_url"] = normalize_server_url(entry["server_url"], allow_insecure_http=True)
+    if "allow_insecure_http" in entry:
+        if not isinstance(entry["allow_insecure_http"], bool):
+            raise ValueError("PowerContext allow_insecure_http must be a JSON boolean")  # noqa: TRY003
+        result["allow_insecure_http"] = entry["allow_insecure_http"]
+    return result
+
+
+def parse_boolean(value: object) -> bool:
+    """Reject misspellings instead of interpreting nonempty strings as true."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise ValueError("invalid boolean PowerContext allow_insecure_http configuration")  # noqa: TRY003
+
+
+def resolve_allow_insecure_http(
+    server_url: str,
+    *,
+    host: str,
+    host_environment: str,
+    explicit: bool | None = None,
+    saved: dict[str, Any] | None = None,
+) -> bool:
+    """Resolve consent without transferring saved consent to another endpoint."""
+    settings = load_client_settings(host) if saved is None else saved
+    if explicit is not None:
+        return parse_boolean(explicit)
+    names = [host_environment, "POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP"]
+    for name in names:
+        if name in os.environ:
+            return parse_boolean(os.environ[name])
+    consent = settings.get("allow_insecure_http", False)
+    if not isinstance(consent, bool):
+        raise ValueError("PowerContext allow_insecure_http must be a JSON boolean")  # noqa: TRY003, TRY004
+    saved_url = settings.get("server_url")
+    return bool(
+        consent
+        and isinstance(saved_url, str)
+        and normalize_server_url(saved_url, allow_insecure_http=True)
+        == normalize_server_url(server_url, allow_insecure_http=True)
+    )

--- a/integrations/codex/plugins/powercontext/README.md
+++ b/integrations/codex/plugins/powercontext/README.md
@@ -65,8 +65,28 @@ request to one known Scope.
 the hook: the hook validates its PowerContext MCP URL and derives the HTTP API
 base by removing the final `/mcp` path segment. Change that file before
 installing the plugin when the loopback default is not appropriate. MCP URLs
-cannot contain credentials, query strings, or fragments; plain HTTP is accepted
-only for loopback hosts.
+cannot contain credentials, query strings, or fragments. Plain HTTP is accepted
+for loopback hosts by default. To configure a non-loopback HTTP server explicitly:
+
+```bash
+powercontext setup codex --server-url http://memory.example:8000 --allow-insecure-http
+```
+
+Setup saves nonsecret client settings under `hosts.codex` in
+`~/.config/powercontext/clients.json` (`POWERCONTEXT_CLIENT_CONFIG_FILE` overrides
+the path) and configures the installed MCP endpoint. Saved HTTP consent applies
+only to that endpoint, ignoring trailing slashes and the `/mcp` suffix.
+`POWERCONTEXT_CODEX_ALLOW_INSECURE_HTTP` overrides
+`POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP`, including an explicit `false`; both
+override saved consent. Invalid boolean values are rejected. A direct
+`CodexPluginSettings(allow_insecure_http=...)` argument has highest priority.
+The MCP file remains authoritative for the URL; a URL environment variable
+does not redirect the hook independently of MCP.
+
+This setting governs PowerContext's hook HTTP requests. Codex owns the native
+MCP transport and its policy. HTTP sends request content and any authorization
+header without encryption; this opt-in does not disable HTTPS certificate
+verification.
 
 The hook strictly validates `powercontext.prepared-context.v1`, rejects redirects,
 caps response bodies at 1 MiB, and applies both per-request and shared wall-clock

--- a/integrations/codex/plugins/powercontext/powercontext_client_config.py
+++ b/integrations/codex/plugins/powercontext/powercontext_client_config.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Endpoint-bound transport settings for an independently installed plugin.
+
+This standard-library helper is distributed with each Python host plugin.
+It must not import the PowerContext package, which need not be installed.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+
+def normalize_server_url(value: str, *, allow_insecure_http: bool = False) -> str:
+    """Validate a Server endpoint and remove the optional MCP suffix."""
+    parsed = urlsplit(value.strip().rstrip("/"))
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("PowerContext Server URL must not contain credentials")  # noqa: TRY003
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        raise ValueError("PowerContext Server URL must use HTTP or HTTPS")  # noqa: TRY003
+    if parsed.query or parsed.fragment:
+        raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
+    # Accessing port also rejects malformed and out-of-range ports.
+    port = parsed.port
+    host = parsed.hostname.lower()
+    try:
+        loopback = ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        loopback = host == "localhost"
+    if parsed.scheme == "http" and not loopback and not allow_insecure_http:
+        raise ValueError(  # noqa: TRY003
+            "unencrypted PowerContext URLs must be loopback addresses unless allow_insecure_http is explicitly enabled"
+        )
+    netloc = f"[{host}]" if ":" in host else host
+    if port is not None and port != (443 if parsed.scheme == "https" else 80):
+        netloc += f":{port}"
+    path = parsed.path.rstrip("/").removesuffix("/mcp")
+    return urlunsplit((parsed.scheme, netloc, path, "", "")).rstrip("/")
+
+
+def load_client_settings(host: str) -> dict[str, Any]:
+    """Read only the nonsecret settings owned by this host."""
+    configured = os.environ.get("POWERCONTEXT_CLIENT_CONFIG_FILE")
+    path = Path(configured).expanduser() if configured else Path.home() / ".config" / "powercontext" / "clients.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, UnicodeError, ValueError):
+        raise ValueError("invalid PowerContext client settings file") from None  # noqa: TRY003
+    if not isinstance(data, dict) or type(data.get("version")) is not int or data["version"] != 1:
+        raise ValueError("invalid PowerContext client settings version")  # noqa: TRY003
+    hosts = data.get("hosts")
+    if not isinstance(hosts, dict):
+        raise ValueError("invalid PowerContext client host settings")  # noqa: TRY003, TRY004
+    entry = hosts.get(host, {})
+    if not isinstance(entry, dict):
+        raise ValueError("invalid PowerContext client host settings")  # noqa: TRY003, TRY004
+    result: dict[str, Any] = {}
+    if "server_url" in entry:
+        if not isinstance(entry["server_url"], str):
+            raise ValueError("invalid PowerContext client server URL")  # noqa: TRY003
+        result["server_url"] = normalize_server_url(entry["server_url"], allow_insecure_http=True)
+    if "allow_insecure_http" in entry:
+        if not isinstance(entry["allow_insecure_http"], bool):
+            raise ValueError("PowerContext allow_insecure_http must be a JSON boolean")  # noqa: TRY003
+        result["allow_insecure_http"] = entry["allow_insecure_http"]
+    return result
+
+
+def parse_boolean(value: object) -> bool:
+    """Reject misspellings instead of interpreting nonempty strings as true."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise ValueError("invalid boolean PowerContext allow_insecure_http configuration")  # noqa: TRY003
+
+
+def resolve_allow_insecure_http(
+    server_url: str,
+    *,
+    host: str,
+    host_environment: str,
+    explicit: bool | None = None,
+    saved: dict[str, Any] | None = None,
+) -> bool:
+    """Resolve consent without transferring saved consent to another endpoint."""
+    settings = load_client_settings(host) if saved is None else saved
+    if explicit is not None:
+        return parse_boolean(explicit)
+    names = [host_environment, "POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP"]
+    for name in names:
+        if name in os.environ:
+            return parse_boolean(os.environ[name])
+    consent = settings.get("allow_insecure_http", False)
+    if not isinstance(consent, bool):
+        raise ValueError("PowerContext allow_insecure_http must be a JSON boolean")  # noqa: TRY003, TRY004
+    saved_url = settings.get("server_url")
+    return bool(
+        consent
+        and isinstance(saved_url, str)
+        and normalize_server_url(saved_url, allow_insecure_http=True)
+        == normalize_server_url(server_url, allow_insecure_http=True)
+    )

--- a/integrations/codex/plugins/powercontext/settings.py
+++ b/integrations/codex/plugins/powercontext/settings.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlsplit, urlunsplit
 
+from powercontext_client_config import parse_boolean, resolve_allow_insecure_http
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
@@ -46,7 +47,7 @@ def _is_loopback_host(host: str) -> bool:
 
 
 class _McpEndpoint(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
 
     type: Literal["http"]
     url: str
@@ -55,14 +56,14 @@ class _McpEndpoint(BaseModel):
 
     @model_validator(mode="after")
     def validate_url(self) -> _McpEndpoint:
-        _http_base_url(self.url)
+        _http_base_url(self.url, allow_insecure_http=True)
         if self.env_http_headers != _AUTHORIZATION_ENVIRONMENT:
             raise ValueError("MCP authorization must use the PowerContext Codex environment")  # noqa: TRY003
         return self
 
 
 class _McpConfiguration(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
 
     mcp_servers: dict[str, _McpEndpoint] = Field(alias="mcpServers")
 
@@ -98,6 +99,7 @@ class CodexPluginSettings(BaseSettings):
     )
 
     server_url: str = Field(default="", repr=False)
+    allow_insecure_http: bool | None = None
     authorization: SecretStr | None = Field(default=None, repr=False)
     scope_id: str | None = None
     context_assembly: dict[str, Any] | None = None
@@ -106,6 +108,22 @@ class CodexPluginSettings(BaseSettings):
     request_timeout_seconds: float = Field(default=1.0, gt=0)
     http_budget_seconds: float = Field(default=4.0, gt=0)
     flush_max_calls: int = Field(default=4, ge=1, le=16)
+
+    @field_validator("allow_insecure_http", mode="before")
+    @classmethod
+    def validate_http_consent(cls, value: object) -> bool | None:
+        return None if value is None else parse_boolean(value)
+
+    @model_validator(mode="after")
+    def validate_transport(self) -> CodexPluginSettings:
+        self.allow_insecure_http = resolve_allow_insecure_http(
+            self.server_url,
+            host="codex",
+            host_environment="POWERCONTEXT_CODEX_ALLOW_INSECURE_HTTP",
+            explicit=self.allow_insecure_http,
+        )
+        _http_base_url(f"{self.server_url}/mcp", allow_insecure_http=self.allow_insecure_http)
+        return self
 
     @field_validator("server_url")
     @classmethod
@@ -160,10 +178,10 @@ class CodexPluginSettings(BaseSettings):
 
 def _server_url_from_mcp_configuration() -> str:
     configuration = _McpConfiguration.model_validate_json(_MCP_CONFIGURATION_PATH.read_text())
-    return _http_base_url(configuration.mcp_servers["powercontext"].url)
+    return _http_base_url(configuration.mcp_servers["powercontext"].url, allow_insecure_http=True)
 
 
-def _http_base_url(mcp_url: str) -> str:
+def _http_base_url(mcp_url: str, *, allow_insecure_http: bool = False) -> str:
     normalized = mcp_url.rstrip("/")
     parsed = urlsplit(normalized)
     if parsed.username is not None or parsed.password is not None:
@@ -172,7 +190,7 @@ def _http_base_url(mcp_url: str) -> str:
         raise ValueError("PowerContext MCP URL must use HTTP or HTTPS")  # noqa: TRY003
     if parsed.query or parsed.fragment:
         raise ValueError("PowerContext MCP URL must not contain a query or fragment")  # noqa: TRY003
-    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname):
+    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname) and not allow_insecure_http:
         raise ValueError("unencrypted PowerContext MCP URLs must be loopback addresses")  # noqa: TRY003
     mcp_path = parsed.path.rstrip("/")
     if not mcp_path.endswith("/mcp"):

--- a/integrations/dsh/plugins/powercontext/README.md
+++ b/integrations/dsh/plugins/powercontext/README.md
@@ -52,6 +52,18 @@ the `POWERCONTEXT_DSH_` prefix for `BASE_URL`, `AUTHORIZATION`, `SCOPE_ID`, `CAP
 `timeoutMs`, `requestTimeoutMs`, `maxBytes`, and `flushMaxCalls` are plugin patch settings. Context returned by recall
 is labelled as untrusted history. An unavailable Server never blocks normal Harness work.
 
+Remote HTTP is rejected by default. For an explicitly trusted plaintext connection, set
+`POWERCONTEXT_DSH_ALLOW_INSECURE_HTTP=true` or the plugin setting `allowInsecureHttp: true`.
+The common `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP` flag applies when the host flag is absent; a host flag of
+`false` overrides it. Environment flags accept only `true/false`, `1/0`, `yes/no`, or `on/off`.
+HTTPS certificate validation and redirect rejection remain enabled.
+
+Setup-saved URLs and endpoint-specific consent are read from `~/.config/powercontext/clients.json`
+(override with `POWERCONTEXT_CLIENT_CONFIG_FILE`). URL environment overrides, including
+`POWERCONTEXT_CLIENT_SERVER_URL`, take precedence over explicit plugin URLs, then saved URLs and the loopback default.
+Changing the endpoint does not reuse saved or native HTTP consent. Native `allowInsecureHttp: true` must accompany
+the matching `baseUrl`; an environment URL override needs its own matching or explicit environment consent.
+
 Automatic failures are reported through the native `powercontext.dsh` logger with a stage, a safe outcome, and an
 optional public error code. They do not become model messages. Scope failure stops that step's PowerContext work;
 prepare and capture otherwise fail independently. Cancellation prevents subsequent operations, and logger failures

--- a/integrations/dsh/plugins/powercontext/cordis.patch.yml
+++ b/integrations/dsh/plugins/powercontext/cordis.patch.yml
@@ -16,7 +16,6 @@
     - id: powercontext-dsh
       name: powercontext-dsh
       config:
-        baseUrl: http://127.0.0.1:8000
         timeoutMs: 4000
         requestTimeoutMs: 1000
         maxBytes: 8000

--- a/integrations/dsh/plugins/powercontext/lib/index.d.ts
+++ b/integrations/dsh/plugins/powercontext/lib/index.d.ts
@@ -20,6 +20,7 @@ import { Context } from "@deepseek-ai/cordis";
 interface PluginConfig {
   contextAssembly?: Record<string, unknown>;
   baseUrl?: string;
+  allowInsecureHttp?: boolean;
   authorization?: string;
   scopeId?: string;
   timeoutMs?: number;

--- a/integrations/dsh/plugins/powercontext/lib/index.js
+++ b/integrations/dsh/plugins/powercontext/lib/index.js
@@ -15,9 +15,10 @@
  */
 
 import { createRequire } from "node:module";
-import { createHash } from "node:crypto";
-import { join, resolve } from "node:path";
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 //#region src/errors.ts
@@ -1281,6 +1282,99 @@ const OPERATIONS = {
 const OPERATION_IDS = Object.keys(OPERATIONS);
 
 //#endregion
+//#region src/transport.ts
+function optionalText$1(value) {
+	return typeof value === "string" ? value.trim() || void 0 : void 0;
+}
+function optionalBoolean(value, name$1) {
+	if (value === void 0) return void 0;
+	if (typeof value !== "boolean") throw new Error(`${name$1} must be a boolean`);
+	return value;
+}
+function environmentBoolean(env, name$1) {
+	if (env[name$1] === void 0) return void 0;
+	const value = env[name$1].trim().toLowerCase();
+	if ([
+		"true",
+		"1",
+		"yes",
+		"on"
+	].includes(value)) return true;
+	if ([
+		"false",
+		"0",
+		"no",
+		"off"
+	].includes(value)) return false;
+	throw new Error(`${name$1} must be a boolean (true/false, 1/0, yes/no, on/off)`);
+}
+function readSavedClient(host, env) {
+	const home = optionalText$1(env.HOME) ?? homedir();
+	const configuredPath = optionalText$1(env.POWERCONTEXT_CLIENT_CONFIG_FILE);
+	const path = configuredPath?.startsWith("~/") ? join(home, configuredPath.slice(2)) : configuredPath ?? join(home, ".config", "powercontext", "clients.json");
+	let contents;
+	try {
+		contents = readFileSync(path, "utf8");
+	} catch (error) {
+		if (error.code === "ENOENT") return {};
+		throw new Error("Unable to read PowerContext client configuration", { cause: error });
+	}
+	let document;
+	try {
+		document = JSON.parse(contents);
+	} catch {
+		throw new Error("PowerContext client configuration must be valid JSON");
+	}
+	if (!document || typeof document !== "object" || Array.isArray(document) || document.version !== 1) throw new Error("PowerContext client configuration must have version 1");
+	const hosts = document.hosts;
+	if (!hosts || typeof hosts !== "object" || Array.isArray(hosts)) throw new Error("PowerContext client configuration hosts must be an object");
+	const value = hosts[host];
+	if (value === void 0) return {};
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("PowerContext saved host configuration must be an object");
+	const entry = value;
+	if (entry.server_url !== void 0 && !optionalText$1(entry.server_url)) throw new Error("PowerContext saved server_url must be a non-empty string");
+	return {
+		server_url: optionalText$1(entry.server_url),
+		allow_insecure_http: optionalBoolean(entry.allow_insecure_http, "allow_insecure_http")
+	};
+}
+function normalizeServerUrl(value, allowInsecureHttp = false, name$1 = "PowerContext server URL") {
+	optionalBoolean(allowInsecureHttp, "allowInsecureHttp");
+	let url;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new Error(`${name$1} must be a valid HTTP(S) URL`);
+	}
+	if (!["http:", "https:"].includes(url.protocol)) throw new Error(`${name$1} must use HTTP or HTTPS`);
+	if (url.username || url.password || url.search || url.hash) throw new Error(`${name$1} must not contain credentials, a query, or a fragment`);
+	const host = url.hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+	const octets = host.split(".");
+	const loopback = host === "localhost" || host === "::1" || octets.length === 4 && octets[0] === "127" && octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255);
+	if (url.protocol === "http:" && !loopback && !allowInsecureHttp) throw new Error(`${name$1} must use HTTPS outside loopback; explicitly enable allow_insecure_http to permit plaintext HTTP`);
+	return url.toString().replace(/\/+$/, "").replace(/\/mcp$/, "").replace(/\/+$/, "");
+}
+function resolveTransport(host, env, nativeUrl, nativeConsent, defaultUrl) {
+	const prefix = `POWERCONTEXT_${host.toUpperCase()}`;
+	const saved = readSavedClient(host, env);
+	const environmentUrl = optionalText$1(env[`${prefix}_BASE_URL`]) ?? optionalText$1(env[`${prefix}_SERVER_URL`]) ?? optionalText$1(env[`${prefix}_ENDPOINT`]) ?? optionalText$1(env.POWERCONTEXT_CLIENT_SERVER_URL);
+	const pluginUrl = optionalText$1(nativeUrl);
+	const selectedUrl = environmentUrl ?? pluginUrl ?? saved.server_url ?? defaultUrl;
+	const normalized = selectedUrl === void 0 ? void 0 : normalizeServerUrl(selectedUrl, true, `${prefix}_BASE_URL`);
+	const savedUrl = saved.server_url === void 0 ? void 0 : normalizeServerUrl(saved.server_url, true);
+	const hostConsent = environmentBoolean(env, `${prefix}_ALLOW_INSECURE_HTTP`);
+	const commonConsent = environmentBoolean(env, "POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP");
+	const pluginConsent = optionalBoolean(nativeConsent, "allowInsecureHttp");
+	const nativeEndpoint = pluginUrl === void 0 ? void 0 : normalizeServerUrl(pluginUrl, true);
+	const allowInsecureHttp = hostConsent ?? commonConsent ?? (pluginConsent === false ? false : normalized !== void 0 && normalized === nativeEndpoint ? pluginConsent : void 0) ?? (normalized !== void 0 && normalized === savedUrl ? saved.allow_insecure_http : void 0) ?? false;
+	return {
+		baseUrl: normalized === void 0 ? void 0 : normalizeServerUrl(normalized, allowInsecureHttp, `${prefix}_BASE_URL`),
+		allowInsecureHttp,
+		source: environmentUrl ? "environment" : pluginUrl ? "plugin" : saved.server_url ? "saved" : "default"
+	};
+}
+
+//#endregion
 //#region src/client.ts
 function combineSignals(signals) {
 	const present$1 = signals.filter(Boolean);
@@ -1406,7 +1500,7 @@ var PowerContextClient = class {
 	requestTimeoutMs;
 	fetchImpl;
 	constructor(options) {
-		this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+		this.baseUrl = normalizeServerUrl(options.baseUrl, options.allowInsecureHttp);
 		this.authorization = options.authorization;
 		this.requestTimeoutMs = options.requestTimeoutMs;
 		this.fetchImpl = options.fetch ?? fetch;
@@ -2377,6 +2471,7 @@ const DEFAULTS = {
 		scopeId: "default"
 	},
 	baseUrl: "http://127.0.0.1:8000",
+	allowInsecureHttp: false,
 	authorization: void 0,
 	scopeId: void 0,
 	timeoutMs: 4e3,
@@ -2406,9 +2501,6 @@ function envBoolean(env, name$1) {
 		"off"
 	].includes(value)) return false;
 }
-function stripSlash(url) {
-	return url.replace(/\/+$/, "");
-}
 function optionalText(value) {
 	const trimmed = value?.trim();
 	return trimmed ? trimmed : void 0;
@@ -2425,16 +2517,18 @@ function contextAssembly(raw, fallback) {
 	return structuredClone(value);
 }
 function resolveConfig(config = {}, env = process.env) {
+	const transport = resolveTransport("dsh", env, config.baseUrl, config.allowInsecureHttp, DEFAULTS.baseUrl);
 	const maxBytes = config.maxBytes ?? DEFAULTS.maxBytes;
 	if (maxBytes < 512 || maxBytes > 32768) throw new Error("maxBytes must be between 512 and 32768");
 	return {
 		contextAssembly: contextAssembly(envString(env, "POWERCONTEXT_DSH_CONTEXT_ASSEMBLY"), config.contextAssembly),
 		sources: {
-			baseUrl: envString(env, "POWERCONTEXT_DSH_BASE_URL") ? "environment" : config.baseUrl ? "plugin" : "default",
+			baseUrl: transport.source,
 			authorization: envString(env, "POWERCONTEXT_DSH_AUTHORIZATION") ? "environment" : optionalText(config.authorization) ? "plugin" : "default",
 			scopeId: envString(env, "POWERCONTEXT_DSH_SCOPE_ID") ? "environment" : optionalText(config.scopeId) ? "plugin" : "default"
 		},
-		baseUrl: stripSlash(envString(env, "POWERCONTEXT_DSH_BASE_URL") ?? config.baseUrl ?? DEFAULTS.baseUrl),
+		baseUrl: transport.baseUrl,
+		allowInsecureHttp: transport.allowInsecureHttp,
 		authorization: envString(env, "POWERCONTEXT_DSH_AUTHORIZATION") ?? optionalText(config.authorization),
 		scopeId: envString(env, "POWERCONTEXT_DSH_SCOPE_ID") ?? optionalText(config.scopeId),
 		timeoutMs: config.timeoutMs ?? DEFAULTS.timeoutMs,
@@ -3238,6 +3332,7 @@ function createRuntime(ctx, config) {
 	const resolved = resolveConfig(config);
 	const client = new PowerContextClient({
 		baseUrl: resolved.baseUrl,
+		allowInsecureHttp: resolved.allowInsecureHttp,
 		authorization: resolved.authorization,
 		requestTimeoutMs: resolved.requestTimeoutMs
 	});

--- a/integrations/dsh/plugins/powercontext/src/client.ts
+++ b/integrations/dsh/plugins/powercontext/src/client.ts
@@ -25,6 +25,7 @@ import {
   UnknownOperationError,
 } from './errors.ts'
 import { OPERATIONS, type OperationId, type OperationSpec } from './operations.generated.ts'
+import { normalizeServerUrl } from './transport.ts'
 
 export type JsonObject = Record<string, unknown>
 export type FetchFn = (input: string, init: RequestInit) => Promise<Response>
@@ -36,6 +37,7 @@ export type ClientSuccess =
 
 export interface ClientOptions {
   baseUrl: string
+  allowInsecureHttp?: boolean
   authorization?: string
   requestTimeoutMs: number
   fetch?: FetchFn
@@ -190,7 +192,7 @@ export class PowerContextClient {
   private readonly fetchImpl: FetchFn
 
   constructor(options: ClientOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
+    this.baseUrl = normalizeServerUrl(options.baseUrl, options.allowInsecureHttp)
     this.authorization = options.authorization
     this.requestTimeoutMs = options.requestTimeoutMs
     this.fetchImpl = options.fetch ?? fetch

--- a/integrations/dsh/plugins/powercontext/src/config.ts
+++ b/integrations/dsh/plugins/powercontext/src/config.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import { resolveTransport } from './transport.ts'
+
 export interface PluginConfig {
   contextAssembly?: Record<string, unknown>
   baseUrl?: string
+  allowInsecureHttp?: boolean
   authorization?: string
   scopeId?: string
   timeoutMs?: number
@@ -31,6 +34,7 @@ export interface ResolvedConfig {
   contextAssembly?: Record<string, unknown>
   sources: { baseUrl: ConfigSource; authorization: ConfigSource; scopeId: ConfigSource }
   baseUrl: string
+  allowInsecureHttp: boolean
   authorization: string | undefined
   scopeId: string | undefined
   timeoutMs: number
@@ -41,11 +45,12 @@ export interface ResolvedConfig {
   flushMaxCalls: number
 }
 
-export type ConfigSource = 'environment' | 'plugin' | 'default'
+export type ConfigSource = 'environment' | 'plugin' | 'saved' | 'default'
 
 const DEFAULTS: ResolvedConfig = {
   sources: { baseUrl: 'default', authorization: 'default', scopeId: 'default' },
   baseUrl: 'http://127.0.0.1:8000',
+  allowInsecureHttp: false,
   authorization: undefined,
   scopeId: undefined,
   timeoutMs: 4000,
@@ -67,10 +72,6 @@ function envBoolean(env: NodeJS.ProcessEnv, name: string): boolean | undefined {
   if (['1', 'true', 'yes', 'on'].includes(value)) return true
   if (['0', 'false', 'no', 'off'].includes(value)) return false
   return undefined
-}
-
-function stripSlash(url: string): string {
-  return url.replace(/\/+$/, '')
 }
 
 function optionalText(value: string | undefined): string | undefined {
@@ -96,6 +97,7 @@ export function resolveConfig(
   config: PluginConfig = {},
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedConfig {
+  const transport = resolveTransport('dsh', env, config.baseUrl, config.allowInsecureHttp, DEFAULTS.baseUrl)
   const maxBytes = config.maxBytes ?? DEFAULTS.maxBytes
   if (maxBytes < 512 || maxBytes > 32768) {
     throw new Error('maxBytes must be between 512 and 32768')
@@ -103,11 +105,12 @@ export function resolveConfig(
   return {
     contextAssembly: contextAssembly(envString(env, 'POWERCONTEXT_DSH_CONTEXT_ASSEMBLY'), config.contextAssembly),
     sources: {
-      baseUrl: envString(env, 'POWERCONTEXT_DSH_BASE_URL') ? 'environment' : config.baseUrl ? 'plugin' : 'default',
+      baseUrl: transport.source,
       authorization: envString(env, 'POWERCONTEXT_DSH_AUTHORIZATION') ? 'environment' : optionalText(config.authorization) ? 'plugin' : 'default',
       scopeId: envString(env, 'POWERCONTEXT_DSH_SCOPE_ID') ? 'environment' : optionalText(config.scopeId) ? 'plugin' : 'default',
     },
-    baseUrl: stripSlash(envString(env, 'POWERCONTEXT_DSH_BASE_URL') ?? config.baseUrl ?? DEFAULTS.baseUrl),
+    baseUrl: transport.baseUrl!,
+    allowInsecureHttp: transport.allowInsecureHttp,
     authorization: envString(env, 'POWERCONTEXT_DSH_AUTHORIZATION') ?? optionalText(config.authorization),
     scopeId: envString(env, 'POWERCONTEXT_DSH_SCOPE_ID') ?? optionalText(config.scopeId),
     timeoutMs: config.timeoutMs ?? DEFAULTS.timeoutMs,

--- a/integrations/dsh/plugins/powercontext/src/index.ts
+++ b/integrations/dsh/plugins/powercontext/src/index.ts
@@ -65,6 +65,7 @@ function createRuntime(ctx: Context, config: PluginConfig): PluginRuntime {
   const resolved = resolveConfig(config)
   const client = new PowerContextClient({
     baseUrl: resolved.baseUrl,
+    allowInsecureHttp: resolved.allowInsecureHttp,
     authorization: resolved.authorization,
     requestTimeoutMs: resolved.requestTimeoutMs,
   })

--- a/integrations/dsh/plugins/powercontext/src/transport.ts
+++ b/integrations/dsh/plugins/powercontext/src/transport.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+// Each host is an independently distributed package; keep the shared client config
+// contract and policy aligned with powercontext.client.transport_policy and powercontext.transport.
+type SavedClient = { server_url?: string; allow_insecure_http?: boolean }
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === 'string' ? value.trim() || undefined : undefined
+}
+
+function optionalBoolean(value: unknown, name: string): boolean | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'boolean') throw new Error(`${name} must be a boolean`)
+  return value
+}
+
+function environmentBoolean(env: NodeJS.ProcessEnv, name: string): boolean | undefined {
+  if (env[name] === undefined) return undefined
+  const value = env[name]!.trim().toLowerCase()
+  if (['true', '1', 'yes', 'on'].includes(value)) return true
+  if (['false', '0', 'no', 'off'].includes(value)) return false
+  throw new Error(`${name} must be a boolean (true/false, 1/0, yes/no, on/off)`)
+}
+
+function readSavedClient(host: string, env: NodeJS.ProcessEnv): SavedClient {
+  const home = optionalText(env.HOME) ?? homedir()
+  const configuredPath = optionalText(env.POWERCONTEXT_CLIENT_CONFIG_FILE)
+  const path = configuredPath?.startsWith('~/')
+    ? join(home, configuredPath.slice(2))
+    : configuredPath ?? join(home, '.config', 'powercontext', 'clients.json')
+  let contents: string
+  try {
+    contents = readFileSync(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw new Error('Unable to read PowerContext client configuration', { cause: error })
+  }
+  let document: unknown
+  try {
+    document = JSON.parse(contents)
+  } catch {
+    throw new Error('PowerContext client configuration must be valid JSON')
+  }
+  if (!document || typeof document !== 'object' || Array.isArray(document)
+    || (document as { version?: unknown }).version !== 1) {
+    throw new Error('PowerContext client configuration must have version 1')
+  }
+  const hosts = (document as { hosts?: unknown }).hosts
+  if (!hosts || typeof hosts !== 'object' || Array.isArray(hosts)) {
+    throw new Error('PowerContext client configuration hosts must be an object')
+  }
+  const value = (hosts as Record<string, unknown>)[host]
+  if (value === undefined) return {}
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('PowerContext saved host configuration must be an object')
+  }
+  const entry = value as Record<string, unknown>
+  if (entry.server_url !== undefined && !optionalText(entry.server_url)) {
+    throw new Error('PowerContext saved server_url must be a non-empty string')
+  }
+  return {
+    server_url: optionalText(entry.server_url),
+    allow_insecure_http: optionalBoolean(entry.allow_insecure_http, 'allow_insecure_http'),
+  }
+}
+
+export function normalizeServerUrl(value: string, allowInsecureHttp = false, name = 'PowerContext server URL'): string {
+  optionalBoolean(allowInsecureHttp, 'allowInsecureHttp')
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${name} must be a valid HTTP(S) URL`)
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error(`${name} must use HTTP or HTTPS`)
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(`${name} must not contain credentials, a query, or a fragment`)
+  }
+  const host = url.hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '')
+  const octets = host.split('.')
+  const loopback = host === 'localhost' || host === '::1'
+    || (octets.length === 4 && octets[0] === '127'
+      && octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255))
+  if (url.protocol === 'http:' && !loopback && !allowInsecureHttp) {
+    throw new Error(`${name} must use HTTPS outside loopback; explicitly enable allow_insecure_http to permit plaintext HTTP`)
+  }
+  return url.toString().replace(/\/+$/, '').replace(/\/mcp$/, '').replace(/\/+$/, '')
+}
+
+export function resolveTransport(
+  host: string,
+  env: NodeJS.ProcessEnv,
+  nativeUrl?: unknown,
+  nativeConsent?: unknown,
+  defaultUrl?: string,
+): { baseUrl: string | undefined; allowInsecureHttp: boolean; source: 'environment' | 'plugin' | 'saved' | 'default' } {
+  const prefix = `POWERCONTEXT_${host.toUpperCase()}`
+  const saved = readSavedClient(host, env)
+  const environmentUrl = optionalText(env[`${prefix}_BASE_URL`])
+    ?? optionalText(env[`${prefix}_SERVER_URL`])
+    ?? optionalText(env[`${prefix}_ENDPOINT`])
+    ?? optionalText(env.POWERCONTEXT_CLIENT_SERVER_URL)
+  const pluginUrl = optionalText(nativeUrl)
+  const selectedUrl = environmentUrl ?? pluginUrl ?? saved.server_url ?? defaultUrl
+  const normalized = selectedUrl === undefined ? undefined : normalizeServerUrl(selectedUrl, true, `${prefix}_BASE_URL`)
+  const savedUrl = saved.server_url === undefined ? undefined : normalizeServerUrl(saved.server_url, true)
+  const hostConsent = environmentBoolean(env, `${prefix}_ALLOW_INSECURE_HTTP`)
+  const commonConsent = environmentBoolean(env, 'POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP')
+  const pluginConsent = optionalBoolean(nativeConsent, 'allowInsecureHttp')
+  const nativeEndpoint = pluginUrl === undefined ? undefined : normalizeServerUrl(pluginUrl, true)
+  // Persisted native consent belongs to its endpoint, just like setup-saved consent.
+  // An explicit refusal remains effective even when the endpoint is overridden.
+  const matchingNativeConsent = pluginConsent === false
+    ? false
+    : normalized !== undefined && normalized === nativeEndpoint ? pluginConsent : undefined
+  const allowInsecureHttp = hostConsent ?? commonConsent ?? matchingNativeConsent
+    ?? (normalized !== undefined && normalized === savedUrl ? saved.allow_insecure_http : undefined) ?? false
+  return {
+    baseUrl: normalized === undefined ? undefined : normalizeServerUrl(normalized, allowInsecureHttp, `${prefix}_BASE_URL`),
+    allowInsecureHttp,
+    source: environmentUrl ? 'environment' : pluginUrl ? 'plugin' : saved.server_url ? 'saved' : 'default',
+  }
+}

--- a/integrations/dsh/plugins/powercontext/tests/client.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/client.spec.ts
@@ -224,6 +224,7 @@ describe('PowerContextClient', () => {
     let operationIndex = 0
     const client = new PowerContextClient({
       baseUrl: 'http://example.test',
+      allowInsecureHttp: true,
       requestTimeoutMs: 1000,
       fetch: async (url, init) => {
         const spec = OPERATIONS[OPERATION_IDS[operationIndex++]!]

--- a/integrations/dsh/plugins/powercontext/tests/commands.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/commands.spec.ts
@@ -96,6 +96,7 @@ describe('config env overrides', () => {
       { baseUrl: 'http://127.0.0.1:8000', capturePrompts: true },
       {
         POWERCONTEXT_DSH_BASE_URL: 'http://example.local:9000/',
+        POWERCONTEXT_DSH_ALLOW_INSECURE_HTTP: 'true',
         POWERCONTEXT_DSH_SCOPE_ID: 'project:from-env',
         POWERCONTEXT_DSH_CAPTURE_PROMPTS: 'false',
       },

--- a/integrations/dsh/plugins/powercontext/tests/direct-failures.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/direct-failures.spec.ts
@@ -258,7 +258,7 @@ describe('registered /pc command routing', () => {
   it('keeps bare status available and redacts endpoint secrets when Scope fails', async () => {
     const h = fixture(
       async () => domainResponse(404, 'scope_not_found'),
-      'http://user:private-response-marker@example.test/prefix?token=private-response-marker#private-response-marker',
+      'https://example.test/private-response-marker',
     )
     h.runtime.config.scopeId = 'configured-but-unresolved'
     const result = await h.command('')
@@ -268,7 +268,7 @@ describe('registered /pc command routing', () => {
     expect(result.text).toContain('/pc doctor')
     expect(result.text).not.toContain(PRIVATE)
     expect(result.text).not.toContain('configured-but-unresolved')
-    expect(h.calls.map(call => call.path)).toEqual(['/prefix'])
+    expect(h.calls.map(call => call.path)).toEqual(['/private-response-marker' + RESOLVE_PATH])
   })
 
   it('contains a scoped command failure without writing or selecting another Scope', async () => {

--- a/integrations/dsh/plugins/powercontext/tests/doctor.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/doctor.spec.ts
@@ -180,7 +180,8 @@ describe('read-only DSH Doctor', () => {
   })
 
   it('rejects malformed endpoint configuration without making requests', async () => {
-    const h = fixture(undefined, { baseUrl: 'http://user:' + PRIVATE + '@localhost/?token=' + PRIVATE })
+    const h = fixture()
+    h.runtime.config.baseUrl = 'http://user:' + PRIVATE + '@localhost/?token=' + PRIVATE
     const result = await h.doctor()
     expect(result).toMatchObject({ ok: false, checks: { configuration: { code: 'invalid_endpoint' } } })
     expect(JSON.stringify(result)).not.toContain(PRIVATE)

--- a/integrations/dsh/plugins/powercontext/tests/recall-fail-open.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/recall-fail-open.spec.ts
@@ -23,6 +23,7 @@ import type { ResolvedConfig } from '../src/config.ts'
 const config: ResolvedConfig = {
   sources: { baseUrl: 'plugin', authorization: 'default', scopeId: 'plugin' },
   baseUrl: 'http://127.0.0.1:8000',
+  allowInsecureHttp: false,
   authorization: undefined,
   scopeId: 'project:demo',
   timeoutMs: 4000,

--- a/integrations/dsh/plugins/powercontext/tests/transport-consent.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/transport-consent.spec.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveConfig } from '../src/config.ts'
+import { PowerContextClient } from '../src/client.ts'
+
+const remote = 'http://memory.example.test:8000'
+const hostUrl = 'POWERCONTEXT_DSH_BASE_URL'
+const hostFlag = 'POWERCONTEXT_DSH_ALLOW_INSECURE_HTTP'
+let directory: string
+let configFile: string
+
+function resolve(overrides: NodeJS.ProcessEnv = {}, native: Record<string, unknown> = {}) {
+  const env = { POWERCONTEXT_CLIENT_CONFIG_FILE: configFile, ...overrides }
+  return resolveConfig(native, env)
+}
+
+function save(serverUrl = remote, consent: unknown = true) {
+  writeFileSync(configFile, JSON.stringify({
+    version: 1,
+    hosts: { dsh: { server_url: serverUrl, allow_insecure_http: consent } },
+  }))
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'powercontext-dsh-transport-'))
+  configFile = join(directory, 'clients.json')
+})
+afterEach(() => rmSync(directory, { recursive: true, force: true }))
+
+describe('dsh transport consent', () => {
+  it('rejects non-boolean consent from direct JavaScript callers', () => {
+    expect(() => new PowerContextClient({
+      baseUrl: remote, requestTimeoutMs: 1000,
+      allowInsecureHttp: 'false' as unknown as boolean,
+    })).toThrow(/boolean/)
+  })
+
+  it('enforces transport policy when constructing a client directly', async () => {
+    const options = {
+      baseUrl: remote, requestTimeoutMs: 1000,
+      fetch: async (_url: string, init: RequestInit) => {
+        expect(init.redirect).toBe('manual')
+        return new Response('{}', { headers: { 'content-type': 'application/json' } })
+      },
+    }
+    expect(() => new PowerContextClient(options)).toThrow(/HTTPS/)
+    const client = new PowerContextClient({ ...options, allowInsecureHttp: true })
+    await expect(client.request('get_liveness')).resolves.toMatchObject({ status: 200 })
+  })
+
+  it('rejects remote cleartext without consent', () => {
+    expect(() => resolve({ [hostUrl]: remote })).toThrow(/HTTPS/)
+  })
+
+  it.each(['true', '1', 'yes', 'on', ' TRUE '])('accepts explicit consent %s', (value) => {
+    expect(resolve({ [hostUrl]: remote, [hostFlag]: value }).baseUrl).toBe(remote)
+  })
+
+  it('accepts common consent and a common server URL', () => {
+    const result = resolve({
+      POWERCONTEXT_CLIENT_SERVER_URL: remote,
+      POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'yes',
+    })
+    expect(result.baseUrl).toBe(remote)
+    expect(result.allowInsecureHttp).toBe(true)
+  })
+
+  it.each(['false', '0', 'no', 'off'])('lets host %s override common consent', (value) => {
+    expect(() => resolve({
+      [hostUrl]: remote,
+      [hostFlag]: value,
+      POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'true',
+    })).toThrow(/HTTPS/)
+  })
+
+  it.each([hostFlag, 'POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP'])('rejects invalid %s', (name) => {
+    expect(() => resolve({ [name]: 'sometimes' })).toThrow(/boolean/)
+  })
+
+  it('loads setup-saved endpoint and consent when native configuration is absent', () => {
+    save()
+    expect(resolve().baseUrl).toBe(remote)
+    expect(resolve().allowInsecureHttp).toBe(true)
+  })
+
+  it('normalizes saved MCP URLs before matching consent', () => {
+    save(remote + '/mcp/')
+    expect(resolve({ [hostUrl]: remote + '/' }).baseUrl).toBe(remote)
+  })
+
+  it('does not reuse saved consent for a different endpoint', () => {
+    save()
+    expect(() => resolve({ [hostUrl]: 'http://other.test' })).toThrow(/HTTPS/)
+  })
+
+  it('lets explicit common false revoke saved consent', () => {
+    save()
+    expect(() => resolve({ POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'false' })).toThrow(/HTTPS/)
+  })
+
+  it('rejects non-boolean saved consent', () => {
+    save(remote, 'true')
+    expect(() => resolve()).toThrow(/boolean/)
+  })
+
+  it.each(['localhost', '127.0.0.2', '[::1]'])('allows loopback HTTP at %s', (host) => {
+    expect(resolve({ [hostUrl]: 'http://' + host + ':8000' }).baseUrl).toBe('http://' + host + ':8000')
+  })
+
+  it.each(['ftp://memory.test', 'https://user:password@memory.test', 'https://memory.test/?secret=value', 'https://memory.test/#fragment'])(
+    'keeps URL restrictions when opted in: %s', (url) => {
+      expect(() => resolve({ [hostUrl]: url, [hostFlag]: 'true' })).toThrow()
+    },
+  )
+
+  it('honors explicit native consent and rejects a non-boolean native value', () => {
+    expect(resolve({}, { baseUrl: remote, allowInsecureHttp: true }).baseUrl).toBe(remote)
+    expect(() => resolve({}, { baseUrl: remote, allowInsecureHttp: 'yes' })).toThrow(/boolean/)
+  })
+
+  it('does not transfer native consent when an environment URL changes the endpoint', () => {
+    expect(() => resolve({ [hostUrl]: 'http://other.test' }, {
+      baseUrl: remote, allowInsecureHttp: true,
+    })).toThrow(/HTTPS/)
+  })
+
+  it('matches native consent against normalized endpoints', () => {
+    expect(resolve({ [hostUrl]: remote + '/' }, {
+      baseUrl: remote + '/mcp/', allowInsecureHttp: true,
+    }).baseUrl).toBe(remote)
+  })
+
+  it('requires an endpoint alongside native consent', () => {
+    expect(() => resolve({ [hostUrl]: remote }, { allowInsecureHttp: true })).toThrow(/HTTPS/)
+  })
+
+  it('permits a changed endpoint when the environment explicitly authorizes it', () => {
+    expect(resolve({ [hostUrl]: 'http://other.test', [hostFlag]: 'true' }, {
+      baseUrl: remote, allowInsecureHttp: true,
+    }).baseUrl).toBe('http://other.test')
+  })
+
+  it('lets an environment false override native consent', () => {
+    expect(() => resolve({ [hostFlag]: 'false' }, {
+      baseUrl: remote, allowInsecureHttp: true,
+    })).toThrow(/HTTPS/)
+  })
+
+  it('does not let native false or a changed native endpoint inherit saved consent', () => {
+    save()
+    expect(() => resolve({}, { allowInsecureHttp: false })).toThrow(/HTTPS/)
+    expect(() => resolve({}, { baseUrl: 'http://other.test' })).toThrow(/HTTPS/)
+  })
+})

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -100,6 +100,7 @@ Environment variables override file values:
 | --- | --- |
 | `POWERCONTEXT_HERMES_CONFIG` | Path to a JSON config file (defaults to `$HERMES_HOME/powercontext/config.json`). |
 | `POWERCONTEXT_HERMES_BASE_URL` | PowerContext server URL |
+| `POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP` | Explicit non-loopback HTTP consent; overrides common and saved consent, including `false`. |
 | `POWERCONTEXT_HERMES_AUTHORIZATION` | Complete authorization header, e.g. `Bearer <token>` |
 | `POWERCONTEXT_HERMES_TOKEN` | Token shorthand; used when `AUTHORIZATION` is absent |
 | `POWERCONTEXT_HERMES_SCOPE_ID` | Explicit server-owned Scope ID |
@@ -110,6 +111,32 @@ Environment variables override file values:
 | `POWERCONTEXT_HERMES_CAPTURE_PRE_COMPRESS` | Capture filtered new user/assistant turns before compression; disabled by default |
 | `POWERCONTEXT_HERMES_EVALUATION_TRACE` | Record recalled context in per-session local JSONL files; disabled by default |
 | `POWERCONTEXT_HERMES_EVALUATION_TRACE_PATH` | Override the evaluation trace directory |
+
+The client accepts HTTPS and loopback HTTP by default. To configure a
+non-loopback HTTP endpoint explicitly:
+
+```bash
+powercontext setup hermes --server-url http://memory.example:8000 --allow-insecure-http
+```
+
+Setup stores nonsecret settings under `hosts.hermes` in
+`~/.config/powercontext/clients.json` (`POWERCONTEXT_CLIENT_CONFIG_FILE` overrides
+the path). Hermes' native `base_url` configuration remains supported; when it
+is absent, the provider also checks `POWERCONTEXT_CLIENT_SERVER_URL` and saved
+client settings before the loopback default. The host URL environment overrides
+native configuration.
+
+A direct client `allow_insecure_http` argument overrides
+`POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP`, then
+`POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP`, then saved consent. Native Hermes
+configuration can store `allow_insecure_http` with `base_url`; this pair takes
+precedence over shared saved settings. Saved consent belongs only to the
+matching endpoint after stripping trailing slashes and `/mcp`. Changing an
+endpoint through the setup wizard or a session override clears inherited
+consent. Invalid boolean values are rejected.
+
+HTTP sends request content and authorization headers without encryption. This
+opt-in does not change HTTPS certificate verification.
 
 Hermes asks the Server to resolve an explicit Scope, durable session and
 workspace bindings, or the Server default, in that order. Workspace paths are

--- a/integrations/hermes/plugins/powercontext/client.py
+++ b/integrations/hermes/plugins/powercontext/client.py
@@ -24,6 +24,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
+from .powercontext_client_config import normalize_server_url, resolve_allow_insecure_http
+
 if TYPE_CHECKING:
     from typing_extensions import override
 else:
@@ -145,10 +147,17 @@ class PowerContextClient:
         base_url: str,
         *,
         authorization: str | None = None,
+        allow_insecure_http: bool | None = None,
         timeout: float = 5.0,
         transport: Transport | None = None,
     ) -> None:
-        self.base_url = base_url.rstrip("/")
+        self.allow_insecure_http = resolve_allow_insecure_http(
+            base_url,
+            host="hermes",
+            host_environment="POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP",
+            explicit=allow_insecure_http,
+        )
+        self.base_url = normalize_server_url(base_url, allow_insecure_http=self.allow_insecure_http)
         self.authorization = authorization.strip() if authorization else None
         self.timeout = timeout
         self._opener = build_opener(_NoRedirectHandler())

--- a/integrations/hermes/plugins/powercontext/config_schema.py
+++ b/integrations/hermes/plugins/powercontext/config_schema.py
@@ -47,6 +47,13 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             inline=True,
         ),
         ProviderField(
+            key="allow_insecure_http",
+            label="Allow unencrypted HTTP",
+            kind=KIND_BOOL,
+            env_key="POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP",
+            description="Explicitly allow HTTP to the configured non-loopback server; does not disable TLS verification.",
+        ),
+        ProviderField(
             key="scope_id",
             label="Explicit Scope ID",
             kind=KIND_TEXT,

--- a/integrations/hermes/plugins/powercontext/powercontext_client_config.py
+++ b/integrations/hermes/plugins/powercontext/powercontext_client_config.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Endpoint-bound transport settings for an independently installed plugin.
+
+This standard-library helper is distributed with each Python host plugin.
+It must not import the PowerContext package, which need not be installed.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+
+def normalize_server_url(value: str, *, allow_insecure_http: bool = False) -> str:
+    """Validate a Server endpoint and remove the optional MCP suffix."""
+    parsed = urlsplit(value.strip().rstrip("/"))
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("PowerContext Server URL must not contain credentials")  # noqa: TRY003
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        raise ValueError("PowerContext Server URL must use HTTP or HTTPS")  # noqa: TRY003
+    if parsed.query or parsed.fragment:
+        raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
+    # Accessing port also rejects malformed and out-of-range ports.
+    port = parsed.port
+    host = parsed.hostname.lower()
+    try:
+        loopback = ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        loopback = host == "localhost"
+    if parsed.scheme == "http" and not loopback and not allow_insecure_http:
+        raise ValueError(  # noqa: TRY003
+            "unencrypted PowerContext URLs must be loopback addresses unless allow_insecure_http is explicitly enabled"
+        )
+    netloc = f"[{host}]" if ":" in host else host
+    if port is not None and port != (443 if parsed.scheme == "https" else 80):
+        netloc += f":{port}"
+    path = parsed.path.rstrip("/").removesuffix("/mcp")
+    return urlunsplit((parsed.scheme, netloc, path, "", "")).rstrip("/")
+
+
+def load_client_settings(host: str) -> dict[str, Any]:
+    """Read only the nonsecret settings owned by this host."""
+    configured = os.environ.get("POWERCONTEXT_CLIENT_CONFIG_FILE")
+    path = Path(configured).expanduser() if configured else Path.home() / ".config" / "powercontext" / "clients.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, UnicodeError, ValueError):
+        raise ValueError("invalid PowerContext client settings file") from None  # noqa: TRY003
+    if not isinstance(data, dict) or type(data.get("version")) is not int or data["version"] != 1:
+        raise ValueError("invalid PowerContext client settings version")  # noqa: TRY003
+    hosts = data.get("hosts")
+    if not isinstance(hosts, dict):
+        raise ValueError("invalid PowerContext client host settings")  # noqa: TRY003, TRY004
+    entry = hosts.get(host, {})
+    if not isinstance(entry, dict):
+        raise ValueError("invalid PowerContext client host settings")  # noqa: TRY003, TRY004
+    result: dict[str, Any] = {}
+    if "server_url" in entry:
+        if not isinstance(entry["server_url"], str):
+            raise ValueError("invalid PowerContext client server URL")  # noqa: TRY003
+        result["server_url"] = normalize_server_url(entry["server_url"], allow_insecure_http=True)
+    if "allow_insecure_http" in entry:
+        if not isinstance(entry["allow_insecure_http"], bool):
+            raise ValueError("PowerContext allow_insecure_http must be a JSON boolean")  # noqa: TRY003
+        result["allow_insecure_http"] = entry["allow_insecure_http"]
+    return result
+
+
+def parse_boolean(value: object) -> bool:
+    """Reject misspellings instead of interpreting nonempty strings as true."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise ValueError("invalid boolean PowerContext allow_insecure_http configuration")  # noqa: TRY003
+
+
+def resolve_allow_insecure_http(
+    server_url: str,
+    *,
+    host: str,
+    host_environment: str,
+    explicit: bool | None = None,
+    saved: dict[str, Any] | None = None,
+) -> bool:
+    """Resolve consent without transferring saved consent to another endpoint."""
+    settings = load_client_settings(host) if saved is None else saved
+    if explicit is not None:
+        return parse_boolean(explicit)
+    names = [host_environment, "POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP"]
+    for name in names:
+        if name in os.environ:
+            return parse_boolean(os.environ[name])
+    consent = settings.get("allow_insecure_http", False)
+    if not isinstance(consent, bool):
+        raise ValueError("PowerContext allow_insecure_http must be a JSON boolean")  # noqa: TRY003, TRY004
+    saved_url = settings.get("server_url")
+    return bool(
+        consent
+        and isinstance(saved_url, str)
+        and normalize_server_url(saved_url, allow_insecure_http=True)
+        == normalize_server_url(server_url, allow_insecure_http=True)
+    )

--- a/integrations/hermes/plugins/powercontext/provider.py
+++ b/integrations/hermes/plugins/powercontext/provider.py
@@ -91,6 +91,12 @@ from .helpers import (
     redact_secrets as _redact_secrets,
 )
 from .operations import OPERATION_TOOL_MAP as _OPERATION_TOOL_MAP
+from .powercontext_client_config import (
+    load_client_settings,
+    normalize_server_url,
+    parse_boolean,
+    resolve_allow_insecure_http,
+)
 
 try:
     from agent.memory_provider import MemoryProvider, RecallStatus  # ty: ignore[unresolved-import]
@@ -116,6 +122,17 @@ _AUTOMATIC_OPERATION_PATHS = {
     "pre_compaction_flush": frozenset({"/v1/memory/flush"}),
     "session_end_flush": frozenset({"/v1/memory/flush"}),
 }
+
+
+def _merge_config(existing: dict[str, Any], values: dict[str, Any]) -> dict[str, Any]:
+    merged = {**existing, **values}
+    if "base_url" in values and "allow_insecure_http" not in values and "allow_insecure_http" in existing:
+        previous_url = existing.get("base_url")
+        if not isinstance(previous_url, str) or normalize_server_url(
+            previous_url, allow_insecure_http=True
+        ) != normalize_server_url(str(values["base_url"]), allow_insecure_http=True):
+            merged["allow_insecure_http"] = False
+    return merged
 
 
 def _diagnostic_classification(
@@ -221,7 +238,7 @@ class PowerContextMemoryProvider(MemoryProvider):
 
     def is_available(self) -> bool:
         """Check local configuration only; do not make a network request."""
-        base_url = str(_config_value(self._config, "base_url", "POWERCONTEXT_HERMES_BASE_URL", _DEFAULT_BASE_URL))
+        base_url = self._server_url(self._config)
         return bool(base_url.strip())
 
     def unavailable_reason(self) -> str:
@@ -240,6 +257,12 @@ class PowerContextMemoryProvider(MemoryProvider):
                 "description": "Authorization header (optional)",
                 "secret": True,
                 "env_var": "POWERCONTEXT_HERMES_AUTHORIZATION",
+            },
+            {
+                "key": "allow_insecure_http",
+                "description": "Allow unencrypted HTTP to this non-loopback PowerContext server",
+                "choices": ["true", "false"],
+                "env_var": "POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP",
             },
             {
                 "key": "scope_id",
@@ -295,8 +318,7 @@ class PowerContextMemoryProvider(MemoryProvider):
     def save_config(self, values: dict[str, Any], hermes_home: str) -> None:
         """Persist generic Hermes setup values to Hermes' flat JSON backend."""
         path = _config_path(hermes_home)
-        config = _load_json_config(hermes_home)
-        config.update(values)
+        config = _merge_config(_load_json_config(hermes_home), values)
 
         path.parent.mkdir(parents=True, exist_ok=True)
         temporary_path = path.with_name(f".{path.name}.tmp")
@@ -312,7 +334,7 @@ class PowerContextMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs: Any) -> None:
         hermes_home = str(kwargs.get("hermes_home") or Path.home() / ".hermes")
         file_config = _load_json_config(hermes_home)
-        merged_config = {**file_config, **self._config}
+        merged_config = _merge_config(file_config, self._config)
         self._config = merged_config
         self._hermes_home = hermes_home
         self._session_id = session_id
@@ -580,14 +602,36 @@ class PowerContextMemoryProvider(MemoryProvider):
         except OSError:
             logger.debug("Could not persist PowerContext Hermes memory map", exc_info=True)
 
+    @staticmethod
+    def _server_url(config: dict[str, Any]) -> str:
+        saved = load_client_settings("hermes")
+        fallback = os.environ.get("POWERCONTEXT_CLIENT_SERVER_URL") or saved.get("server_url") or _DEFAULT_BASE_URL
+        return str(_config_value(config, "base_url", "POWERCONTEXT_HERMES_BASE_URL", fallback))
+
     def _make_client(self, config: dict[str, Any]) -> PowerContextClient:
         authorization = _config_value(config, "authorization", "POWERCONTEXT_HERMES_AUTHORIZATION")
         if not authorization:
             token = _config_value(config, "token", "POWERCONTEXT_HERMES_TOKEN")
             authorization = f"Bearer {token}" if token else None
+        base_url = self._server_url(config)
+        saved = load_client_settings("hermes")
+        if "allow_insecure_http" in config:
+            # Native Hermes consent belongs to its saved base_url. An environment
+            # endpoint override must not inherit it for a different server.
+            saved = {
+                "server_url": config.get("base_url"),
+                "allow_insecure_http": parse_boolean(config["allow_insecure_http"]),
+            }
+        allow_insecure_http = resolve_allow_insecure_http(
+            base_url,
+            host="hermes",
+            host_environment="POWERCONTEXT_HERMES_ALLOW_INSECURE_HTTP",
+            saved=saved,
+        )
         return PowerContextClient(
-            str(_config_value(config, "base_url", "POWERCONTEXT_HERMES_BASE_URL", _DEFAULT_BASE_URL)),
+            base_url,
             authorization=authorization,
+            allow_insecure_http=allow_insecure_http,
             timeout=_as_float(_config_value(config, "timeout", "POWERCONTEXT_HERMES_TIMEOUT"), _DEFAULT_TIMEOUT),
         )
 

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -54,3 +54,10 @@ storage of user and model content: `PowerContextMiddleware(auto_capture=True)`.
 
 Configuration uses `POWERCONTEXT_LANGCHAIN_BASE_URL`, `POWERCONTEXT_LANGCHAIN_TOKEN`,
 `POWERCONTEXT_LANGCHAIN_SCOPE_ID`, `POWERCONTEXT_LANGCHAIN_TIMEOUT`, and `POWERCONTEXT_LANGCHAIN_MAX_BYTES`.
+
+Non-loopback HTTP requires explicit consent: set `POWERCONTEXT_LANGCHAIN_ALLOW_INSECURE_HTTP=true` or
+`allow_insecure_http=True` on `PowerContextLangChainSettings` or `PowerContextScope`. HTTPS certificate validation
+remains enabled. Transport settings resolve from explicit values, host environment, common
+`POWERCONTEXT_CLIENT_SERVER_URL` / `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP`, then the `langchain` entry in
+`~/.config/powercontext/clients.json` (overridden by `POWERCONTEXT_CLIENT_CONFIG_FILE`). A host value of `false`
+overrides common `true`. Saved consent applies only to its saved Server URL; changing a run's URL does not reuse it.

--- a/integrations/langchain/src/powercontext_langchain/client.py
+++ b/integrations/langchain/src/powercontext_langchain/client.py
@@ -45,6 +45,7 @@ class ResolvedConfig:
     timeout: float
     max_bytes: int
     context_assembly: ContextAssembly | None = None
+    allow_insecure_http: bool = False
 
 
 def resolve_config(
@@ -57,13 +58,17 @@ def resolve_config(
     resolved_settings = settings or PowerContextLangChainSettings()
     resolved_scope = scope or PowerContextScope()
     token = resolved_scope.token if resolved_scope.token is not None else _secret_value(resolved_settings.token)
+    base_url, allow_insecure_http = resolved_settings.resolve_transport(
+        server_url=resolved_scope.base_url, allow_insecure_http=resolved_scope.allow_insecure_http
+    )
     return ResolvedConfig(
-        base_url=(resolved_scope.base_url or resolved_settings.base_url).strip(),
+        base_url=base_url,
         scope_id=_explicit_scope_id(resolved_scope.scope_id or resolved_settings.scope_id),
         token=token,
         timeout=resolved_scope.timeout if resolved_scope.timeout is not None else resolved_settings.timeout,
         max_bytes=resolved_settings.max_bytes,
         context_assembly=resolved_settings.context_assembly,
+        allow_insecure_http=allow_insecure_http,
     )
 
 
@@ -102,8 +107,11 @@ def open_client(config: ResolvedConfig) -> PowerContextClient:
             token=config.token,
             http_client=client,
             trust_transport_security=trust_transport_security,
+            allow_insecure_http=config.allow_insecure_http,
         )
-    return PowerContextClient(config.base_url, token=config.token, timeout=config.timeout)
+    return PowerContextClient(
+        config.base_url, token=config.token, timeout=config.timeout, allow_insecure_http=config.allow_insecure_http
+    )
 
 
 @contextmanager

--- a/integrations/langchain/src/powercontext_langchain/scope.py
+++ b/integrations/langchain/src/powercontext_langchain/scope.py
@@ -27,6 +27,7 @@ class PowerContextScope:
     base_url: str | None = None
     token: str | None = field(default=None, repr=False)
     timeout: float | None = None
+    allow_insecure_http: bool | None = None
 
 
 __all__ = ["PowerContextScope"]

--- a/integrations/langchain/src/powercontext_langchain/settings.py
+++ b/integrations/langchain/src/powercontext_langchain/settings.py
@@ -14,8 +14,12 @@
 
 """Process configuration for the PowerContext LangChain middleware."""
 
+from typing import ClassVar
+
 from pydantic import Field, SecretStr, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import SettingsConfigDict
+
+from powercontext.client.transport_policy import ClientTransportSettings
 
 try:
     from powercontext.http import ContextAssembly
@@ -24,7 +28,7 @@ except ImportError:
     from types import NoneType as ContextAssembly
 
 
-class PowerContextLangChainSettings(BaseSettings):
+class PowerContextLangChainSettings(ClientTransportSettings):
     """PowerContext settings read from ``POWERCONTEXT_LANGCHAIN_*`` variables."""
 
     model_config = SettingsConfigDict(
@@ -35,6 +39,7 @@ class PowerContextLangChainSettings(BaseSettings):
         hide_input_in_errors=True,
     )
 
+    transport_host: ClassVar[str] = "langchain"
     base_url: str = "http://127.0.0.1:8000"
     token: SecretStr | None = Field(default=None, repr=False)
     scope_id: str | None = None

--- a/integrations/langgraph/README.md
+++ b/integrations/langgraph/README.md
@@ -83,6 +83,7 @@ Configuration is read through pydantic-settings with the prefix `POWERCONTEXT_LA
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `POWERCONTEXT_LANGGRAPH_BASE_URL` | `http://127.0.0.1:8000` | PowerContext Server URL |
+| `POWERCONTEXT_LANGGRAPH_ALLOW_INSECURE_HTTP` | `false` | Explicitly allow non-loopback HTTP; HTTPS certificate validation stays enabled |
 | `POWERCONTEXT_LANGGRAPH_TOKEN` | unset | Bearer token forwarded to `PowerContextClient` |
 | `POWERCONTEXT_LANGGRAPH_SCOPE_ID` | unset | Existing Server Scope to use instead of the Server default |
 | `POWERCONTEXT_LANGGRAPH_TIMEOUT` | `10` | Client timeout in seconds |
@@ -91,6 +92,12 @@ Configuration is read through pydantic-settings with the prefix `POWERCONTEXT_LA
 `TOKEN` carries a bare token rather than a complete `Authorization` header value, differing from the
 `POWERCONTEXT_*_AUTHORIZATION` convention used by the Codex, Claude Code, and DeepSeek Harness plugins.
 `PowerContextClient` accepts the bare token and composes the header internally.
+
+`allow_insecure_http=True` on `PowerContextLangGraphSettings` or `PowerContextScope` also permits non-loopback HTTP.
+Transport settings resolve from explicit values, host environment, common
+`POWERCONTEXT_CLIENT_SERVER_URL` / `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP`, then the `langgraph` entry in
+`~/.config/powercontext/clients.json` (overridden by `POWERCONTEXT_CLIENT_CONFIG_FILE`). A host value of `false`
+overrides common `true`. Saved consent applies only to its saved Server URL; changing a run's URL does not reuse it.
 
 ## Scope resolution
 

--- a/integrations/langgraph/src/powercontext_langgraph/client.py
+++ b/integrations/langgraph/src/powercontext_langgraph/client.py
@@ -52,6 +52,7 @@ class ResolvedConfig:
     timeout: float
     max_bytes: int
     context_assembly: ContextAssembly | None = None
+    allow_insecure_http: bool = False
 
 
 def resolve_config(
@@ -66,13 +67,17 @@ def resolve_config(
     # The scope token is a plain str; the settings token is a SecretStr. Unwrap to a plain str at this boundary so the
     # client can compose the ``Authorization`` header, while the stored settings/scope fields stay repr-safe.
     token = scope.token if scope.token is not None else _secret_value(resolved_settings.token)
+    base_url, allow_insecure_http = resolved_settings.resolve_transport(
+        server_url=scope.base_url, allow_insecure_http=scope.allow_insecure_http
+    )
     return ResolvedConfig(
-        base_url=(scope.base_url or resolved_settings.base_url).strip(),
+        base_url=base_url,
         scope_id=_explicit_scope_id(scope.scope_id or resolved_settings.scope_id),
         token=token,
         timeout=scope.timeout if scope.timeout is not None else resolved_settings.timeout,
         max_bytes=resolved_settings.max_bytes,
         context_assembly=resolved_settings.context_assembly,
+        allow_insecure_http=allow_insecure_http,
     )
 
 
@@ -112,8 +117,11 @@ def open_client(config: ResolvedConfig) -> PowerContextClient:
             token=config.token,
             http_client=client,
             trust_transport_security=trust_transport_security,
+            allow_insecure_http=config.allow_insecure_http,
         )
-    return PowerContextClient(config.base_url, token=config.token, timeout=config.timeout)
+    return PowerContextClient(
+        config.base_url, token=config.token, timeout=config.timeout, allow_insecure_http=config.allow_insecure_http
+    )
 
 
 @contextmanager

--- a/integrations/langgraph/src/powercontext_langgraph/scope.py
+++ b/integrations/langgraph/src/powercontext_langgraph/scope.py
@@ -39,6 +39,7 @@ class PowerContextScope:
     # in a traceback or trace of the run context. Kept a plain ``str`` for ergonomic ``PowerContextScope(token=...)``.
     token: str | None = field(default=None, repr=False)
     timeout: float | None = None
+    allow_insecure_http: bool | None = None
 
 
 __all__ = ["PowerContextScope"]

--- a/integrations/langgraph/src/powercontext_langgraph/settings.py
+++ b/integrations/langgraph/src/powercontext_langgraph/settings.py
@@ -16,8 +16,12 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from pydantic import Field, SecretStr, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import SettingsConfigDict
+
+from powercontext.client.transport_policy import ClientTransportSettings
 
 try:
     from powercontext.http import ContextAssembly
@@ -26,7 +30,7 @@ except ImportError:
     from types import NoneType as ContextAssembly
 
 
-class PowerContextLangGraphSettings(BaseSettings):
+class PowerContextLangGraphSettings(ClientTransportSettings):
     """PowerContext settings read from the environment.
 
     ``token`` is a bare token, not a complete ``Authorization`` header value. It is forwarded to
@@ -37,6 +41,7 @@ class PowerContextLangGraphSettings(BaseSettings):
         env_prefix="POWERCONTEXT_LANGGRAPH_", extra="ignore", env_ignore_empty=True, frozen=True
     )
 
+    transport_host: ClassVar[str] = "langgraph"
     base_url: str = "http://127.0.0.1:8000"
     # A bearer credential: typed SecretStr and hidden from reprs so it never surfaces in a traceback or trace.
     token: SecretStr | None = Field(default=None, repr=False)

--- a/integrations/minimax/plugins/powercontext/README.md
+++ b/integrations/minimax/plugins/powercontext/README.md
@@ -77,6 +77,13 @@ Keep this file private and out of version control; on Linux and macOS, restrict 
 
 For server-side setup, see [Enable authentication](https://powercontext.oceanbase.io/en/docs/operate/deploy-server/#enable-authentication). The PowerContext server token authenticates MCP requests; model provider credentials belong in the server's model configuration.
 
+This package contains a Skill and native MCP configuration, with no local
+PowerContext HTTP client. MiniMax Code owns the MCP connection and its HTTP/TLS
+policy; `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP` and PowerContext's saved client
+settings do not control that native transport. Configure any remote endpoint
+in MiniMax Code's private MCP configuration. Prefer HTTPS: HTTP transmits
+content and authorization headers without encryption.
+
 ## Your data
 
 The server stores context in a local SQLite database by default. Queries and content you ask to save go to that server. If you enable generation or embedding services, the server may send relevant content to the configured model endpoints.

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -114,9 +114,17 @@ chmod 600 ~/.openclaw/.env
 openclaw gateway restart
 ```
 
-Do not put credentials in the endpoint. The current configuration accepts both HTTP and HTTPS URLs; use plain HTTP
-only for a trusted loopback Server and use HTTPS for every remote Server. This is an operator security requirement,
-not a restriction currently enforced by the CLI or plugin.
+Do not put credentials in the endpoint. Remote HTTP is rejected by default. For an explicitly trusted plaintext
+connection, set `POWERCONTEXT_OPENCLAW_ALLOW_INSECURE_HTTP=true` or the plugin setting `allowInsecureHttp: true`.
+The common `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP` flag applies when the host flag is absent; a host flag of
+`false` overrides it. Flags accept only `true/false`, `1/0`, `yes/no`, or `on/off`.
+HTTPS certificate validation remains enabled, and the plugin rejects redirects.
+
+Setup-saved URLs and endpoint-specific consent are read from `~/.config/powercontext/clients.json`
+(override with `POWERCONTEXT_CLIENT_CONFIG_FILE`). `POWERCONTEXT_OPENCLAW_BASE_URL`, then
+`POWERCONTEXT_CLIENT_SERVER_URL`, take precedence over an explicit plugin endpoint and the saved URL.
+Changing the endpoint does not reuse saved or native HTTP consent. Native `allowInsecureHttp: true` must accompany
+the matching `endpoint`; an environment URL override needs its own matching or explicit environment consent.
 
 ## Verify the installation
 

--- a/integrations/openclaw/plugins/memory-powercontext/openclaw.plugin.json
+++ b/integrations/openclaw/plugins/memory-powercontext/openclaw.plugin.json
@@ -45,6 +45,10 @@
           }
         ]
       },
+      "allowInsecureHttp": {
+        "type": "boolean",
+        "description": "Explicitly permit plaintext HTTP to a non-loopback server. HTTPS certificate verification remains enabled."
+      },
       "tokenEnv": {
         "type": "string",
         "minLength": 1,
@@ -93,6 +97,10 @@
     "endpoint": {
       "label": "PowerContext Endpoint",
       "help": "Base URL of the PowerContext server."
+    },
+    "allowInsecureHttp": {
+      "label": "Allow insecure HTTP",
+      "help": "Explicit consent to send requests and credentials over plaintext HTTP outside loopback."
     },
     "tokenEnv": {
       "label": "PowerContext Token Environment Variable",

--- a/integrations/openclaw/plugins/memory-powercontext/src/config.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/config.ts
@@ -18,9 +18,11 @@
 import { createHash } from "node:crypto";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveTransport } from "./transport.js";
 
 export type PowerContextConfig = {
   endpoint?: string;
+  allowInsecureHttp: boolean;
   scopeId?: string;
   tokenEnv: string;
   timeoutMs: number;
@@ -32,6 +34,7 @@ export type PowerContextConfig = {
 };
 
 const DEFAULT_CONFIG: PowerContextConfig = {
+  allowInsecureHttp: false,
   tokenEnv: "POWERCONTEXT_CLIENT_API_TOKEN",
   timeoutMs: 2500,
   prepareMaxBytes: 8000,
@@ -53,28 +56,14 @@ function boundedInteger(value: unknown, fallback: number, min: number, max: numb
     : fallback;
 }
 
-function normalizeEndpoint(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const endpoint = value.trim().replace(/\/+$/u, "");
-  if (!/^https?:\/\//iu.test(endpoint)) {
-    return undefined;
-  }
-  try {
-    const parsed = new URL(endpoint);
-    return parsed.username || parsed.password ? undefined : endpoint;
-  } catch {
-    return undefined;
-  }
-}
-
 export function resolvePowerContextConfig(
   config: OpenClawConfig | undefined,
   fallback?: unknown,
+  env: NodeJS.ProcessEnv = process.env,
 ): PowerContextConfig {
   const raw = readPluginConfig(config, fallback);
-  const endpoint = normalizeEndpoint(raw.endpoint);
+  const transport = resolveTransport("openclaw", env, raw.endpoint, raw.allowInsecureHttp);
+  const endpoint = transport.baseUrl;
   const assembly = raw.contextAssembly;
   if (assembly !== undefined && (!assembly || typeof assembly !== "object" || Array.isArray(assembly))) {
     throw new Error("PowerContext contextAssembly must be an object");
@@ -86,6 +75,7 @@ export function resolvePowerContextConfig(
   const scopeId = typeof raw.scopeId === "string" && raw.scopeId.trim() ? raw.scopeId.trim() : undefined;
   return {
     ...DEFAULT_CONFIG,
+    allowInsecureHttp: transport.allowInsecureHttp,
     ...(endpoint ? { endpoint } : {}),
     ...(scopeId ? { scopeId } : {}),
     tokenEnv,

--- a/integrations/openclaw/plugins/memory-powercontext/src/http.test.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/http.test.ts
@@ -23,6 +23,31 @@ afterEach(() => {
 });
 
 describe("PowerContext HTTP errors", () => {
+  it("rejects non-boolean consent from direct JavaScript callers", async () => {
+    const config = resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" });
+    config.endpoint = "http://powercontext.test";
+    config.allowInsecureHttp = "false" as unknown as boolean;
+    const fetchMock = vi.fn(async () => new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(createPowerContextClient(() => config).get("/v1/scopes")).rejects.toThrow(/boolean/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not follow redirects even with explicit HTTP consent", async () => {
+    const fetchMock = vi.fn(async (_url, init) => {
+      expect(init.redirect).toBe("manual");
+      return new Response("", { status: 302, headers: { location: "http://another.test" } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const config = resolvePowerContextConfig(undefined, {
+      endpoint: "http://powercontext.test", allowInsecureHttp: true,
+    });
+    await expect(createPowerContextClient(() => config).get("/v1/scopes")).rejects.toMatchObject({
+      status: 302,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("forwards the configured bearer token and preserves Access denial details", async () => {
     const tokenEnv = "POWERCONTEXT_OPENCLAW_TEST_TOKEN";
     process.env[tokenEnv] = "integration-token";
@@ -38,7 +63,7 @@ describe("PowerContext HTTP errors", () => {
         }),
       );
       const config = resolvePowerContextConfig(undefined, {
-        endpoint: "http://powercontext.test",
+        endpoint: "https://powercontext.test",
         tokenEnv,
       });
       const client = createPowerContextClient(() => config);
@@ -61,7 +86,7 @@ describe("PowerContext HTTP errors", () => {
         { status: 409, headers: { "content-type": "application/json" } },
       )),
     );
-    const config = resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" });
+    const config = resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" });
     const client = createPowerContextClient(() => config);
 
     await expect(client.post("/v1/sources/content", {})).rejects.toMatchObject({

--- a/integrations/openclaw/plugins/memory-powercontext/src/http.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/http.ts
@@ -16,6 +16,7 @@
 
 
 import type { PowerContextConfig } from "./config.js";
+import { normalizeServerUrl } from "./transport.js";
 
 export class PowerContextRequestError extends Error {
   readonly status?: number;
@@ -44,6 +45,7 @@ export function createPowerContextClient(getConfig: () => PowerContextConfig) {
     if (!config.endpoint) {
       throw new PowerContextRequestError(path, "PowerContext endpoint is not configured");
     }
+    const endpoint = normalizeServerUrl(config.endpoint, config.allowInsecureHttp);
     const controller = new AbortController();
     const abort = () => controller.abort();
     signal?.addEventListener("abort", abort, { once: true });
@@ -63,8 +65,9 @@ export function createPowerContextClient(getConfig: () => PowerContextConfig) {
       }
       let response: Response;
       try {
-        response = await fetch(`${config.endpoint}${path}`, {
+        response = await fetch(`${endpoint}${path}`, {
           method,
+          redirect: "manual",
           headers,
           ...(body ? { body: JSON.stringify(body) } : {}),
           signal: controller.signal,

--- a/integrations/openclaw/plugins/memory-powercontext/src/lifecycle.test.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/lifecycle.test.ts
@@ -39,7 +39,7 @@ function createLifecycleHarness() {
   let captureError: unknown;
   let flushError: unknown;
   const config = resolvePowerContextConfig(undefined, {
-    endpoint: "http://powercontext.test",
+    endpoint: "https://powercontext.test",
   });
   const projectScopes = new Map(
     [

--- a/integrations/openclaw/plugins/memory-powercontext/src/manager.test.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/manager.test.ts
@@ -45,7 +45,7 @@ describe("PowerContext memory manager", () => {
     } as unknown as PowerContextClient;
     const manager = new PowerContextMemoryManager(
       "main",
-      () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       client,
       () => true,
     );
@@ -77,7 +77,7 @@ describe("PowerContext memory manager", () => {
         return { citation, version: 1, kind: "fact", text: "remembered fact", state: "active" } as T;
       },
     } as unknown as PowerContextClient;
-    const config = resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" });
+    const config = resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" });
     const manager = new PowerContextMemoryManager("main", () => config, client, () => true);
 
     const [result] = await manager.search("fact", {

--- a/integrations/openclaw/plugins/memory-powercontext/src/tools.test.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/tools.test.ts
@@ -42,7 +42,7 @@ describe("PowerContext tools", () => {
     } as OpenClawPluginToolContext;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
     };
 
@@ -60,7 +60,7 @@ describe("PowerContext tools", () => {
     } as OpenClawPluginToolContext;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
     };
 
@@ -84,7 +84,7 @@ describe("PowerContext tools", () => {
     const manager = {} as never;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
       managerFor: () => manager,
     };
@@ -107,7 +107,7 @@ describe("PowerContext tools", () => {
     } as OpenClawPluginToolContext;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
     };
     const tool = createMemorySearchTool(context, deps);
@@ -130,7 +130,7 @@ describe("PowerContext tools", () => {
     } as OpenClawPluginToolContext;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
     };
     const tool = createMemoryGetTool(context, deps);
@@ -150,7 +150,7 @@ describe("PowerContext tools", () => {
       entry_id: "entry-1",
       entry_version_id: "version-1",
     });
-    const config = () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" });
+    const config = () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" });
     const domainClient = (status: number) => ({
       async post() {
         throw new PowerContextRequestError("/v1/memory/entries/get", "domain error", status);
@@ -201,7 +201,7 @@ describe("PowerContext tools", () => {
     } as OpenClawPluginToolContext;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
     };
 

--- a/integrations/openclaw/plugins/memory-powercontext/src/transport-consent.spec.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/transport-consent.spec.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolvePowerContextConfig } from './config.js'
+
+const remote = 'http://memory.example.test:8000'
+const hostUrl = 'POWERCONTEXT_OPENCLAW_BASE_URL'
+const hostFlag = 'POWERCONTEXT_OPENCLAW_ALLOW_INSECURE_HTTP'
+let directory: string
+let configFile: string
+
+function resolve(overrides: NodeJS.ProcessEnv = {}, native: Record<string, unknown> = {}) {
+  const env = { POWERCONTEXT_CLIENT_CONFIG_FILE: configFile, ...overrides }
+  const result = resolvePowerContextConfig(undefined, native, env)
+  return { ...result, baseUrl: result.endpoint }
+}
+
+function save(serverUrl = remote, consent: unknown = true) {
+  writeFileSync(configFile, JSON.stringify({
+    version: 1,
+    hosts: { openclaw: { server_url: serverUrl, allow_insecure_http: consent } },
+  }))
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'powercontext-openclaw-transport-'))
+  configFile = join(directory, 'clients.json')
+})
+afterEach(() => rmSync(directory, { recursive: true, force: true }))
+
+describe('openclaw transport consent', () => {
+  it('rejects remote cleartext without consent', () => {
+    expect(() => resolve({ [hostUrl]: remote })).toThrow(/HTTPS/)
+  })
+
+  it.each(['true', '1', 'yes', 'on', ' TRUE '])('accepts explicit consent %s', (value) => {
+    expect(resolve({ [hostUrl]: remote, [hostFlag]: value }).baseUrl).toBe(remote)
+  })
+
+  it('accepts common consent and a common server URL', () => {
+    const result = resolve({
+      POWERCONTEXT_CLIENT_SERVER_URL: remote,
+      POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'yes',
+    })
+    expect(result.baseUrl).toBe(remote)
+    expect(result.allowInsecureHttp).toBe(true)
+  })
+
+  it.each(['false', '0', 'no', 'off'])('lets host %s override common consent', (value) => {
+    expect(() => resolve({
+      [hostUrl]: remote,
+      [hostFlag]: value,
+      POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'true',
+    })).toThrow(/HTTPS/)
+  })
+
+  it.each([hostFlag, 'POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP'])('rejects invalid %s', (name) => {
+    expect(() => resolve({ [name]: 'sometimes' })).toThrow(/boolean/)
+  })
+
+  it('loads setup-saved endpoint and consent when native configuration is absent', () => {
+    save()
+    expect(resolve().baseUrl).toBe(remote)
+    expect(resolve().allowInsecureHttp).toBe(true)
+  })
+
+  it('normalizes saved MCP URLs before matching consent', () => {
+    save(remote + '/mcp/')
+    expect(resolve({ [hostUrl]: remote + '/' }).baseUrl).toBe(remote)
+  })
+
+  it('does not reuse saved consent for a different endpoint', () => {
+    save()
+    expect(() => resolve({ [hostUrl]: 'http://other.test' })).toThrow(/HTTPS/)
+  })
+
+  it('lets explicit common false revoke saved consent', () => {
+    save()
+    expect(() => resolve({ POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'false' })).toThrow(/HTTPS/)
+  })
+
+  it('rejects non-boolean saved consent', () => {
+    save(remote, 'true')
+    expect(() => resolve()).toThrow(/boolean/)
+  })
+
+  it.each(['localhost', '127.0.0.2', '[::1]'])('allows loopback HTTP at %s', (host) => {
+    expect(resolve({ [hostUrl]: 'http://' + host + ':8000' }).baseUrl).toBe('http://' + host + ':8000')
+  })
+
+  it.each(['ftp://memory.test', 'https://user:password@memory.test', 'https://memory.test/?secret=value', 'https://memory.test/#fragment'])(
+    'keeps URL restrictions when opted in: %s', (url) => {
+      expect(() => resolve({ [hostUrl]: url, [hostFlag]: 'true' })).toThrow()
+    },
+  )
+
+  it('honors explicit native consent and rejects a non-boolean native value', () => {
+    expect(resolve({}, { endpoint: remote, allowInsecureHttp: true }).baseUrl).toBe(remote)
+    expect(() => resolve({}, { endpoint: remote, allowInsecureHttp: 'yes' })).toThrow(/boolean/)
+  })
+
+  it('does not transfer native consent when an environment URL changes the endpoint', () => {
+    expect(() => resolve({ [hostUrl]: 'http://other.test' }, {
+      endpoint: remote, allowInsecureHttp: true,
+    })).toThrow(/HTTPS/)
+  })
+
+  it('matches native consent against normalized endpoints', () => {
+    expect(resolve({ [hostUrl]: remote + '/' }, {
+      endpoint: remote + '/mcp/', allowInsecureHttp: true,
+    }).baseUrl).toBe(remote)
+  })
+
+  it('requires an endpoint alongside native consent', () => {
+    expect(() => resolve({ [hostUrl]: remote }, { allowInsecureHttp: true })).toThrow(/HTTPS/)
+  })
+
+  it('permits a changed endpoint when the environment explicitly authorizes it', () => {
+    expect(resolve({ [hostUrl]: 'http://other.test', [hostFlag]: 'true' }, {
+      endpoint: remote, allowInsecureHttp: true,
+    }).baseUrl).toBe('http://other.test')
+  })
+
+  it('lets an environment false override native consent', () => {
+    expect(() => resolve({ [hostFlag]: 'false' }, {
+      endpoint: remote, allowInsecureHttp: true,
+    })).toThrow(/HTTPS/)
+  })
+
+  it('does not let native false or a changed native endpoint inherit saved consent', () => {
+    save()
+    expect(() => resolve({}, { allowInsecureHttp: false })).toThrow(/HTTPS/)
+    expect(() => resolve({}, { endpoint: 'http://other.test' })).toThrow(/HTTPS/)
+  })
+})

--- a/integrations/openclaw/plugins/memory-powercontext/src/transport.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/transport.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+// Each host is an independently distributed package; keep the shared client config
+// contract and policy aligned with powercontext.client.transport_policy and powercontext.transport.
+type SavedClient = { server_url?: string; allow_insecure_http?: boolean }
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === 'string' ? value.trim() || undefined : undefined
+}
+
+function optionalBoolean(value: unknown, name: string): boolean | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'boolean') throw new Error(`${name} must be a boolean`)
+  return value
+}
+
+function environmentBoolean(env: NodeJS.ProcessEnv, name: string): boolean | undefined {
+  if (env[name] === undefined) return undefined
+  const value = env[name]!.trim().toLowerCase()
+  if (['true', '1', 'yes', 'on'].includes(value)) return true
+  if (['false', '0', 'no', 'off'].includes(value)) return false
+  throw new Error(`${name} must be a boolean (true/false, 1/0, yes/no, on/off)`)
+}
+
+function readSavedClient(host: string, env: NodeJS.ProcessEnv): SavedClient {
+  const home = optionalText(env.HOME) ?? homedir()
+  const configuredPath = optionalText(env.POWERCONTEXT_CLIENT_CONFIG_FILE)
+  const path = configuredPath?.startsWith('~/')
+    ? join(home, configuredPath.slice(2))
+    : configuredPath ?? join(home, '.config', 'powercontext', 'clients.json')
+  let contents: string
+  try {
+    contents = readFileSync(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw new Error('Unable to read PowerContext client configuration', { cause: error })
+  }
+  let document: unknown
+  try {
+    document = JSON.parse(contents)
+  } catch {
+    throw new Error('PowerContext client configuration must be valid JSON')
+  }
+  if (!document || typeof document !== 'object' || Array.isArray(document)
+    || (document as { version?: unknown }).version !== 1) {
+    throw new Error('PowerContext client configuration must have version 1')
+  }
+  const hosts = (document as { hosts?: unknown }).hosts
+  if (!hosts || typeof hosts !== 'object' || Array.isArray(hosts)) {
+    throw new Error('PowerContext client configuration hosts must be an object')
+  }
+  const value = (hosts as Record<string, unknown>)[host]
+  if (value === undefined) return {}
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('PowerContext saved host configuration must be an object')
+  }
+  const entry = value as Record<string, unknown>
+  if (entry.server_url !== undefined && !optionalText(entry.server_url)) {
+    throw new Error('PowerContext saved server_url must be a non-empty string')
+  }
+  return {
+    server_url: optionalText(entry.server_url),
+    allow_insecure_http: optionalBoolean(entry.allow_insecure_http, 'allow_insecure_http'),
+  }
+}
+
+export function normalizeServerUrl(value: string, allowInsecureHttp = false, name = 'PowerContext server URL'): string {
+  optionalBoolean(allowInsecureHttp, 'allowInsecureHttp')
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${name} must be a valid HTTP(S) URL`)
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error(`${name} must use HTTP or HTTPS`)
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(`${name} must not contain credentials, a query, or a fragment`)
+  }
+  const host = url.hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '')
+  const octets = host.split('.')
+  const loopback = host === 'localhost' || host === '::1'
+    || (octets.length === 4 && octets[0] === '127'
+      && octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255))
+  if (url.protocol === 'http:' && !loopback && !allowInsecureHttp) {
+    throw new Error(`${name} must use HTTPS outside loopback; explicitly enable allow_insecure_http to permit plaintext HTTP`)
+  }
+  return url.toString().replace(/\/+$/, '').replace(/\/mcp$/, '').replace(/\/+$/, '')
+}
+
+export function resolveTransport(
+  host: string,
+  env: NodeJS.ProcessEnv,
+  nativeUrl?: unknown,
+  nativeConsent?: unknown,
+  defaultUrl?: string,
+): { baseUrl: string | undefined; allowInsecureHttp: boolean; source: 'environment' | 'plugin' | 'saved' | 'default' } {
+  const prefix = `POWERCONTEXT_${host.toUpperCase()}`
+  const saved = readSavedClient(host, env)
+  const environmentUrl = optionalText(env[`${prefix}_BASE_URL`])
+    ?? optionalText(env[`${prefix}_SERVER_URL`])
+    ?? optionalText(env[`${prefix}_ENDPOINT`])
+    ?? optionalText(env.POWERCONTEXT_CLIENT_SERVER_URL)
+  const pluginUrl = optionalText(nativeUrl)
+  const selectedUrl = environmentUrl ?? pluginUrl ?? saved.server_url ?? defaultUrl
+  const normalized = selectedUrl === undefined ? undefined : normalizeServerUrl(selectedUrl, true, `${prefix}_BASE_URL`)
+  const savedUrl = saved.server_url === undefined ? undefined : normalizeServerUrl(saved.server_url, true)
+  const hostConsent = environmentBoolean(env, `${prefix}_ALLOW_INSECURE_HTTP`)
+  const commonConsent = environmentBoolean(env, 'POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP')
+  const pluginConsent = optionalBoolean(nativeConsent, 'allowInsecureHttp')
+  const nativeEndpoint = pluginUrl === undefined ? undefined : normalizeServerUrl(pluginUrl, true)
+  // Persisted native consent belongs to its endpoint, just like setup-saved consent.
+  // An explicit refusal remains effective even when the endpoint is overridden.
+  const matchingNativeConsent = pluginConsent === false
+    ? false
+    : normalized !== undefined && normalized === nativeEndpoint ? pluginConsent : undefined
+  const allowInsecureHttp = hostConsent ?? commonConsent ?? matchingNativeConsent
+    ?? (normalized !== undefined && normalized === savedUrl ? saved.allow_insecure_http : undefined) ?? false
+  return {
+    baseUrl: normalized === undefined ? undefined : normalizeServerUrl(normalized, allowInsecureHttp, `${prefix}_BASE_URL`),
+    allowInsecureHttp,
+    source: environmentUrl ? 'environment' : pluginUrl ? 'plugin' : saved.server_url ? 'saved' : 'default',
+  }
+}

--- a/integrations/opencode/plugins/powercontext/README.md
+++ b/integrations/opencode/plugins/powercontext/README.md
@@ -21,4 +21,14 @@ Each Session resolves an explicit Scope, its durable Session or workspace bindin
 `AUTHORIZATION`, `CAPTURE_PROMPTS`, `FLUSH_ON_CAPTURE`, `REQUEST_TIMEOUT_MS`, `HTTP_BUDGET_MS`, `MAX_BYTES`, and
 `FLUSH_MAX_CALLS`.
 
+Remote HTTP is rejected by default. Explicitly allow it with `POWERCONTEXT_OPENCODE_ALLOW_INSECURE_HTTP=true`,
+or use `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP=true` as the common fallback. A host flag of `false` overrides
+the common flag. Flags accept only `true/false`, `1/0`, `yes/no`, or `on/off`; HTTPS certificate validation and
+redirect rejection remain enabled.
+
+Setup-saved URLs and endpoint-specific consent are read from `~/.config/powercontext/clients.json`
+(override with `POWERCONTEXT_CLIENT_CONFIG_FILE`). The host URL environment variable, then
+`POWERCONTEXT_CLIENT_SERVER_URL`, override the saved URL and loopback default. Changing the endpoint does not
+reuse saved HTTP consent.
+
 OpenCode 1.18.21 or newer in the 1.x line is required. Server failures are fail-open and never block normal work.

--- a/integrations/opencode/plugins/powercontext/lib/index.js
+++ b/integrations/opencode/plugins/powercontext/lib/index.js
@@ -16,7 +16,9 @@
 import { createHash } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { tool } from "@opencode-ai/plugin";
-import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 
 //#region src/errors.ts
 const REQUEST_ID_HEADER = "X-PowerContext-Request-ID";
@@ -147,10 +149,19 @@ const OPERATIONS = {
 	list_scopes: {
 		method: "GET",
 		path: "/v1/scopes",
-		location: null,
+		location: "query",
 		scopeMode: "none",
 		pathParameters: [],
-		queryParams: [],
+		queryParams: [
+			"query",
+			"query_field",
+			"parent_scope_id",
+			"external_reference_kind",
+			"binding_integration",
+			"binding_kind",
+			"limit",
+			"cursor"
+		],
 		headerParams: [],
 		successStatuses: [200],
 		emptyStatuses: []
@@ -914,6 +925,17 @@ const OPERATIONS = {
 		successStatuses: [200],
 		emptyStatuses: []
 	},
+	list_sources: {
+		method: "GET",
+		path: "/v1/scopes/{scope_id}/sources",
+		location: "query",
+		scopeMode: "none",
+		pathParameters: ["scope_id"],
+		queryParams: ["limit", "cursor"],
+		headerParams: [],
+		successStatuses: [200],
+		emptyStatuses: []
+	},
 	create_source: {
 		method: "POST",
 		path: "/v1/scopes/{scope_id}/sources",
@@ -1224,6 +1246,99 @@ const OPERATIONS = {
 const OPERATION_IDS = Object.keys(OPERATIONS);
 
 //#endregion
+//#region src/transport.ts
+function optionalText(value) {
+	return typeof value === "string" ? value.trim() || void 0 : void 0;
+}
+function optionalBoolean(value, name) {
+	if (value === void 0) return void 0;
+	if (typeof value !== "boolean") throw new Error(`${name} must be a boolean`);
+	return value;
+}
+function environmentBoolean(env, name) {
+	if (env[name] === void 0) return void 0;
+	const value = env[name].trim().toLowerCase();
+	if ([
+		"true",
+		"1",
+		"yes",
+		"on"
+	].includes(value)) return true;
+	if ([
+		"false",
+		"0",
+		"no",
+		"off"
+	].includes(value)) return false;
+	throw new Error(`${name} must be a boolean (true/false, 1/0, yes/no, on/off)`);
+}
+function readSavedClient(host, env) {
+	const home = optionalText(env.HOME) ?? homedir();
+	const configuredPath = optionalText(env.POWERCONTEXT_CLIENT_CONFIG_FILE);
+	const path = configuredPath?.startsWith("~/") ? join(home, configuredPath.slice(2)) : configuredPath ?? join(home, ".config", "powercontext", "clients.json");
+	let contents;
+	try {
+		contents = readFileSync(path, "utf8");
+	} catch (error) {
+		if (error.code === "ENOENT") return {};
+		throw new Error("Unable to read PowerContext client configuration", { cause: error });
+	}
+	let document;
+	try {
+		document = JSON.parse(contents);
+	} catch {
+		throw new Error("PowerContext client configuration must be valid JSON");
+	}
+	if (!document || typeof document !== "object" || Array.isArray(document) || document.version !== 1) throw new Error("PowerContext client configuration must have version 1");
+	const hosts = document.hosts;
+	if (!hosts || typeof hosts !== "object" || Array.isArray(hosts)) throw new Error("PowerContext client configuration hosts must be an object");
+	const value = hosts[host];
+	if (value === void 0) return {};
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("PowerContext saved host configuration must be an object");
+	const entry = value;
+	if (entry.server_url !== void 0 && !optionalText(entry.server_url)) throw new Error("PowerContext saved server_url must be a non-empty string");
+	return {
+		server_url: optionalText(entry.server_url),
+		allow_insecure_http: optionalBoolean(entry.allow_insecure_http, "allow_insecure_http")
+	};
+}
+function normalizeServerUrl(value, allowInsecureHttp = false, name = "PowerContext server URL") {
+	optionalBoolean(allowInsecureHttp, "allowInsecureHttp");
+	let url;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new Error(`${name} must be a valid HTTP(S) URL`);
+	}
+	if (!["http:", "https:"].includes(url.protocol)) throw new Error(`${name} must use HTTP or HTTPS`);
+	if (url.username || url.password || url.search || url.hash) throw new Error(`${name} must not contain credentials, a query, or a fragment`);
+	const host = url.hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+	const octets = host.split(".");
+	const loopback = host === "localhost" || host === "::1" || octets.length === 4 && octets[0] === "127" && octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255);
+	if (url.protocol === "http:" && !loopback && !allowInsecureHttp) throw new Error(`${name} must use HTTPS outside loopback; explicitly enable allow_insecure_http to permit plaintext HTTP`);
+	return url.toString().replace(/\/+$/, "").replace(/\/mcp$/, "").replace(/\/+$/, "");
+}
+function resolveTransport(host, env, nativeUrl, nativeConsent, defaultUrl) {
+	const prefix = `POWERCONTEXT_${host.toUpperCase()}`;
+	const saved = readSavedClient(host, env);
+	const environmentUrl = optionalText(env[`${prefix}_BASE_URL`]) ?? optionalText(env[`${prefix}_SERVER_URL`]) ?? optionalText(env[`${prefix}_ENDPOINT`]) ?? optionalText(env.POWERCONTEXT_CLIENT_SERVER_URL);
+	const pluginUrl = optionalText(nativeUrl);
+	const selectedUrl = environmentUrl ?? pluginUrl ?? saved.server_url ?? defaultUrl;
+	const normalized = selectedUrl === void 0 ? void 0 : normalizeServerUrl(selectedUrl, true, `${prefix}_BASE_URL`);
+	const savedUrl = saved.server_url === void 0 ? void 0 : normalizeServerUrl(saved.server_url, true);
+	const hostConsent = environmentBoolean(env, `${prefix}_ALLOW_INSECURE_HTTP`);
+	const commonConsent = environmentBoolean(env, "POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP");
+	const pluginConsent = optionalBoolean(nativeConsent, "allowInsecureHttp");
+	const nativeEndpoint = pluginUrl === void 0 ? void 0 : normalizeServerUrl(pluginUrl, true);
+	const allowInsecureHttp = hostConsent ?? commonConsent ?? (pluginConsent === false ? false : normalized !== void 0 && normalized === nativeEndpoint ? pluginConsent : void 0) ?? (normalized !== void 0 && normalized === savedUrl ? saved.allow_insecure_http : void 0) ?? false;
+	return {
+		baseUrl: normalized === void 0 ? void 0 : normalizeServerUrl(normalized, allowInsecureHttp, `${prefix}_BASE_URL`),
+		allowInsecureHttp,
+		source: environmentUrl ? "environment" : pluginUrl ? "plugin" : saved.server_url ? "saved" : "default"
+	};
+}
+
+//#endregion
 //#region src/client.ts
 function combineSignals(signals) {
 	if (signals.length === 1) return signals[0];
@@ -1339,6 +1454,10 @@ var PowerContextClient = class {
 	fetchImpl;
 	constructor(options) {
 		this.options = options;
+		this.options = {
+			...options,
+			baseUrl: normalizeServerUrl(options.baseUrl, options.allowInsecureHttp)
+		};
 		this.fetchImpl = options.fetch ?? fetch;
 	}
 	async request(id, payload, signal) {
@@ -1419,6 +1538,7 @@ var PowerContextClient = class {
 //#region src/config.ts
 const DEFAULTS = {
 	baseUrl: "http://127.0.0.1:8000",
+	allowInsecureHttp: false,
 	scopeId: void 0,
 	authorization: void 0,
 	capturePrompts: true,
@@ -1466,30 +1586,15 @@ function envInteger(env, name, fallback, minimum, maximum) {
 	if (!Number.isInteger(value) || value < minimum || value > maximum) throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
 	return value;
 }
-function normalizeBaseUrl(value) {
-	let url;
-	try {
-		url = new URL(value);
-	} catch {
-		throw new Error("POWERCONTEXT_OPENCODE_BASE_URL must be a valid HTTP(S) URL");
-	}
-	if (!["http:", "https:"].includes(url.protocol)) throw new Error("POWERCONTEXT_OPENCODE_BASE_URL must use HTTP or HTTPS");
-	if (url.username || url.password || url.search || url.hash) throw new Error("POWERCONTEXT_OPENCODE_BASE_URL must not contain credentials, a query, or a fragment");
-	const loopback = [
-		"localhost",
-		"127.0.0.1",
-		"[::1]"
-	].includes(url.hostname);
-	if (url.protocol === "http:" && !loopback) throw new Error("POWERCONTEXT_OPENCODE_BASE_URL must use HTTPS outside loopback");
-	return url.toString().replace(/\/+$/, "");
-}
 function resolveConfig(env = process.env) {
+	const transport = resolveTransport("opencode", env, void 0, void 0, DEFAULTS.baseUrl);
 	const requestTimeoutMs = envInteger(env, "POWERCONTEXT_OPENCODE_REQUEST_TIMEOUT_MS", DEFAULTS.requestTimeoutMs, 50, 3e4);
 	const httpBudgetMs = envInteger(env, "POWERCONTEXT_OPENCODE_HTTP_BUDGET_MS", DEFAULTS.httpBudgetMs, 100, 6e4);
 	if (requestTimeoutMs > httpBudgetMs) throw new Error("POWERCONTEXT_OPENCODE_REQUEST_TIMEOUT_MS must not exceed POWERCONTEXT_OPENCODE_HTTP_BUDGET_MS");
 	return {
 		contextAssembly: contextAssembly(envString(env, "POWERCONTEXT_OPENCODE_CONTEXT_ASSEMBLY")),
-		baseUrl: normalizeBaseUrl(envString(env, "POWERCONTEXT_OPENCODE_BASE_URL") ?? DEFAULTS.baseUrl),
+		baseUrl: transport.baseUrl,
+		allowInsecureHttp: transport.allowInsecureHttp,
 		scopeId: envString(env, "POWERCONTEXT_OPENCODE_SCOPE_ID"),
 		authorization: envString(env, "POWERCONTEXT_OPENCODE_AUTHORIZATION"),
 		capturePrompts: envBoolean(env, "POWERCONTEXT_OPENCODE_CAPTURE_PROMPTS") ?? DEFAULTS.capturePrompts,
@@ -1816,6 +1921,7 @@ function createRuntime(input, config) {
 	const sessionContexts = /* @__PURE__ */ new Map();
 	const client = new PowerContextClient({
 		baseUrl: config.baseUrl,
+		allowInsecureHttp: config.allowInsecureHttp,
 		authorization: config.authorization,
 		requestTimeoutMs: config.requestTimeoutMs
 	});

--- a/integrations/opencode/plugins/powercontext/src/client.ts
+++ b/integrations/opencode/plugins/powercontext/src/client.ts
@@ -24,6 +24,7 @@ import {
   UnknownOperationError,
 } from './errors.ts'
 import { OPERATIONS, type OperationId, type OperationSpec } from './operations.generated.ts'
+import { normalizeServerUrl } from './transport.ts'
 
 export type JsonObject = Record<string, unknown>
 export type FetchFn = (input: string, init: RequestInit) => Promise<Response>
@@ -31,6 +32,7 @@ export type ClientSuccess = { kind: 'json'; value: unknown; status: number; requ
 
 export interface ClientOptions {
   baseUrl: string
+  allowInsecureHttp?: boolean
   authorization?: string
   requestTimeoutMs: number
   fetch?: FetchFn
@@ -181,6 +183,7 @@ export class PowerContextClient {
   private readonly fetchImpl: FetchFn
 
   constructor(private readonly options: ClientOptions) {
+    this.options = { ...options, baseUrl: normalizeServerUrl(options.baseUrl, options.allowInsecureHttp) }
     this.fetchImpl = options.fetch ?? fetch
   }
 

--- a/integrations/opencode/plugins/powercontext/src/config.ts
+++ b/integrations/opencode/plugins/powercontext/src/config.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import { resolveTransport } from './transport.ts'
+
 export interface ResolvedConfig {
   contextAssembly?: Record<string, unknown>
   baseUrl: string
+  allowInsecureHttp: boolean
   scopeId: string | undefined
   authorization: string | undefined
   capturePrompts: boolean
@@ -29,6 +32,7 @@ export interface ResolvedConfig {
 
 const DEFAULTS: ResolvedConfig = {
   baseUrl: 'http://127.0.0.1:8000',
+  allowInsecureHttp: false,
   scopeId: undefined,
   authorization: undefined,
   capturePrompts: true,
@@ -76,27 +80,8 @@ function envInteger(env: NodeJS.ProcessEnv, name: string, fallback: number, mini
   return value
 }
 
-function normalizeBaseUrl(value: string): string {
-  let url: URL
-  try {
-    url = new URL(value)
-  } catch {
-    throw new Error('POWERCONTEXT_OPENCODE_BASE_URL must be a valid HTTP(S) URL')
-  }
-  if (!['http:', 'https:'].includes(url.protocol)) {
-    throw new Error('POWERCONTEXT_OPENCODE_BASE_URL must use HTTP or HTTPS')
-  }
-  if (url.username || url.password || url.search || url.hash) {
-    throw new Error('POWERCONTEXT_OPENCODE_BASE_URL must not contain credentials, a query, or a fragment')
-  }
-  const loopback = ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)
-  if (url.protocol === 'http:' && !loopback) {
-    throw new Error('POWERCONTEXT_OPENCODE_BASE_URL must use HTTPS outside loopback')
-  }
-  return url.toString().replace(/\/+$/, '')
-}
-
 export function resolveConfig(env: NodeJS.ProcessEnv = process.env): ResolvedConfig {
+  const transport = resolveTransport('opencode', env, undefined, undefined, DEFAULTS.baseUrl)
   const requestTimeoutMs = envInteger(
     env,
     'POWERCONTEXT_OPENCODE_REQUEST_TIMEOUT_MS',
@@ -116,7 +101,8 @@ export function resolveConfig(env: NodeJS.ProcessEnv = process.env): ResolvedCon
   }
   return {
     contextAssembly: contextAssembly(envString(env, 'POWERCONTEXT_OPENCODE_CONTEXT_ASSEMBLY')),
-    baseUrl: normalizeBaseUrl(envString(env, 'POWERCONTEXT_OPENCODE_BASE_URL') ?? DEFAULTS.baseUrl),
+    baseUrl: transport.baseUrl!,
+    allowInsecureHttp: transport.allowInsecureHttp,
     scopeId: envString(env, 'POWERCONTEXT_OPENCODE_SCOPE_ID'),
     authorization: envString(env, 'POWERCONTEXT_OPENCODE_AUTHORIZATION'),
     capturePrompts: envBoolean(env, 'POWERCONTEXT_OPENCODE_CAPTURE_PROMPTS') ?? DEFAULTS.capturePrompts,

--- a/integrations/opencode/plugins/powercontext/src/index.ts
+++ b/integrations/opencode/plugins/powercontext/src/index.ts
@@ -227,6 +227,7 @@ function createRuntime(input: PluginInput, config: ResolvedConfig): Runtime {
   const sessionContexts = new Map<string, Promise<SessionContext>>()
   const client = new PowerContextClient({
     baseUrl: config.baseUrl,
+    allowInsecureHttp: config.allowInsecureHttp,
     authorization: config.authorization,
     requestTimeoutMs: config.requestTimeoutMs,
   })

--- a/integrations/opencode/plugins/powercontext/src/transport.ts
+++ b/integrations/opencode/plugins/powercontext/src/transport.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+// Each host is an independently distributed package; keep the shared client config
+// contract and policy aligned with powercontext.client.transport_policy and powercontext.transport.
+type SavedClient = { server_url?: string; allow_insecure_http?: boolean }
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === 'string' ? value.trim() || undefined : undefined
+}
+
+function optionalBoolean(value: unknown, name: string): boolean | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'boolean') throw new Error(`${name} must be a boolean`)
+  return value
+}
+
+function environmentBoolean(env: NodeJS.ProcessEnv, name: string): boolean | undefined {
+  if (env[name] === undefined) return undefined
+  const value = env[name]!.trim().toLowerCase()
+  if (['true', '1', 'yes', 'on'].includes(value)) return true
+  if (['false', '0', 'no', 'off'].includes(value)) return false
+  throw new Error(`${name} must be a boolean (true/false, 1/0, yes/no, on/off)`)
+}
+
+function readSavedClient(host: string, env: NodeJS.ProcessEnv): SavedClient {
+  const home = optionalText(env.HOME) ?? homedir()
+  const configuredPath = optionalText(env.POWERCONTEXT_CLIENT_CONFIG_FILE)
+  const path = configuredPath?.startsWith('~/')
+    ? join(home, configuredPath.slice(2))
+    : configuredPath ?? join(home, '.config', 'powercontext', 'clients.json')
+  let contents: string
+  try {
+    contents = readFileSync(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw new Error('Unable to read PowerContext client configuration', { cause: error })
+  }
+  let document: unknown
+  try {
+    document = JSON.parse(contents)
+  } catch {
+    throw new Error('PowerContext client configuration must be valid JSON')
+  }
+  if (!document || typeof document !== 'object' || Array.isArray(document)
+    || (document as { version?: unknown }).version !== 1) {
+    throw new Error('PowerContext client configuration must have version 1')
+  }
+  const hosts = (document as { hosts?: unknown }).hosts
+  if (!hosts || typeof hosts !== 'object' || Array.isArray(hosts)) {
+    throw new Error('PowerContext client configuration hosts must be an object')
+  }
+  const value = (hosts as Record<string, unknown>)[host]
+  if (value === undefined) return {}
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('PowerContext saved host configuration must be an object')
+  }
+  const entry = value as Record<string, unknown>
+  if (entry.server_url !== undefined && !optionalText(entry.server_url)) {
+    throw new Error('PowerContext saved server_url must be a non-empty string')
+  }
+  return {
+    server_url: optionalText(entry.server_url),
+    allow_insecure_http: optionalBoolean(entry.allow_insecure_http, 'allow_insecure_http'),
+  }
+}
+
+export function normalizeServerUrl(value: string, allowInsecureHttp = false, name = 'PowerContext server URL'): string {
+  optionalBoolean(allowInsecureHttp, 'allowInsecureHttp')
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${name} must be a valid HTTP(S) URL`)
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error(`${name} must use HTTP or HTTPS`)
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(`${name} must not contain credentials, a query, or a fragment`)
+  }
+  const host = url.hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '')
+  const octets = host.split('.')
+  const loopback = host === 'localhost' || host === '::1'
+    || (octets.length === 4 && octets[0] === '127'
+      && octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255))
+  if (url.protocol === 'http:' && !loopback && !allowInsecureHttp) {
+    throw new Error(`${name} must use HTTPS outside loopback; explicitly enable allow_insecure_http to permit plaintext HTTP`)
+  }
+  return url.toString().replace(/\/+$/, '').replace(/\/mcp$/, '').replace(/\/+$/, '')
+}
+
+export function resolveTransport(
+  host: string,
+  env: NodeJS.ProcessEnv,
+  nativeUrl?: unknown,
+  nativeConsent?: unknown,
+  defaultUrl?: string,
+): { baseUrl: string | undefined; allowInsecureHttp: boolean; source: 'environment' | 'plugin' | 'saved' | 'default' } {
+  const prefix = `POWERCONTEXT_${host.toUpperCase()}`
+  const saved = readSavedClient(host, env)
+  const environmentUrl = optionalText(env[`${prefix}_BASE_URL`])
+    ?? optionalText(env[`${prefix}_SERVER_URL`])
+    ?? optionalText(env[`${prefix}_ENDPOINT`])
+    ?? optionalText(env.POWERCONTEXT_CLIENT_SERVER_URL)
+  const pluginUrl = optionalText(nativeUrl)
+  const selectedUrl = environmentUrl ?? pluginUrl ?? saved.server_url ?? defaultUrl
+  const normalized = selectedUrl === undefined ? undefined : normalizeServerUrl(selectedUrl, true, `${prefix}_BASE_URL`)
+  const savedUrl = saved.server_url === undefined ? undefined : normalizeServerUrl(saved.server_url, true)
+  const hostConsent = environmentBoolean(env, `${prefix}_ALLOW_INSECURE_HTTP`)
+  const commonConsent = environmentBoolean(env, 'POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP')
+  const pluginConsent = optionalBoolean(nativeConsent, 'allowInsecureHttp')
+  const nativeEndpoint = pluginUrl === undefined ? undefined : normalizeServerUrl(pluginUrl, true)
+  // Persisted native consent belongs to its endpoint, just like setup-saved consent.
+  // An explicit refusal remains effective even when the endpoint is overridden.
+  const matchingNativeConsent = pluginConsent === false
+    ? false
+    : normalized !== undefined && normalized === nativeEndpoint ? pluginConsent : undefined
+  const allowInsecureHttp = hostConsent ?? commonConsent ?? matchingNativeConsent
+    ?? (normalized !== undefined && normalized === savedUrl ? saved.allow_insecure_http : undefined) ?? false
+  return {
+    baseUrl: normalized === undefined ? undefined : normalizeServerUrl(normalized, allowInsecureHttp, `${prefix}_BASE_URL`),
+    allowInsecureHttp,
+    source: environmentUrl ? 'environment' : pluginUrl ? 'plugin' : saved.server_url ? 'saved' : 'default',
+  }
+}

--- a/integrations/opencode/plugins/powercontext/tests/transport-consent.spec.ts
+++ b/integrations/opencode/plugins/powercontext/tests/transport-consent.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveConfig } from '../src/config.ts'
+import { PowerContextClient } from '../src/client.ts'
+
+const remote = 'http://memory.example.test:8000'
+const hostUrl = 'POWERCONTEXT_OPENCODE_BASE_URL'
+const hostFlag = 'POWERCONTEXT_OPENCODE_ALLOW_INSECURE_HTTP'
+let directory: string
+let configFile: string
+
+function resolve(overrides: NodeJS.ProcessEnv = {}, native: Record<string, unknown> = {}) {
+  const env = { POWERCONTEXT_CLIENT_CONFIG_FILE: configFile, ...overrides }
+  return resolveConfig(env)
+}
+
+function save(serverUrl = remote, consent: unknown = true) {
+  writeFileSync(configFile, JSON.stringify({
+    version: 1,
+    hosts: { opencode: { server_url: serverUrl, allow_insecure_http: consent } },
+  }))
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'powercontext-opencode-transport-'))
+  configFile = join(directory, 'clients.json')
+})
+afterEach(() => rmSync(directory, { recursive: true, force: true }))
+
+describe('opencode transport consent', () => {
+  it('rejects non-boolean consent from direct JavaScript callers', () => {
+    expect(() => new PowerContextClient({
+      baseUrl: remote, requestTimeoutMs: 1000,
+      allowInsecureHttp: 'false' as unknown as boolean,
+    })).toThrow(/boolean/)
+  })
+
+  it('enforces transport policy when constructing a client directly', async () => {
+    const options = {
+      baseUrl: remote, requestTimeoutMs: 1000,
+      fetch: async (_url: string, init: RequestInit) => {
+        expect(init.redirect).toBe('manual')
+        return new Response('{}', { headers: { 'content-type': 'application/json' } })
+      },
+    }
+    expect(() => new PowerContextClient(options)).toThrow(/HTTPS/)
+    const client = new PowerContextClient({ ...options, allowInsecureHttp: true })
+    await expect(client.request('get_liveness')).resolves.toMatchObject({ status: 200 })
+  })
+
+  it('rejects remote cleartext without consent', () => {
+    expect(() => resolve({ [hostUrl]: remote })).toThrow(/HTTPS/)
+  })
+
+  it.each(['true', '1', 'yes', 'on', ' TRUE '])('accepts explicit consent %s', (value) => {
+    expect(resolve({ [hostUrl]: remote, [hostFlag]: value }).baseUrl).toBe(remote)
+  })
+
+  it('accepts common consent and a common server URL', () => {
+    const result = resolve({
+      POWERCONTEXT_CLIENT_SERVER_URL: remote,
+      POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'yes',
+    })
+    expect(result.baseUrl).toBe(remote)
+    expect(result.allowInsecureHttp).toBe(true)
+  })
+
+  it.each(['false', '0', 'no', 'off'])('lets host %s override common consent', (value) => {
+    expect(() => resolve({
+      [hostUrl]: remote,
+      [hostFlag]: value,
+      POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'true',
+    })).toThrow(/HTTPS/)
+  })
+
+  it.each([hostFlag, 'POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP'])('rejects invalid %s', (name) => {
+    expect(() => resolve({ [name]: 'sometimes' })).toThrow(/boolean/)
+  })
+
+  it('loads setup-saved endpoint and consent when native configuration is absent', () => {
+    save()
+    expect(resolve().baseUrl).toBe(remote)
+    expect(resolve().allowInsecureHttp).toBe(true)
+  })
+
+  it('normalizes saved MCP URLs before matching consent', () => {
+    save(remote + '/mcp/')
+    expect(resolve({ [hostUrl]: remote + '/' }).baseUrl).toBe(remote)
+  })
+
+  it('does not reuse saved consent for a different endpoint', () => {
+    save()
+    expect(() => resolve({ [hostUrl]: 'http://other.test' })).toThrow(/HTTPS/)
+  })
+
+  it('lets explicit common false revoke saved consent', () => {
+    save()
+    expect(() => resolve({ POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'false' })).toThrow(/HTTPS/)
+  })
+
+  it('rejects non-boolean saved consent', () => {
+    save(remote, 'true')
+    expect(() => resolve()).toThrow(/boolean/)
+  })
+
+  it.each(['localhost', '127.0.0.2', '[::1]'])('allows loopback HTTP at %s', (host) => {
+    expect(resolve({ [hostUrl]: 'http://' + host + ':8000' }).baseUrl).toBe('http://' + host + ':8000')
+  })
+
+  it.each(['ftp://memory.test', 'https://user:password@memory.test', 'https://memory.test/?secret=value', 'https://memory.test/#fragment'])(
+    'keeps URL restrictions when opted in: %s', (url) => {
+      expect(() => resolve({ [hostUrl]: url, [hostFlag]: 'true' })).toThrow()
+    },
+  )
+})

--- a/integrations/pi/plugins/powercontext/README.md
+++ b/integrations/pi/plugins/powercontext/README.md
@@ -17,3 +17,13 @@ Start `powercontext server run`, then open a new Pi session in the project. The 
 The package resolves an explicit Scope, a durable workspace binding, or the Server default. Use
 `POWERCONTEXT_PI_BASE_URL`, `POWERCONTEXT_PI_SCOPE_ID`, and `POWERCONTEXT_PI_CAPTURE_PROMPTS` to adjust the connection,
 explicit override, and automatic prompt capture.
+
+Remote HTTP is rejected by default. Explicitly allow it with `POWERCONTEXT_PI_ALLOW_INSECURE_HTTP=true`,
+or use `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP=true` as the common fallback. A host flag of `false` overrides
+the common flag. Flags accept only `true/false`, `1/0`, `yes/no`, or `on/off`; HTTPS certificate validation and
+redirect rejection remain enabled.
+
+Setup-saved URLs and endpoint-specific consent are read from `~/.config/powercontext/clients.json`
+(override with `POWERCONTEXT_CLIENT_CONFIG_FILE`). The host URL environment variable, then
+`POWERCONTEXT_CLIENT_SERVER_URL`, override the saved URL and loopback default. Changing the endpoint does not
+reuse saved HTTP consent.

--- a/integrations/pi/plugins/powercontext/extensions/powercontext.ts
+++ b/integrations/pi/plugins/powercontext/extensions/powercontext.ts
@@ -28,6 +28,7 @@ function createRuntime(): PluginRuntime {
   const config = resolveConfig()
   const client = new PowerContextClient({
     baseUrl: config.baseUrl,
+    allowInsecureHttp: config.allowInsecureHttp,
     authorization: config.authorization,
     requestTimeoutMs: config.requestTimeoutMs,
   })

--- a/integrations/pi/plugins/powercontext/src/client.ts
+++ b/integrations/pi/plugins/powercontext/src/client.ts
@@ -24,6 +24,7 @@ import {
   UnknownOperationError,
 } from './errors.ts'
 import { OPERATIONS, type OperationId, type OperationSpec } from './operations.generated.ts'
+import { normalizeServerUrl } from './transport.ts'
 
 export type JsonObject = Record<string, unknown>
 export type FetchFn = (input: string, init: RequestInit) => Promise<Response>
@@ -32,6 +33,7 @@ export type ClientSuccess = { kind: 'json'; value: unknown; status: number; requ
 
 export interface ClientOptions {
   baseUrl: string
+  allowInsecureHttp?: boolean
   authorization?: string
   requestTimeoutMs: number
   fetch?: FetchFn
@@ -189,7 +191,7 @@ export class PowerContextClient {
   private readonly fetchImpl: FetchFn
 
   constructor(options: ClientOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
+    this.baseUrl = normalizeServerUrl(options.baseUrl, options.allowInsecureHttp)
     this.authorization = options.authorization
     this.requestTimeoutMs = options.requestTimeoutMs
     this.fetchImpl = options.fetch ?? fetch

--- a/integrations/pi/plugins/powercontext/src/config.ts
+++ b/integrations/pi/plugins/powercontext/src/config.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import { resolveTransport } from './transport.ts'
+
 export interface ResolvedConfig {
   contextAssembly?: Record<string, unknown>
   baseUrl: string
+  allowInsecureHttp: boolean
   scopeId: string | undefined
   authorization: string | undefined
   capturePrompts: boolean
@@ -29,6 +32,7 @@ export interface ResolvedConfig {
 
 const DEFAULTS: ResolvedConfig = {
   baseUrl: 'http://127.0.0.1:8000',
+  allowInsecureHttp: false,
   scopeId: undefined,
   authorization: undefined,
   capturePrompts: true,
@@ -82,45 +86,8 @@ function envInteger(
   return value
 }
 
-function isIpv4Loopback(host: string): boolean {
-  const octets = host.split('.')
-  if (octets.length !== 4) return false
-  if (!octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255)) return false
-  // The whole 127.0.0.0/8 block is loopback, not just 127.0.0.1.
-  return octets[0] === '127'
-}
-
-function isLoopback(hostname: string): boolean {
-  // Mirror the shared `is_loopback_host` transport contract (src/powercontext/transport.py): trim,
-  // lowercase, drop the IPv6 brackets that URL.hostname keeps, then accept `localhost`, the whole
-  // IPv4 127.0.0.0/8 block, and IPv6 ::1. Drift here is pinned by transport-policy.spec.ts, which
-  // shares its host vectors with the Python drift guard.
-  const normalized = hostname.trim().toLowerCase().replace(/^\[/, '').replace(/\]$/, '')
-  if (!normalized) return false
-  if (normalized === 'localhost' || normalized === '::1') return true
-  return isIpv4Loopback(normalized)
-}
-
-function normalizeBaseUrl(value: string): string {
-  let url: URL
-  try {
-    url = new URL(value)
-  } catch {
-    throw new Error('POWERCONTEXT_PI_BASE_URL must be a valid HTTP(S) URL')
-  }
-  if (!['http:', 'https:'].includes(url.protocol)) {
-    throw new Error('POWERCONTEXT_PI_BASE_URL must use HTTP or HTTPS')
-  }
-  if (url.username || url.password || url.search || url.hash) {
-    throw new Error('POWERCONTEXT_PI_BASE_URL must not contain credentials, a query, or a fragment')
-  }
-  if (url.protocol === 'http:' && !isLoopback(url.hostname)) {
-    throw new Error('POWERCONTEXT_PI_BASE_URL must use HTTPS outside loopback')
-  }
-  return url.toString().replace(/\/+$/, '')
-}
-
 export function resolveConfig(env: NodeJS.ProcessEnv = process.env): ResolvedConfig {
+  const transport = resolveTransport('pi', env, undefined, undefined, DEFAULTS.baseUrl)
   const requestTimeoutMs = envInteger(env, 'POWERCONTEXT_PI_REQUEST_TIMEOUT_MS', DEFAULTS.requestTimeoutMs, 50, 30_000)
   const httpBudgetMs = envInteger(env, 'POWERCONTEXT_PI_HTTP_BUDGET_MS', DEFAULTS.httpBudgetMs, 100, 60_000)
   if (requestTimeoutMs > httpBudgetMs) {
@@ -128,7 +95,8 @@ export function resolveConfig(env: NodeJS.ProcessEnv = process.env): ResolvedCon
   }
   return {
     contextAssembly: contextAssembly(envString(env, 'POWERCONTEXT_PI_CONTEXT_ASSEMBLY')),
-    baseUrl: normalizeBaseUrl(envString(env, 'POWERCONTEXT_PI_BASE_URL') ?? DEFAULTS.baseUrl),
+    baseUrl: transport.baseUrl!,
+    allowInsecureHttp: transport.allowInsecureHttp,
     scopeId: envString(env, 'POWERCONTEXT_PI_SCOPE_ID'),
     authorization: envString(env, 'POWERCONTEXT_PI_AUTHORIZATION'),
     capturePrompts: envBoolean(env, 'POWERCONTEXT_PI_CAPTURE_PROMPTS') ?? DEFAULTS.capturePrompts,

--- a/integrations/pi/plugins/powercontext/src/transport.ts
+++ b/integrations/pi/plugins/powercontext/src/transport.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+// Each host is an independently distributed package; keep the shared client config
+// contract and policy aligned with powercontext.client.transport_policy and powercontext.transport.
+type SavedClient = { server_url?: string; allow_insecure_http?: boolean }
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === 'string' ? value.trim() || undefined : undefined
+}
+
+function optionalBoolean(value: unknown, name: string): boolean | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'boolean') throw new Error(`${name} must be a boolean`)
+  return value
+}
+
+function environmentBoolean(env: NodeJS.ProcessEnv, name: string): boolean | undefined {
+  if (env[name] === undefined) return undefined
+  const value = env[name]!.trim().toLowerCase()
+  if (['true', '1', 'yes', 'on'].includes(value)) return true
+  if (['false', '0', 'no', 'off'].includes(value)) return false
+  throw new Error(`${name} must be a boolean (true/false, 1/0, yes/no, on/off)`)
+}
+
+function readSavedClient(host: string, env: NodeJS.ProcessEnv): SavedClient {
+  const home = optionalText(env.HOME) ?? homedir()
+  const configuredPath = optionalText(env.POWERCONTEXT_CLIENT_CONFIG_FILE)
+  const path = configuredPath?.startsWith('~/')
+    ? join(home, configuredPath.slice(2))
+    : configuredPath ?? join(home, '.config', 'powercontext', 'clients.json')
+  let contents: string
+  try {
+    contents = readFileSync(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw new Error('Unable to read PowerContext client configuration', { cause: error })
+  }
+  let document: unknown
+  try {
+    document = JSON.parse(contents)
+  } catch {
+    throw new Error('PowerContext client configuration must be valid JSON')
+  }
+  if (!document || typeof document !== 'object' || Array.isArray(document)
+    || (document as { version?: unknown }).version !== 1) {
+    throw new Error('PowerContext client configuration must have version 1')
+  }
+  const hosts = (document as { hosts?: unknown }).hosts
+  if (!hosts || typeof hosts !== 'object' || Array.isArray(hosts)) {
+    throw new Error('PowerContext client configuration hosts must be an object')
+  }
+  const value = (hosts as Record<string, unknown>)[host]
+  if (value === undefined) return {}
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('PowerContext saved host configuration must be an object')
+  }
+  const entry = value as Record<string, unknown>
+  if (entry.server_url !== undefined && !optionalText(entry.server_url)) {
+    throw new Error('PowerContext saved server_url must be a non-empty string')
+  }
+  return {
+    server_url: optionalText(entry.server_url),
+    allow_insecure_http: optionalBoolean(entry.allow_insecure_http, 'allow_insecure_http'),
+  }
+}
+
+export function normalizeServerUrl(value: string, allowInsecureHttp = false, name = 'PowerContext server URL'): string {
+  optionalBoolean(allowInsecureHttp, 'allowInsecureHttp')
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${name} must be a valid HTTP(S) URL`)
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error(`${name} must use HTTP or HTTPS`)
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(`${name} must not contain credentials, a query, or a fragment`)
+  }
+  const host = url.hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '')
+  const octets = host.split('.')
+  const loopback = host === 'localhost' || host === '::1'
+    || (octets.length === 4 && octets[0] === '127'
+      && octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255))
+  if (url.protocol === 'http:' && !loopback && !allowInsecureHttp) {
+    throw new Error(`${name} must use HTTPS outside loopback; explicitly enable allow_insecure_http to permit plaintext HTTP`)
+  }
+  return url.toString().replace(/\/+$/, '').replace(/\/mcp$/, '').replace(/\/+$/, '')
+}
+
+export function resolveTransport(
+  host: string,
+  env: NodeJS.ProcessEnv,
+  nativeUrl?: unknown,
+  nativeConsent?: unknown,
+  defaultUrl?: string,
+): { baseUrl: string | undefined; allowInsecureHttp: boolean; source: 'environment' | 'plugin' | 'saved' | 'default' } {
+  const prefix = `POWERCONTEXT_${host.toUpperCase()}`
+  const saved = readSavedClient(host, env)
+  const environmentUrl = optionalText(env[`${prefix}_BASE_URL`])
+    ?? optionalText(env[`${prefix}_SERVER_URL`])
+    ?? optionalText(env[`${prefix}_ENDPOINT`])
+    ?? optionalText(env.POWERCONTEXT_CLIENT_SERVER_URL)
+  const pluginUrl = optionalText(nativeUrl)
+  const selectedUrl = environmentUrl ?? pluginUrl ?? saved.server_url ?? defaultUrl
+  const normalized = selectedUrl === undefined ? undefined : normalizeServerUrl(selectedUrl, true, `${prefix}_BASE_URL`)
+  const savedUrl = saved.server_url === undefined ? undefined : normalizeServerUrl(saved.server_url, true)
+  const hostConsent = environmentBoolean(env, `${prefix}_ALLOW_INSECURE_HTTP`)
+  const commonConsent = environmentBoolean(env, 'POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP')
+  const pluginConsent = optionalBoolean(nativeConsent, 'allowInsecureHttp')
+  const nativeEndpoint = pluginUrl === undefined ? undefined : normalizeServerUrl(pluginUrl, true)
+  // Persisted native consent belongs to its endpoint, just like setup-saved consent.
+  // An explicit refusal remains effective even when the endpoint is overridden.
+  const matchingNativeConsent = pluginConsent === false
+    ? false
+    : normalized !== undefined && normalized === nativeEndpoint ? pluginConsent : undefined
+  const allowInsecureHttp = hostConsent ?? commonConsent ?? matchingNativeConsent
+    ?? (normalized !== undefined && normalized === savedUrl ? saved.allow_insecure_http : undefined) ?? false
+  return {
+    baseUrl: normalized === undefined ? undefined : normalizeServerUrl(normalized, allowInsecureHttp, `${prefix}_BASE_URL`),
+    allowInsecureHttp,
+    source: environmentUrl ? 'environment' : pluginUrl ? 'plugin' : saved.server_url ? 'saved' : 'default',
+  }
+}

--- a/integrations/pi/plugins/powercontext/tests/commands.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/commands.spec.ts
@@ -28,6 +28,7 @@ function runtime(fetch: typeof globalThis.fetch, resolveScope = async () => 'sco
     }),
     config: {
       baseUrl: 'http://127.0.0.1:8000',
+      allowInsecureHttp: false,
       scopeId: undefined,
       authorization: undefined,
       capturePrompts: true,

--- a/integrations/pi/plugins/powercontext/tests/config.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/config.spec.ts
@@ -29,6 +29,7 @@ describe('Pi configuration', () => {
       POWERCONTEXT_PI_MAX_BYTES: '12000',
     })).toEqual({
       baseUrl: 'https://memory.example.test',
+      allowInsecureHttp: false,
       scopeId: 'project:demo',
       authorization: 'Bearer token',
       capturePrompts: false,

--- a/integrations/pi/plugins/powercontext/tests/tools.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/tools.spec.ts
@@ -29,6 +29,7 @@ function createRuntime(fetch: FetchFn): PluginRuntime {
     }),
     config: {
       baseUrl: 'http://127.0.0.1:8000',
+      allowInsecureHttp: false,
       scopeId: undefined,
       authorization: undefined,
       capturePrompts: true,

--- a/integrations/pi/plugins/powercontext/tests/transport-consent.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/transport-consent.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveConfig } from '../src/config.ts'
+import { PowerContextClient } from '../src/client.ts'
+
+const remote = 'http://memory.example.test:8000'
+const hostUrl = 'POWERCONTEXT_PI_BASE_URL'
+const hostFlag = 'POWERCONTEXT_PI_ALLOW_INSECURE_HTTP'
+let directory: string
+let configFile: string
+
+function resolve(overrides: NodeJS.ProcessEnv = {}, native: Record<string, unknown> = {}) {
+  const env = { POWERCONTEXT_CLIENT_CONFIG_FILE: configFile, ...overrides }
+  return resolveConfig(env)
+}
+
+function save(serverUrl = remote, consent: unknown = true) {
+  writeFileSync(configFile, JSON.stringify({
+    version: 1,
+    hosts: { pi: { server_url: serverUrl, allow_insecure_http: consent } },
+  }))
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'powercontext-pi-transport-'))
+  configFile = join(directory, 'clients.json')
+})
+afterEach(() => rmSync(directory, { recursive: true, force: true }))
+
+describe('pi transport consent', () => {
+  it('rejects non-boolean consent from direct JavaScript callers', () => {
+    expect(() => new PowerContextClient({
+      baseUrl: remote, requestTimeoutMs: 1000,
+      allowInsecureHttp: 'false' as unknown as boolean,
+    })).toThrow(/boolean/)
+  })
+
+  it('enforces transport policy when constructing a client directly', async () => {
+    const options = {
+      baseUrl: remote, requestTimeoutMs: 1000,
+      fetch: async (_url: string, init: RequestInit) => {
+        expect(init.redirect).toBe('manual')
+        return new Response('{}', { headers: { 'content-type': 'application/json' } })
+      },
+    }
+    expect(() => new PowerContextClient(options)).toThrow(/HTTPS/)
+    const client = new PowerContextClient({ ...options, allowInsecureHttp: true })
+    await expect(client.request('get_liveness')).resolves.toMatchObject({ status: 200 })
+  })
+
+  it('rejects remote cleartext without consent', () => {
+    expect(() => resolve({ [hostUrl]: remote })).toThrow(/HTTPS/)
+  })
+
+  it.each(['true', '1', 'yes', 'on', ' TRUE '])('accepts explicit consent %s', (value) => {
+    expect(resolve({ [hostUrl]: remote, [hostFlag]: value }).baseUrl).toBe(remote)
+  })
+
+  it('accepts common consent and a common server URL', () => {
+    const result = resolve({
+      POWERCONTEXT_CLIENT_SERVER_URL: remote,
+      POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'yes',
+    })
+    expect(result.baseUrl).toBe(remote)
+    expect(result.allowInsecureHttp).toBe(true)
+  })
+
+  it.each(['false', '0', 'no', 'off'])('lets host %s override common consent', (value) => {
+    expect(() => resolve({
+      [hostUrl]: remote,
+      [hostFlag]: value,
+      POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'true',
+    })).toThrow(/HTTPS/)
+  })
+
+  it.each([hostFlag, 'POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP'])('rejects invalid %s', (name) => {
+    expect(() => resolve({ [name]: 'sometimes' })).toThrow(/boolean/)
+  })
+
+  it('loads setup-saved endpoint and consent when native configuration is absent', () => {
+    save()
+    expect(resolve().baseUrl).toBe(remote)
+    expect(resolve().allowInsecureHttp).toBe(true)
+  })
+
+  it('normalizes saved MCP URLs before matching consent', () => {
+    save(remote + '/mcp/')
+    expect(resolve({ [hostUrl]: remote + '/' }).baseUrl).toBe(remote)
+  })
+
+  it('does not reuse saved consent for a different endpoint', () => {
+    save()
+    expect(() => resolve({ [hostUrl]: 'http://other.test' })).toThrow(/HTTPS/)
+  })
+
+  it('lets explicit common false revoke saved consent', () => {
+    save()
+    expect(() => resolve({ POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP: 'false' })).toThrow(/HTTPS/)
+  })
+
+  it('rejects non-boolean saved consent', () => {
+    save(remote, 'true')
+    expect(() => resolve()).toThrow(/boolean/)
+  })
+
+  it.each(['localhost', '127.0.0.2', '[::1]'])('allows loopback HTTP at %s', (host) => {
+    expect(resolve({ [hostUrl]: 'http://' + host + ':8000' }).baseUrl).toBe('http://' + host + ':8000')
+  })
+
+  it.each(['ftp://memory.test', 'https://user:password@memory.test', 'https://memory.test/?secret=value', 'https://memory.test/#fragment'])(
+    'keeps URL restrictions when opted in: %s', (url) => {
+      expect(() => resolve({ [hostUrl]: url, [hostFlag]: 'true' })).toThrow()
+    },
+  )
+})

--- a/integrations/pydantic-ai/README.md
+++ b/integrations/pydantic-ai/README.md
@@ -50,6 +50,7 @@ Environment variables use the `POWERCONTEXT_PYDANTIC_AI_` prefix.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `BASE_URL` | `http://127.0.0.1:8000` | PowerContext Server HTTP base URL |
+| `ALLOW_INSECURE_HTTP` | `false` | Explicitly allow non-loopback HTTP; HTTPS certificate validation stays enabled |
 | `TOKEN` | unset | Bare Server token; the Client adds the `Bearer` scheme |
 | `SCOPE_ID` | unset | Existing explicit Server Scope; unset selects the Server default |
 | `TIMEOUT` | `10` | HTTP timeout in seconds |
@@ -61,6 +62,12 @@ Environment variables use the `POWERCONTEXT_PYDANTIC_AI_` prefix.
 The `TOKEN` value is deliberately different from the Codex and Claude Code plugin authorization settings: provide
 only the opaque token, not `Bearer TOKEN` or a complete `Authorization` header. It is stored as Pydantic `SecretStr`
 and passed to `PowerContextClient`, which constructs the header.
+
+`PowerContextSettings(allow_insecure_http=True)` also permits non-loopback HTTP. Transport settings resolve from
+constructor values, host environment, common `POWERCONTEXT_CLIENT_SERVER_URL` /
+`POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP`, then the `pydantic-ai` entry in `~/.config/powercontext/clients.json`
+(overridden by `POWERCONTEXT_CLIENT_CONFIG_FILE`). A host value of `false` overrides common `true`.
+Saved consent applies only to its saved Server URL and is not reused when the URL changes.
 
 Both components accept `settings=`, `id=` (default `powercontext`), and `scope_id=`. `scope_id` can be a fixed string
 or a callable receiving the current `RunContext`. Resolution order is constructor value or callback, then environment

--- a/integrations/pydantic-ai/src/powercontext_pydantic_ai/settings.py
+++ b/integrations/pydantic-ai/src/powercontext_pydantic_ai/settings.py
@@ -16,11 +16,13 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
 from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import Field, HttpUrl, SecretStr, TypeAdapter, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import SettingsConfigDict
 
+from powercontext.client.transport_policy import ClientTransportSettings
 from powercontext.limits import MAX_SCOPE_ID_LENGTH
 
 try:
@@ -32,7 +34,7 @@ except ImportError:
 _HTTP_URL_ADAPTER = TypeAdapter(HttpUrl)
 
 
-class PowerContextSettings(BaseSettings):
+class PowerContextSettings(ClientTransportSettings):
     """PowerContext settings loaded from constructor values or the environment."""
 
     model_config = SettingsConfigDict(
@@ -43,6 +45,7 @@ class PowerContextSettings(BaseSettings):
         hide_input_in_errors=True,
     )
 
+    transport_host: ClassVar[str] = "pydantic-ai"
     base_url: str = "http://127.0.0.1:8000"
     token: SecretStr | None = Field(default=None, repr=False)
     scope_id: str | None = Field(default=None, min_length=1, max_length=MAX_SCOPE_ID_LENGTH)

--- a/integrations/pydantic-ai/src/powercontext_pydantic_ai/toolset.py
+++ b/integrations/pydantic-ai/src/powercontext_pydantic_ai/toolset.py
@@ -148,10 +148,12 @@ class PowerContextToolset(FunctionToolset[AgentDepsT], Generic[AgentDepsT]):
         if state.client is not None:
             return self
         token = self.settings.token.get_secret_value() if self.settings.token is not None else None
+        server_url, allow_insecure_http = self.settings.resolve_transport()
         client = PowerContextClient(
-            self.settings.base_url,
+            server_url,
             token=token,
             timeout=self.settings.timeout,
+            allow_insecure_http=allow_insecure_http,
         )
         await client.__aenter__()
         try:

--- a/integrations/workbuddy/README.md
+++ b/integrations/workbuddy/README.md
@@ -72,6 +72,7 @@ WORKBUDDY_HOOKS_DIR="${WORKBUDDY_HOOKS_DIR:-$HOME/.workbuddy/hooks}"
 mkdir -p "$WORKBUDDY_HOOKS_DIR"
 cp "$PLUGIN"/hooks/workbuddy_powercontext_hook.py \
    "$PLUGIN"/hooks/workbuddy_settings.py \
+   "$PLUGIN"/hooks/powercontext_client_config.py \
    "$PLUGIN"/hooks/prepared_context.py \
    "$WORKBUDDY_HOOKS_DIR"/
 cp "$PLUGIN/scripts/workspace_scope.py" \
@@ -84,6 +85,7 @@ The resulting layout is:
 <WORKBUDDY_HOOKS_DIR>/
   workbuddy_powercontext_hook.py
   workbuddy_settings.py
+  powercontext_client_config.py
   prepared_context.py
   powercontext_scope_binding.py
 ```
@@ -184,6 +186,7 @@ override the defaults; restart WorkBuddy after changing them.
 | Variable | Purpose |
 | --- | --- |
 | `POWERCONTEXT_WORKBUDDY_SERVER_URL` | PowerContext server URL (default `http://127.0.0.1:8000`). |
+| `POWERCONTEXT_WORKBUDDY_ALLOW_INSECURE_HTTP` | Explicit non-loopback HTTP consent; overrides common and saved consent, including `false`. |
 | `POWERCONTEXT_WORKBUDDY_AUTHORIZATION` | Complete authorization header, e.g. `Bearer <token>` |
 | `POWERCONTEXT_WORKBUDDY_SCOPE_ID` | Explicit server-owned Scope ID |
 | `POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS` | Capture user prompts as Sources (default `true`) |
@@ -192,11 +195,26 @@ override the defaults; restart WorkBuddy after changing them.
 | `POWERCONTEXT_WORKBUDDY_HTTP_BUDGET_SECONDS` | Shared wall-clock budget for one prompt (default `4.0`) |
 | `POWERCONTEXT_WORKBUDDY_FLUSH_MAX_CALLS` | Maximum flush calls (default `4`) |
 
-The hook validates its PowerContext MCP URL and derives the HTTP API base by
-removing the final `/mcp` path segment. Change `plugins/powercontext/.mcp.json`
-before installing when the loopback default is not appropriate. MCP URLs cannot
-contain credentials, query strings, or fragments; plain HTTP is accepted only
-for loopback hosts.
+The hook selects its URL from `POWERCONTEXT_WORKBUDDY_SERVER_URL`,
+`POWERCONTEXT_CLIENT_SERVER_URL`, saved settings, then the loopback default.
+It removes a final `/mcp` suffix and rejects credentials, query strings, and
+fragments. HTTPS and loopback HTTP work by default. To persist a non-loopback
+HTTP endpoint and configure the native MCP URL consistently:
+
+```bash
+powercontext setup workbuddy --server-url http://memory.example:8000 --allow-insecure-http
+```
+
+Nonsecret settings are stored under `hosts.workbuddy` in
+`~/.config/powercontext/clients.json`; `POWERCONTEXT_CLIENT_CONFIG_FILE` overrides
+the location. Saved consent applies only to the same normalized endpoint.
+An explicit settings constructor argument overrides the host environment,
+then `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP`, then saved consent. Boolean
+misspellings are rejected, and explicit `false` disables inherited consent.
+
+The guard applies to the PowerContext hook; WorkBuddy owns native MCP transport
+policy. HTTP sends request content and authorization headers without encryption.
+HTTPS certificate verification remains enabled.
 
 ## Runtime behavior
 

--- a/integrations/workbuddy/plugins/powercontext/hooks/powercontext_client_config.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/powercontext_client_config.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Endpoint-bound transport settings for an independently installed plugin.
+
+This standard-library helper is distributed with each Python host plugin.
+It must not import the PowerContext package, which need not be installed.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+
+def normalize_server_url(value: str, *, allow_insecure_http: bool = False) -> str:
+    """Validate a Server endpoint and remove the optional MCP suffix."""
+    parsed = urlsplit(value.strip().rstrip("/"))
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("PowerContext Server URL must not contain credentials")  # noqa: TRY003
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        raise ValueError("PowerContext Server URL must use HTTP or HTTPS")  # noqa: TRY003
+    if parsed.query or parsed.fragment:
+        raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
+    # Accessing port also rejects malformed and out-of-range ports.
+    port = parsed.port
+    host = parsed.hostname.lower()
+    try:
+        loopback = ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        loopback = host == "localhost"
+    if parsed.scheme == "http" and not loopback and not allow_insecure_http:
+        raise ValueError(  # noqa: TRY003
+            "unencrypted PowerContext URLs must be loopback addresses unless allow_insecure_http is explicitly enabled"
+        )
+    netloc = f"[{host}]" if ":" in host else host
+    if port is not None and port != (443 if parsed.scheme == "https" else 80):
+        netloc += f":{port}"
+    path = parsed.path.rstrip("/").removesuffix("/mcp")
+    return urlunsplit((parsed.scheme, netloc, path, "", "")).rstrip("/")
+
+
+def load_client_settings(host: str) -> dict[str, Any]:
+    """Read only the nonsecret settings owned by this host."""
+    configured = os.environ.get("POWERCONTEXT_CLIENT_CONFIG_FILE")
+    path = Path(configured).expanduser() if configured else Path.home() / ".config" / "powercontext" / "clients.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, UnicodeError, ValueError):
+        raise ValueError("invalid PowerContext client settings file") from None  # noqa: TRY003
+    if not isinstance(data, dict) or type(data.get("version")) is not int or data["version"] != 1:
+        raise ValueError("invalid PowerContext client settings version")  # noqa: TRY003
+    hosts = data.get("hosts")
+    if not isinstance(hosts, dict):
+        raise ValueError("invalid PowerContext client host settings")  # noqa: TRY003, TRY004
+    entry = hosts.get(host, {})
+    if not isinstance(entry, dict):
+        raise ValueError("invalid PowerContext client host settings")  # noqa: TRY003, TRY004
+    result: dict[str, Any] = {}
+    if "server_url" in entry:
+        if not isinstance(entry["server_url"], str):
+            raise ValueError("invalid PowerContext client server URL")  # noqa: TRY003
+        result["server_url"] = normalize_server_url(entry["server_url"], allow_insecure_http=True)
+    if "allow_insecure_http" in entry:
+        if not isinstance(entry["allow_insecure_http"], bool):
+            raise ValueError("PowerContext allow_insecure_http must be a JSON boolean")  # noqa: TRY003
+        result["allow_insecure_http"] = entry["allow_insecure_http"]
+    return result
+
+
+def parse_boolean(value: object) -> bool:
+    """Reject misspellings instead of interpreting nonempty strings as true."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise ValueError("invalid boolean PowerContext allow_insecure_http configuration")  # noqa: TRY003
+
+
+def resolve_allow_insecure_http(
+    server_url: str,
+    *,
+    host: str,
+    host_environment: str,
+    explicit: bool | None = None,
+    saved: dict[str, Any] | None = None,
+) -> bool:
+    """Resolve consent without transferring saved consent to another endpoint."""
+    settings = load_client_settings(host) if saved is None else saved
+    if explicit is not None:
+        return parse_boolean(explicit)
+    names = [host_environment, "POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP"]
+    for name in names:
+        if name in os.environ:
+            return parse_boolean(os.environ[name])
+    consent = settings.get("allow_insecure_http", False)
+    if not isinstance(consent, bool):
+        raise ValueError("PowerContext allow_insecure_http must be a JSON boolean")  # noqa: TRY003, TRY004
+    saved_url = settings.get("server_url")
+    return bool(
+        consent
+        and isinstance(saved_url, str)
+        and normalize_server_url(saved_url, allow_insecure_http=True)
+        == normalize_server_url(server_url, allow_insecure_http=True)
+    )

--- a/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py
@@ -20,10 +20,13 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 from dataclasses import dataclass
 from urllib.parse import urlsplit, urlunsplit
+
+from powercontext_client_config import load_client_settings, resolve_allow_insecure_http
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
@@ -43,9 +46,17 @@ class WorkBuddyPluginSettings:
     request_timeout_seconds: float = 1.0
     http_budget_seconds: float = 4.0
     flush_max_calls: int = 4
+    allow_insecure_http: bool | None = None
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "server_url", _http_base_url(self.server_url))
+        allow_insecure_http = resolve_allow_insecure_http(
+            self.server_url,
+            host="workbuddy",
+            host_environment="POWERCONTEXT_WORKBUDDY_ALLOW_INSECURE_HTTP",
+            explicit=self.allow_insecure_http,
+        )
+        object.__setattr__(self, "allow_insecure_http", allow_insecure_http)
+        object.__setattr__(self, "server_url", _http_base_url(self.server_url, allow_insecure_http=allow_insecure_http))
         object.__setattr__(self, "authorization", _authorization_header(self.authorization))
         object.__setattr__(self, "scope_id", _optional_text(self.scope_id))
         if self.request_timeout_seconds <= 0 or self.http_budget_seconds <= 0:
@@ -57,8 +68,11 @@ class WorkBuddyPluginSettings:
     def from_environment(cls) -> WorkBuddyPluginSettings:
         """Load WorkBuddy user options and integration-specific environment values."""
 
+        saved = load_client_settings("workbuddy")
         return cls(
-            server_url=_first_environment("POWERCONTEXT_WORKBUDDY_SERVER_URL") or "http://127.0.0.1:8000",
+            server_url=_first_environment("POWERCONTEXT_WORKBUDDY_SERVER_URL", "POWERCONTEXT_CLIENT_SERVER_URL")
+            or saved.get("server_url")
+            or "http://127.0.0.1:8000",
             authorization=_first_environment("POWERCONTEXT_WORKBUDDY_AUTHORIZATION"),
             scope_id=_first_environment("POWERCONTEXT_WORKBUDDY_SCOPE_ID"),
             context_assembly=_environment_object("POWERCONTEXT_WORKBUDDY_CONTEXT_ASSEMBLY"),
@@ -151,7 +165,7 @@ def _authorization_header(value: str | None) -> str | None:
     return normalized
 
 
-def _http_base_url(value: str) -> str:
+def _http_base_url(value: str, *, allow_insecure_http: bool = False) -> str:
     normalized = value.strip().rstrip("/")
     parsed = urlsplit(normalized)
     if parsed.username is not None or parsed.password is not None:
@@ -160,7 +174,11 @@ def _http_base_url(value: str) -> str:
         raise ValueError("PowerContext Server URL must use HTTP or HTTPS")  # noqa: TRY003
     if parsed.query or parsed.fragment:
         raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
-    if parsed.scheme == "http" and parsed.hostname.lower() not in _LOOPBACK_HOSTS:
+    try:
+        loopback = ipaddress.ip_address(parsed.hostname).is_loopback
+    except ValueError:
+        loopback = parsed.hostname.lower() in _LOOPBACK_HOSTS
+    if parsed.scheme == "http" and not loopback and not allow_insecure_http:
         raise ValueError("unencrypted PowerContext URLs must be loopback addresses")  # noqa: TRY003
     path = parsed.path.rstrip("/")
     if path.endswith("/mcp"):

--- a/src/powercontext/cli/app.py
+++ b/src/powercontext/cli/app.py
@@ -53,6 +53,12 @@ def create_cli(commands: Iterable[typer.Typer] | None = None) -> typer.Typer:
             str | None,
             typer.Option(help="PowerContext Server base URL used by content commands."),
         ] = None,
+        allow_insecure_http: Annotated[
+            bool | None,
+            typer.Option(
+                "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+            ),
+        ] = None,
         timeout: Annotated[
             float | None,
             typer.Option(min=0.1, help="HTTP timeout in seconds used by content commands."),
@@ -77,6 +83,7 @@ def create_cli(commands: Iterable[typer.Typer] | None = None) -> typer.Typer:
             context,
             server_url=server_url,
             timeout=timeout,
+            allow_insecure_http=allow_insecure_http,
             json_output=json_output,
         )
 

--- a/src/powercontext/cli/hosts.py
+++ b/src/powercontext/cli/hosts.py
@@ -188,6 +188,7 @@ def run_setup_select(
     server_url: str | None,
     capture_prompts: bool,
     json_output: bool,
+    allow_insecure_http: bool | None = None,
 ) -> None:
     """Resolve a selection, install those hosts, and print the matrix."""
 
@@ -204,6 +205,8 @@ def run_setup_select(
         ref=ref,
         server_url=server_url,
         capture_prompts=capture_prompts,
+        allow_insecure_http=allow_insecure_http,
+        json_output=json_output,
     )
     write_setup_select_report(report, json_output=json_output)
     if report.has_failure:
@@ -230,10 +233,13 @@ def setup_selected_hosts(
     ref: str,
     server_url: str | None,
     capture_prompts: bool,
+    allow_insecure_http: bool | None = None,
+    json_output: bool = False,
 ) -> SetupSelectReport:
     """Install selected hosts and isolate failures from sibling hosts."""
 
     from powercontext.cli.system import SetupError
+    from powercontext.cli.transport import prepare_setup_transport, save_setup_transport
 
     selected_names = set(selected)
     rows: list[HostSetupRow] = []
@@ -242,14 +248,19 @@ def setup_selected_hosts(
             rows.append(HostSetupRow(host=host.name, status="skipped"))
             continue
         try:
+            transport = prepare_setup_transport(
+                host.name, server_url=server_url, allow_insecure_http=allow_insecure_http, json_output=json_output
+            )
             install_host(
                 host.name,
                 source=source,
                 ref=ref,
-                server_url=server_url,
+                server_url=transport.server_url,
                 capture_prompts=capture_prompts,
+                allow_insecure_http=transport.allow_insecure_http,
             )
             verify_host(host.name)
+            save_setup_transport(transport)
         except SetupError as error:
             rows.append(HostSetupRow(host=host.name, status="failed", error=str(error)))
             continue
@@ -264,13 +275,14 @@ def install_host(
     ref: str,
     server_url: str | None,
     capture_prompts: bool,
+    allow_insecure_http: bool = False,
 ) -> object:
     """Call the existing installer for one first-class host."""
 
     if name == "codex":
         from powercontext.cli.system import install_codex_plugin
 
-        return install_codex_plugin(source=source, ref=ref)
+        return install_codex_plugin(source=source, ref=ref, server_url=server_url)
     if name == "claude-code":
         from powercontext.cli.system import DEFAULT_CLAUDE_CODE_SERVER_URL, install_claude_code_plugin
 
@@ -279,6 +291,7 @@ def install_host(
             ref=ref,
             server_url=server_url if server_url is not None else DEFAULT_CLAUDE_CODE_SERVER_URL,
             capture_prompts=capture_prompts,
+            allow_insecure_http=allow_insecure_http,
         )
     if name == "dsh":
         from powercontext.cli.dsh import install_dsh_plugin
@@ -292,6 +305,7 @@ def install_host(
             source=source,
             ref=ref,
             server_url=server_url if server_url is not None else DEFAULT_OPENCLAW_SERVER_URL,
+            allow_insecure_http=allow_insecure_http,
         )
     if name == "opencode":
         from powercontext.cli.opencode import install_opencode_plugin
@@ -430,9 +444,16 @@ def build_integration_row(name: str, diagnostics: dict[str, Diagnostic]) -> Inte
     """Classify one host diagnostic pair without deciding the command exit code."""
 
     cli_key, cli, integrations = split_host_diagnostics(diagnostics)
+    presence = classify_host_presence(cli, integrations)
+    if presence == "present":
+        from powercontext.cli.transport import transport_diagnostic
+
+        transport = transport_diagnostic(name)
+        if not transport.ok:
+            integrations = (*integrations, ("transport", transport))
     return IntegrationRow(
         host=name,
-        presence=classify_host_presence(cli, integrations),
+        presence=presence,
         cli_key=cli_key,
         cli=cli,
         integrations=integrations,

--- a/src/powercontext/cli/native_transport.py
+++ b/src/powercontext/cli/native_transport.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Read native host transport settings without guessing unsupported configuration."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, cast
+
+from powercontext.client.transport_policy import (
+    load_client_settings,
+    normalize_client_url,
+    parse_client_boolean,
+    resolve_client_transport,
+)
+
+_DEFAULT_URL = "http://127.0.0.1:8000"
+_MISSING = object()
+_UNKNOWN = "Cannot determine PowerContext transport from unsupported or unreadable native host configuration"
+
+
+def _home(variable: str, directory: str) -> Path:
+    configured = os.environ.get(variable, "").strip()
+    return Path(configured).expanduser() if configured else Path.home() / directory
+
+
+def _object_at(value: object, *keys: str) -> dict[str, Any]:
+    for key in (*keys, None):
+        if not isinstance(value, dict) or "$include" in value:
+            raise ValueError(_UNKNOWN)
+        if key is None:
+            return cast(dict[str, Any], value)
+        value = value.get(key, {})
+    return {}  # pragma: no cover
+
+
+def _read(path: Path) -> dict[str, Any]:
+    try:
+        return _object_at(json.loads(path.read_text(encoding="utf-8")))
+    except FileNotFoundError:
+        return {}
+    except (OSError, UnicodeError, ValueError):
+        raise ValueError(_UNKNOWN) from None
+
+
+def _url(value: object) -> str:
+    if not isinstance(value, str) or not value.strip() or "${" in value:
+        raise ValueError(_UNKNOWN)
+    try:
+        return normalize_client_url(value).removesuffix("/mcp").rstrip("/")
+    except ValueError:
+        raise ValueError(_UNKNOWN) from None
+
+
+def _environment_url(*names: str) -> str | None:
+    return next((os.environ[name].strip() for name in names if os.environ.get(name, "").strip()), None)
+
+
+def _codex_url() -> str | None:
+    cache = _home("CODEX_HOME", ".codex") / "plugins" / "cache"
+    try:
+        paths = list(cache.glob("*/powercontext/*/.mcp.json"))
+    except OSError:
+        raise ValueError(_UNKNOWN) from None
+    urls = set()
+    for path in paths:
+        entry = _object_at(_read(path), "mcpServers", "powercontext")
+        raw = entry.get("url")
+        if not isinstance(raw, str) or not raw.rstrip("/").endswith("/mcp"):
+            raise ValueError(_UNKNOWN)
+        urls.add(_url(raw))
+    if len(urls) > 1:
+        raise ValueError("Cannot determine the active PowerContext endpoint from multiple Codex cache versions")  # noqa: TRY003
+    return next(iter(urls), None)
+
+
+def _native_settings(host: str) -> tuple[dict[str, Any], str, str]:
+    if host == "claude-code":
+        settings = _object_at(
+            _read(_home("CLAUDE_CONFIG_DIR", ".claude") / "settings.json"),
+            "pluginConfigs",
+            "powercontext@powercontext",
+            "options",
+        ).copy()
+        for key in ("server_url", "allow_insecure_http"):
+            name = "CLAUDE_PLUGIN_OPTION_" + key.upper()
+            if name in os.environ:
+                settings[key] = os.environ[name]
+        return settings, "server_url", "allow_insecure_http"
+    if host == "hermes":
+        configured = os.environ.get("POWERCONTEXT_HERMES_CONFIG", "").strip()
+        path = Path(configured) if configured else _home("HERMES_HOME", ".hermes") / "powercontext" / "config.json"
+        return _read(path), "base_url", "allow_insecure_http"
+    if host == "openclaw":
+        configured = os.environ.get("OPENCLAW_CONFIG_PATH", "").strip()
+        path = (
+            Path(configured).expanduser() if configured else _home("OPENCLAW_STATE_DIR", ".openclaw") / "openclaw.json"
+        )
+        return (
+            _object_at(_read(path), "plugins", "entries", "memory-powercontext", "config"),
+            "endpoint",
+            "allowInsecureHttp",
+        )
+    return {}, "server_url", "allow_insecure_http"
+
+
+def _workbuddy_mcp_url() -> str | None:
+    entry = _object_at(_read(_home("WORKBUDDY_HOME", ".workbuddy") / "mcp.json"), "mcpServers", "powercontext")
+    if not entry:
+        return None
+    raw = entry.get("url")
+    if isinstance(raw, str):
+        match = re.fullmatch(r"\$\{POWERCONTEXT_WORKBUDDY_SERVER_URL:-(.+)\}/mcp", raw)
+        if match:
+            raw = os.environ.get("POWERCONTEXT_WORKBUDDY_SERVER_URL") or match.group(1)
+    return _url(raw)
+
+
+def _check_dsh_overlays(*, profile: str | None = None) -> None:
+    home = _home("DSH_HOME", ".dsh")
+    profile = profile or os.environ.get("DSH_PROFILE", "").strip() or "web"
+    for path in (home / "cordis.patch.yml", home / "profiles" / profile / "cordis.patch.yml"):
+        try:
+            content = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            continue
+        except (OSError, UnicodeError):
+            raise ValueError(_UNKNOWN) from None
+        # DSH initProfile creates comments followed by an empty patch list.
+        # Recognize only that inert form; do not evaluate YAML tags or patches.
+        content = "\n".join(line.partition("#")[0].strip() for line in content.splitlines()).strip()
+        if content in {"", "[]"}:
+            continue
+        raise ValueError("Cannot determine PowerContext transport with unsupported DSH runtime overlays")  # noqa: TRY003
+
+
+def _selected_url(host: str, prefix: str, native_url: str | None) -> str:
+    common_url = _environment_url("POWERCONTEXT_CLIENT_SERVER_URL")
+    saved_url = load_client_settings(host).get("server_url")
+    environment_url = _environment_url(prefix + "_BASE_URL", prefix + "_SERVER_URL", prefix + "_ENDPOINT")
+    if host == "openclaw" and not (environment_url or common_url or native_url or saved_url):
+        raise ValueError("PowerContext endpoint is not configured in OpenClaw")  # noqa: TRY003
+    fallback = saved_url or _DEFAULT_URL
+    if host == "codex":
+        return _codex_url() or fallback
+    if host == "claude-code":
+        return _environment_url(prefix + "_SERVER_URL") or native_url or common_url or fallback
+    if host == "hermes":
+        return _environment_url(prefix + "_BASE_URL") or native_url or common_url or fallback
+    if host == "workbuddy":
+        return _environment_url(prefix + "_SERVER_URL") or common_url or fallback
+    return environment_url or common_url or native_url or fallback
+
+
+def validate_dsh_setup_transport() -> None:
+    """Require a verifiable DSH patch layer before changing installation state."""
+    try:
+        _check_dsh_overlays(profile="web")
+    except ValueError:
+        raise ValueError(  # noqa: TRY003
+            "Cannot verify customized DSH runtime overlays. Align the endpoint and HTTP consent manually, "
+            "or remove custom overlays before rerunning setup."
+        ) from None
+
+
+def resolve_host_transport(host: str) -> tuple[str, bool]:
+    """Resolve the effective endpoint and consent, or report an unknown native configuration.
+
+    Native HTTP consent is endpoint-bound. This is a read-only diagnostic, not
+    an HTTP guard; callers must label remote HTTP as degraded or blocked.
+    """
+    if host == "dsh":
+        _check_dsh_overlays()
+    native, url_key, consent_key = _native_settings(host)
+    native_url = _url(native[url_key]) if url_key in native else None
+    prefix = "POWERCONTEXT_" + ("CLAUDE" if host == "claude-code" else host.upper().replace("-", "_"))
+    endpoint = _url(_selected_url(host, prefix, native_url))
+    if host == "workbuddy":
+        mcp_url = _workbuddy_mcp_url()
+        if mcp_url is not None and mcp_url != endpoint:
+            raise ValueError("Cannot determine a single PowerContext transport: WorkBuddy Hook and MCP URLs differ")  # noqa: TRY003
+    _, allowed = resolve_client_transport(host, server_url=endpoint)
+    native_consent = native.get(consent_key, _MISSING)
+    if native_consent is not _MISSING:
+        if host == "openclaw" and not isinstance(native_consent, bool):
+            raise ValueError(_UNKNOWN)
+        consent = parse_client_boolean(native_consent)
+        environment_consent = any(
+            name in os.environ for name in (prefix + "_ALLOW_INSECURE_HTTP", "POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP")
+        )
+        if not environment_consent and (host in {"claude-code", "hermes"} or not consent or native_url == endpoint):
+            allowed = consent and native_url == endpoint
+    return endpoint, allowed
+
+
+__all__ = ["resolve_host_transport", "validate_dsh_setup_transport"]

--- a/src/powercontext/cli/openclaw.py
+++ b/src/powercontext/cli/openclaw.py
@@ -48,6 +48,7 @@ def install_openclaw_plugin(
     source: str,
     ref: str,
     server_url: str,
+    allow_insecure_http: bool = False,
 ) -> OpenClawSetupResult:
     """Build, install, and configure the OpenClaw plugin from one source/ref."""
 
@@ -66,6 +67,7 @@ def install_openclaw_plugin(
     configure_openclaw(
         executable=executable,
         server_url=normalized_url,
+        allow_insecure_http=allow_insecure_http,
     )
     return OpenClawSetupResult(
         plugin=OPENCLAW_PLUGIN_NAME,
@@ -233,12 +235,13 @@ def normalize_server_url(value: str) -> str:
     return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
 
 
-def configure_openclaw(*, executable: str, server_url: str) -> None:
+def configure_openclaw(*, executable: str, server_url: str, allow_insecure_http: bool = False) -> None:
     """Write plugin, memory-slot, and coding-tool allowlist configuration."""
 
     settings = [
         {"path": "plugins.entries.memory-powercontext.enabled", "value": True},
         {"path": "plugins.entries.memory-powercontext.config.endpoint", "value": server_url},
+        {"path": "plugins.entries.memory-powercontext.config.allowInsecureHttp", "value": allow_insecure_http},
         {"path": "plugins.entries.memory-powercontext.config.autoRecall", "value": True},
         {"path": "plugins.entries.memory-powercontext.config.autoCapture", "value": True},
         {"path": "plugins.entries.memory-powercontext.hooks.allowConversationAccess", "value": True},

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -34,7 +34,14 @@ from urllib.request import Request, urlopen
 import typer
 from pydantic import ValidationError
 
+from powercontext.cli.transport import (
+    add_transport_diagnostic,
+    is_remote_http,
+    prepare_setup_transport,
+    save_setup_transport,
+)
 from powercontext.client.settings import normalize_server_url
+from powercontext.client.transport_policy import resolve_client_transport
 from powercontext.http import HealthResponse, ReadinessResponse, ReadinessStatus
 from powercontext.paths import powercontext_data_dir
 from powercontext.transport import canonical_loopback_endpoint, is_loopback_host
@@ -390,6 +397,16 @@ def setup_codex(
         str,
         typer.Option(help="Git ref used for a remote marketplace source."),
     ] = DEFAULT_MARKETPLACE_REF,
+    server_url: Annotated[
+        str | None,
+        typer.Option(help="PowerContext Server URL; resolves host/common environment and saved settings."),
+    ] = None,
+    allow_insecure_http: Annotated[
+        bool | None,
+        typer.Option(
+            "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -398,7 +415,11 @@ def setup_codex(
     """Install the PowerContext Codex plugin and prepare local storage."""
 
     try:
-        result = install_codex_plugin(source=source, ref=ref)
+        transport = prepare_setup_transport(
+            "codex", server_url=server_url, allow_insecure_http=allow_insecure_http, json_output=json_output
+        )
+        result = install_codex_plugin(source=source, ref=ref, server_url=transport.server_url)
+        save_setup_transport(transport)
     except SetupError as error:
         typer.echo(str(error), err=True)
         raise typer.Exit(code=1) from error
@@ -428,13 +449,19 @@ def setup_claude_code(
         typer.Option(help="Git ref used for a remote marketplace source."),
     ] = DEFAULT_MARKETPLACE_REF,
     server_url: Annotated[
-        str,
-        typer.Option(help="PowerContext Server base URL configured for the plugin."),
-    ] = DEFAULT_CLAUDE_CODE_SERVER_URL,
+        str | None,
+        typer.Option(help="PowerContext Server URL; resolves host/common environment and saved settings."),
+    ] = None,
     capture_prompts: Annotated[
         bool,
         typer.Option(help="Capture Claude Code user prompts as ordinary Source evidence."),
     ] = True,
+    allow_insecure_http: Annotated[
+        bool | None,
+        typer.Option(
+            "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -445,12 +472,17 @@ def setup_claude_code(
     plan = _claude_setup_plan()
     _write_claude_setup_plan(plan)
     try:
+        transport = prepare_setup_transport(
+            "claude-code", server_url=server_url, allow_insecure_http=allow_insecure_http, json_output=json_output
+        )
         result = install_claude_code_plugin(
             source=source,
             ref=ref,
-            server_url=server_url,
+            server_url=transport.server_url,
+            allow_insecure_http=transport.allow_insecure_http,
             capture_prompts=capture_prompts,
         )
+        save_setup_transport(transport)
     except SetupError as error:
         typer.echo(str(error), err=True)
         raise typer.Exit(code=1) from error
@@ -474,6 +506,16 @@ def setup_dsh(
         str,
         typer.Option(help="Git ref used for a remote source."),
     ] = DEFAULT_MARKETPLACE_REF,
+    server_url: Annotated[
+        str | None,
+        typer.Option(help="PowerContext Server URL; resolves host/common environment and saved settings."),
+    ] = None,
+    allow_insecure_http: Annotated[
+        bool | None,
+        typer.Option(
+            "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -484,7 +526,11 @@ def setup_dsh(
     from powercontext.cli.dsh import install_dsh_plugin, run_dsh_diagnostics
 
     try:
+        transport = prepare_setup_transport(
+            "dsh", server_url=server_url, allow_insecure_http=allow_insecure_http, json_output=json_output
+        )
         result = install_dsh_plugin(source=source, ref=ref)
+        save_setup_transport(transport)
     except SetupError as error:
         typer.echo(str(error), err=True)
         raise typer.Exit(code=1) from error
@@ -514,9 +560,15 @@ def setup_openclaw(
         typer.Option(help="Git ref used for a remote source."),
     ] = DEFAULT_MARKETPLACE_REF,
     server_url: Annotated[
-        str,
-        typer.Option(help="PowerContext Server base URL configured for the plugin."),
-    ] = DEFAULT_OPENCLAW_SERVER_URL,
+        str | None,
+        typer.Option(help="PowerContext Server URL; resolves host/common environment and saved settings."),
+    ] = None,
+    allow_insecure_http: Annotated[
+        bool | None,
+        typer.Option(
+            "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -527,11 +579,16 @@ def setup_openclaw(
     from powercontext.cli.openclaw import install_openclaw_plugin
 
     try:
+        transport = prepare_setup_transport(
+            "openclaw", server_url=server_url, allow_insecure_http=allow_insecure_http, json_output=json_output
+        )
         result = install_openclaw_plugin(
             source=source,
             ref=ref,
-            server_url=server_url,
+            server_url=transport.server_url,
+            allow_insecure_http=transport.allow_insecure_http,
         )
+        save_setup_transport(transport)
     except SetupError as error:
         typer.echo(str(error), err=True)
         raise typer.Exit(code=1) from error
@@ -557,6 +614,16 @@ def setup_pi(
         str,
         typer.Option(help="Git ref used for a remote source."),
     ] = DEFAULT_MARKETPLACE_REF,
+    server_url: Annotated[
+        str | None,
+        typer.Option(help="PowerContext Server URL; resolves host/common environment and saved settings."),
+    ] = None,
+    allow_insecure_http: Annotated[
+        bool | None,
+        typer.Option(
+            "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -567,7 +634,11 @@ def setup_pi(
     from powercontext.cli.pi import install_pi_plugin, run_pi_diagnostics
 
     try:
+        transport = prepare_setup_transport(
+            "pi", server_url=server_url, allow_insecure_http=allow_insecure_http, json_output=json_output
+        )
         result = install_pi_plugin(source=source, ref=ref)
+        save_setup_transport(transport)
     except SetupError as error:
         typer.echo(str(error), err=True)
         raise typer.Exit(code=1) from error
@@ -596,6 +667,16 @@ def setup_opencode(
         str,
         typer.Option(help="Git ref used for a remote source."),
     ] = DEFAULT_MARKETPLACE_REF,
+    server_url: Annotated[
+        str | None,
+        typer.Option(help="PowerContext Server URL; resolves host/common environment and saved settings."),
+    ] = None,
+    allow_insecure_http: Annotated[
+        bool | None,
+        typer.Option(
+            "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -606,7 +687,11 @@ def setup_opencode(
     from powercontext.cli.opencode import install_opencode_plugin, run_opencode_diagnostics
 
     try:
+        transport = prepare_setup_transport(
+            "opencode", server_url=server_url, allow_insecure_http=allow_insecure_http, json_output=json_output
+        )
         result = install_opencode_plugin(source=source, ref=ref)
+        save_setup_transport(transport)
     except SetupError as error:
         typer.echo(str(error), err=True)
         raise typer.Exit(code=1) from error
@@ -636,6 +721,16 @@ def setup_hermes(
         str,
         typer.Option(help="Git ref used for a remote source."),
     ] = DEFAULT_MARKETPLACE_REF,
+    server_url: Annotated[
+        str | None,
+        typer.Option(help="PowerContext Server URL; resolves host/common environment and saved settings."),
+    ] = None,
+    allow_insecure_http: Annotated[
+        bool | None,
+        typer.Option(
+            "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -646,7 +741,11 @@ def setup_hermes(
     from powercontext.cli.hermes import install_hermes_plugin, run_hermes_diagnostics
 
     try:
+        transport = prepare_setup_transport(
+            "hermes", server_url=server_url, allow_insecure_http=allow_insecure_http, json_output=json_output
+        )
         result = install_hermes_plugin(source=source, ref=ref)
+        save_setup_transport(transport)
     except SetupError as error:
         typer.echo(str(error), err=True)
         raise typer.Exit(code=1) from error
@@ -689,6 +788,12 @@ def setup_select(
         bool,
         typer.Option(help="Capture Claude Code user prompts as ordinary Source evidence."),
     ] = True,
+    allow_insecure_http: Annotated[
+        bool | None,
+        typer.Option(
+            "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -705,6 +810,7 @@ def setup_select(
         server_url=server_url,
         capture_prompts=capture_prompts,
         json_output=json_output,
+        allow_insecure_http=allow_insecure_http,
     )
 
 
@@ -718,6 +824,16 @@ def setup_workbuddy(
         str,
         typer.Option(help="Git ref used for a remote source."),
     ] = DEFAULT_MARKETPLACE_REF,
+    server_url: Annotated[
+        str | None,
+        typer.Option(help="PowerContext Server URL; resolves host/common environment and saved settings."),
+    ] = None,
+    allow_insecure_http: Annotated[
+        bool | None,
+        typer.Option(
+            "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -728,7 +844,11 @@ def setup_workbuddy(
     from powercontext.cli.workbuddy import install_workbuddy_plugin, run_workbuddy_diagnostics
 
     try:
-        result = install_workbuddy_plugin(source=source, ref=ref)
+        transport = prepare_setup_transport(
+            "workbuddy", server_url=server_url, allow_insecure_http=allow_insecure_http, json_output=json_output
+        )
+        result = install_workbuddy_plugin(source=source, ref=ref, server_url=transport.server_url)
+        save_setup_transport(transport)
     except SetupError as error:
         typer.echo(str(error), err=True)
         raise typer.Exit(code=1) from error
@@ -753,12 +873,18 @@ def setup_workbuddy(
 def doctor(
     context: typer.Context,
     server_url: Annotated[
-        str,
+        str | None,
         typer.Option(
             envvar="POWERCONTEXT_CLIENT_SERVER_URL",
             help="PowerContext Server base URL.",
         ),
-    ] = "http://127.0.0.1:8000",
+    ] = None,
+    allow_insecure_http: Annotated[
+        bool | None,
+        typer.Option(
+            "--allow-insecure-http/--no-allow-insecure-http", help="Explicitly allow unencrypted remote HTTP."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Write the result as JSON."),
@@ -768,7 +894,7 @@ def doctor(
 
     if context.invoked_subcommand is not None:
         return
-    diagnostics = run_diagnostics(server_url=server_url)
+    diagnostics = run_diagnostics(server_url=server_url, allow_insecure_http=allow_insecure_http)
     _write_diagnostics(diagnostics, json_output=json_output)
     if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)
@@ -784,6 +910,7 @@ def doctor_codex(
     """Check the optional Codex CLI and PowerContext plugin."""
 
     diagnostics = run_codex_diagnostics()
+    add_transport_diagnostic(diagnostics, "codex")
     _write_diagnostics(diagnostics, json_output=json_output)
     if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)
@@ -799,6 +926,7 @@ def doctor_claude_code(
     """Check the optional Claude Code CLI and PowerContext plugin."""
 
     diagnostics = run_claude_code_diagnostics()
+    add_transport_diagnostic(diagnostics, "claude-code")
     _write_diagnostics(diagnostics, json_output=json_output)
     if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)
@@ -816,6 +944,7 @@ def doctor_dsh(
     from powercontext.cli.dsh import run_dsh_diagnostics
 
     diagnostics = run_dsh_diagnostics()
+    add_transport_diagnostic(diagnostics, "dsh")
     _write_diagnostics(diagnostics, json_output=json_output)
     if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)
@@ -834,6 +963,7 @@ def doctor_pi(
 
     diagnostics = run_pi_diagnostics()
 
+    add_transport_diagnostic(diagnostics, "pi")
     _write_diagnostics(diagnostics, json_output=json_output)
     if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)
@@ -851,6 +981,7 @@ def doctor_opencode(
     from powercontext.cli.opencode import run_opencode_diagnostics
 
     diagnostics = run_opencode_diagnostics()
+    add_transport_diagnostic(diagnostics, "opencode")
     _write_diagnostics(diagnostics, json_output=json_output)
     if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)
@@ -868,6 +999,7 @@ def doctor_hermes(
     from powercontext.cli.hermes import run_hermes_diagnostics
 
     diagnostics = run_hermes_diagnostics()
+    add_transport_diagnostic(diagnostics, "hermes")
     _write_diagnostics(diagnostics, json_output=json_output)
     if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)
@@ -885,6 +1017,7 @@ def doctor_workbuddy(
     from powercontext.cli.workbuddy import run_workbuddy_diagnostics
 
     diagnostics = run_workbuddy_diagnostics()
+    add_transport_diagnostic(diagnostics, "workbuddy")
     _write_diagnostics(diagnostics, json_output=json_output)
     if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)
@@ -902,6 +1035,7 @@ def doctor_openclaw(
     from powercontext.cli.openclaw import run_openclaw_diagnostics
 
     diagnostics = run_openclaw_diagnostics()
+    add_transport_diagnostic(diagnostics, "openclaw")
     _write_diagnostics(diagnostics, json_output=json_output)
     if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)
@@ -921,7 +1055,7 @@ def doctor_integrations(
     run_doctor_integrations(json_output=json_output)
 
 
-def install_codex_plugin(*, source: str, ref: str) -> CodexSetupResult:
+def install_codex_plugin(*, source: str, ref: str, server_url: str | None = None) -> CodexSetupResult:
     """Install the plugin from one local or Git marketplace source."""
 
     if which("codex") is None:
@@ -941,6 +1075,8 @@ def install_codex_plugin(*, source: str, ref: str) -> CodexSetupResult:
     marketplace_name = _required_string(marketplace, "marketplaceName")
 
     plugin = _run_codex_json("plugin", "add", f"{PLUGIN_NAME}@{marketplace_name}")
+    if server_url is not None:
+        _configure_codex_endpoint(marketplace_name, _required_string(plugin, "version"), server_url)
     return CodexSetupResult(
         marketplace=marketplace_name,
         plugin=_required_string(plugin, "name"),
@@ -949,18 +1085,39 @@ def install_codex_plugin(*, source: str, ref: str) -> CodexSetupResult:
     )
 
 
+def _configure_codex_endpoint(marketplace: str, plugin_version: str, server_url: str) -> None:
+    """Keep the installed native MCP URL and hook URL identical."""
+
+    if any(part in {"", ".", ".."} or "/" in part or "\\" in part for part in (marketplace, plugin_version)):
+        raise SetupError("Invalid Codex plugin cache location")  # noqa: TRY003
+    codex_home = Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))).expanduser()
+    path = codex_home / "plugins" / "cache" / marketplace / PLUGIN_NAME / plugin_version / ".mcp.json"
+    try:
+        config = json.loads(path.read_text(encoding="utf-8"))
+        entry = config["mcpServers"][PLUGIN_NAME]
+        if not isinstance(entry, dict) or entry.get("type") != "http":
+            raise ValueError("Expected an HTTP MCP server")  # noqa: TRY003, TRY301
+        entry["url"] = server_url.rstrip("/") + "/mcp"
+        _write_bytes_atomically(path, (json.dumps(config, indent=2) + "\n").encode())
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        raise SetupError(  # noqa: TRY003
+            f"Cannot configure the installed Codex MCP endpoint at {path}; rerun setup after checking the plugin cache"
+        ) from error
+
+
 def install_claude_code_plugin(
     *,
     source: str,
     ref: str,
     server_url: str,
     capture_prompts: bool,
+    allow_insecure_http: bool = False,
 ) -> ClaudeCodeSetupResult:
     """Install and verify the plugin from one local or Git marketplace source."""
 
     if which("claude") is None:
         raise SetupError.claude_unavailable()
-    server_url = _normalize_claude_server_url(server_url)
+    server_url = _normalize_claude_server_url(server_url, allow_insecure_http=allow_insecure_http)
 
     marketplace_source = _normalize_claude_marketplace_source(source, ref=ref)
     marketplaces = _run_claude_json("plugin", "marketplace", "list")
@@ -992,7 +1149,9 @@ def install_claude_code_plugin(
         plugin_added = not plugin_existed
         installed = _run_claude_json("plugin", "list")
         plugin = _require_enabled_claude_plugin(installed)
-        _configure_claude_plugin(server_url=server_url, capture_prompts=capture_prompts)
+        _configure_claude_plugin(
+            server_url=server_url, capture_prompts=capture_prompts, allow_insecure_http=allow_insecure_http
+        )
     except SetupError:
         if plugin_added:
             with suppress(SetupError):
@@ -1026,21 +1185,29 @@ def install_claude_code_plugin(
     )
 
 
-def run_diagnostics(*, server_url: str) -> dict[str, Diagnostic]:
+def run_diagnostics(*, server_url: str | None = None, allow_insecure_http: bool | None = None) -> dict[str, Diagnostic]:
     """Collect installed-environment diagnostics without changing state."""
 
     package = Diagnostic(status=DiagnosticStatus.OK, detail=f"powercontext {version('powercontext')}")
     service: dict[str, Diagnostic] = {}
     try:
-        server_url = normalize_server_url(server_url)
+        server_url, allowed = resolve_client_transport(
+            "client", server_url=server_url, allow_insecure_http=allow_insecure_http
+        )
+        server_url = normalize_server_url(server_url, allow_insecure_http=allowed)
     except ValueError as error:
         liveness = Diagnostic(status=DiagnosticStatus.FAILED, detail=str(error))
     else:
         service = _local_service_diagnostics(server_url)
+        if is_remote_http(server_url):
+            service["transport"] = Diagnostic(
+                status=DiagnosticStatus.DEGRADED,
+                detail="Insecure HTTP explicitly enabled; credentials and content are unencrypted in transit",
+            )
         liveness = _server_liveness_diagnostic(server_url)
     readiness = (
         _server_readiness_diagnostic(server_url)
-        if liveness.ok
+        if liveness.ok and server_url is not None
         else Diagnostic(
             status=DiagnosticStatus.SKIPPED,
             detail="not checked because Server liveness failed",
@@ -1341,7 +1508,7 @@ def _normalize_claude_marketplace_source(source: str, *, ref: str) -> str:
     return f"{source}#{ref}"
 
 
-def _normalize_claude_server_url(value: str) -> str:
+def _normalize_claude_server_url(value: str, *, allow_insecure_http: bool = False) -> str:
     normalized = value.strip().rstrip("/")
     parsed = urlsplit(normalized)
     if parsed.username is not None or parsed.password is not None:
@@ -1350,7 +1517,7 @@ def _normalize_claude_server_url(value: str) -> str:
         raise SetupError.claude_server_url_scheme()
     if parsed.query or parsed.fragment:
         raise SetupError.claude_server_url_suffix()
-    if parsed.scheme == "http" and not is_loopback_host(parsed.hostname):
+    if parsed.scheme == "http" and not is_loopback_host(parsed.hostname) and not allow_insecure_http:
         raise SetupError.claude_server_url_transport()
     path = parsed.path.rstrip("/")
     if path.endswith("/mcp"):
@@ -1460,7 +1627,7 @@ def _snapshot_claude_settings() -> bytes | None:
         return None
 
 
-def _configure_claude_plugin(*, server_url: str, capture_prompts: bool) -> None:
+def _configure_claude_plugin(*, server_url: str, capture_prompts: bool, allow_insecure_http: bool = False) -> None:
     """Merge non-sensitive plugin options unsupported by the Claude install CLI."""
 
     settings_file = _claude_config_dir() / "settings.json"
@@ -1486,6 +1653,7 @@ def _configure_claude_plugin(*, server_url: str, capture_prompts: bool) -> None:
     options.update({
         "server_url": server_url,
         "capture_prompts": capture_prompts,
+        "allow_insecure_http": allow_insecure_http,
     })
     try:
         _write_bytes_atomically(settings_file, (json.dumps(settings, indent=2) + "\n").encode())

--- a/src/powercontext/cli/transport.py
+++ b/src/powercontext/cli/transport.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared setup consent and non-secret per-host connection persistence."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+import typer
+
+from powercontext.client.transport_policy import (
+    client_config_file,
+    load_client_settings,
+    parse_client_boolean,
+    resolve_client_transport,
+)
+from powercontext.transport import is_loopback_host
+
+if TYPE_CHECKING:
+    from powercontext.cli.system import Diagnostic
+
+
+@dataclass(frozen=True)
+class SetupTransport:
+    host: str
+    server_url: str
+    allow_insecure_http: bool
+
+
+def is_remote_http(server_url: str) -> bool:
+    """Classify plaintext endpoints without resolving DNS or making a request."""
+
+    parsed = urlsplit(server_url)
+    return parsed.scheme == "http" and not is_loopback_host(parsed.hostname)
+
+
+def prepare_setup_transport(
+    host: str,
+    *,
+    server_url: str | None = None,
+    allow_insecure_http: bool | None = None,
+    json_output: bool = False,
+) -> SetupTransport:
+    """Resolve and confirm the endpoint before any installation side effects."""
+
+    from powercontext.cli.system import SetupError
+
+    try:
+        if host == "dsh":
+            from powercontext.cli.native_transport import validate_dsh_setup_transport
+
+            validate_dsh_setup_transport()
+        prefix = "POWERCONTEXT_" + ("CLAUDE" if host == "claude-code" else host.upper().replace("-", "_")) + "_"
+        has_environment_url = any(
+            os.environ.get(key)
+            for key in (
+                prefix + "BASE_URL",
+                prefix + "SERVER_URL",
+                prefix + "ENDPOINT",
+                "POWERCONTEXT_CLIENT_SERVER_URL",
+            )
+        )
+        if server_url is None and not has_environment_url and not load_client_settings(host).get("server_url"):
+            server_url = existing_native_endpoint(host)
+        endpoint, allowed = resolve_client_transport(
+            host, server_url=server_url, allow_insecure_http=allow_insecure_http
+        )
+        environment_consent = next(
+            (
+                os.environ[key]
+                for key in (prefix + "ALLOW_INSECURE_HTTP", "POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP")
+                if key in os.environ
+            ),
+            None,
+        )
+        environment_refused = environment_consent is not None and not parse_client_boolean(environment_consent)
+    except ValueError as error:
+        raise SetupError(str(error)) from error
+    endpoint = endpoint.removesuffix("/mcp").rstrip("/")
+    if is_remote_http(endpoint):
+        if not allowed:
+            if (
+                allow_insecure_http is None
+                and not environment_refused
+                and not json_output
+                and sys.stdin.isatty()
+                and typer.confirm(
+                    f"{host}: {endpoint} uses unencrypted HTTP. Tokens and conversation content can be "
+                    "read or modified in transit. Allow this endpoint?",
+                    default=False,
+                    err=True,
+                )
+            ):
+                allowed = True
+            else:
+                raise SetupError(  # noqa: TRY003
+                    "Remote HTTP requires explicit consent. Prefer HTTPS or an SSH tunnel, or use "
+                    "--allow-insecure-http (POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP=true)."
+                )
+        typer.echo(
+            f"WARNING: {host} uses unencrypted HTTP at {endpoint}; credentials and content are not "
+            "protected in transit. TLS verification and Server authentication remain unchanged.",
+            err=True,
+        )
+    return SetupTransport(host, endpoint, allowed)
+
+
+def existing_native_endpoint(host: str) -> str | None:
+    """Preserve existing native endpoints when setup has no connection override."""
+
+    if host != "workbuddy":
+        return None
+    from powercontext.cli.workbuddy import workbuddy_home
+
+    path = workbuddy_home() / "mcp.json"
+    try:
+        config = json.loads(path.read_text(encoding="utf-8"))
+        value = config.get("mcpServers", {}).get("powercontext", {}).get("url")
+        if isinstance(value, str):
+            match = re.fullmatch(r"\$\{POWERCONTEXT_WORKBUDDY_SERVER_URL:-(.+)\}/mcp", value)
+            return match.group(1) if match else value
+    except (OSError, ValueError, AttributeError):
+        pass
+    return None
+
+
+def save_setup_transport(settings: SetupTransport) -> None:
+    """Save endpoint-bound consent, rolling back paired native writes on failure."""
+
+    from powercontext.cli.system import SetupError, _write_bytes_atomically
+
+    path = client_config_file()
+    completed: list[tuple[Path, bytes | None]] = []
+    try:
+        config: Any = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {"version": 1, "hosts": {}}
+        if not isinstance(config, dict) or config.get("version") != 1 or not isinstance(config.get("hosts"), dict):
+            raise ValueError("Client configuration must have version 1 and a hosts object")  # noqa: TRY003, TRY301
+        config["hosts"][settings.host] = {
+            "server_url": settings.server_url,
+            "allow_insecure_http": settings.allow_insecure_http,
+        }
+        updates: list[tuple[Path, dict[str, Any]]] = []
+        if settings.host == "hermes":
+            native_path = hermes_config_file()
+            native = json.loads(native_path.read_text(encoding="utf-8")) if native_path.exists() else {}
+            if not isinstance(native, dict):
+                raise ValueError("Hermes client configuration must be an object")  # noqa: TRY003, TRY301
+            native.update(base_url=settings.server_url, allow_insecure_http=settings.allow_insecure_http)
+            updates.append((native_path, native))
+        updates.append((path, config))
+        # Validate every destination before writing either half of a native/shared pair.
+        writes = [
+            (destination, destination.read_bytes() if destination.exists() else None, payload)
+            for destination, payload in updates
+        ]
+        for destination, snapshot, payload in writes:
+            _write_bytes_atomically(destination, (json.dumps(payload, indent=2) + "\n").encode())
+            completed.append((destination, snapshot))
+    except (OSError, ValueError) as error:
+        for destination, snapshot in reversed(completed):
+            try:
+                if snapshot is None:
+                    destination.unlink(missing_ok=True)
+                else:
+                    _write_bytes_atomically(destination, snapshot)
+            except OSError:
+                typer.echo(
+                    f"WARNING: could not restore {destination}; check its configuration before restarting.", err=True
+                )
+        raise SetupError(f"Could not save PowerContext Client settings at {path}") from error  # noqa: TRY003
+
+
+def hermes_config_file() -> Path:
+    """Locate the same native configuration file used by the Hermes provider."""
+
+    override = os.environ.get("POWERCONTEXT_HERMES_CONFIG")
+    if override:
+        return Path(override)
+    return Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "powercontext" / "config.json"
+
+
+def transport_diagnostic(host: str) -> Diagnostic:
+    """Report explicitly insecure transport as degraded rather than silently green."""
+
+    from powercontext.cli.native_transport import resolve_host_transport
+    from powercontext.cli.system import Diagnostic, DiagnosticStatus
+
+    try:
+        endpoint, allowed = resolve_host_transport(host)
+    except ValueError as error:
+        return Diagnostic(status=DiagnosticStatus.FAILED, detail=str(error))
+    if is_remote_http(endpoint):
+        return Diagnostic(
+            status=DiagnosticStatus.DEGRADED if allowed else DiagnosticStatus.FAILED,
+            detail=(
+                f"{endpoint}: insecure HTTP explicitly enabled; credentials and content are unencrypted"
+                if allowed
+                else f"{endpoint}: remote HTTP blocked; use HTTPS or explicitly allow insecure HTTP"
+            ),
+        )
+    return Diagnostic(status=DiagnosticStatus.OK, detail=endpoint)
+
+
+def add_transport_diagnostic(diagnostics: dict[str, Diagnostic], host: str) -> None:
+    """Append policy problems without changing healthy installation reports."""
+
+    diagnostic = transport_diagnostic(host)
+    if not diagnostic.ok:
+        diagnostics["transport"] = diagnostic

--- a/src/powercontext/cli/workbuddy.py
+++ b/src/powercontext/cli/workbuddy.py
@@ -58,6 +58,7 @@ WORKBUDDY_SCOPE_RESOLVER = "powercontext_scope_binding.py"
 WORKBUDDY_HOOK_MODULES = (
     "workbuddy_powercontext_hook.py",
     "workbuddy_settings.py",
+    "powercontext_client_config.py",
     "prepared_context.py",
 )
 WORKBUDDY_SCRIPT_MODULES = ("__init__.py", "workspace_scope.py")
@@ -80,7 +81,7 @@ class WorkBuddySetupResult:
     data_dir: str
 
 
-def install_workbuddy_plugin(*, source: str, ref: str) -> WorkBuddySetupResult:
+def install_workbuddy_plugin(*, source: str, ref: str, server_url: str | None = None) -> WorkBuddySetupResult:
     """Install the PowerContext hooks, MCP server, and Skill into WorkBuddy's user directory."""
 
     data_dir = powercontext_data_dir()
@@ -118,7 +119,7 @@ def install_workbuddy_plugin(*, source: str, ref: str) -> WorkBuddySetupResult:
     try:
         _install_hook_files(plugin_dir, hooks_dir)
         _merge_workbuddy_settings(settings_file, hooks_dir)
-        _merge_workbuddy_mcp(mcp_file)
+        _merge_workbuddy_mcp(mcp_file, server_url=server_url)
         _install_workbuddy_skill(plugin_dir, skills_dir, hooks_dir)
     except BaseException:
         _restore_file(settings_file, settings_snapshot)
@@ -249,7 +250,7 @@ def _merge_workbuddy_settings(settings_file: Path, hooks_dir: Path) -> None:
         raise SetupError.workbuddy_settings_write(settings_file, error) from error
 
 
-def _merge_workbuddy_mcp(mcp_file: Path) -> None:
+def _merge_workbuddy_mcp(mcp_file: Path, *, server_url: str | None = None) -> None:
     """Register the PowerContext MCP server without dropping existing servers."""
 
     config = _load_json_object(
@@ -264,6 +265,8 @@ def _merge_workbuddy_mcp(mcp_file: Path) -> None:
 
     existing = servers_dict.get(WORKBUDDY_PLUGIN_NAME)
     entry = _workbuddy_mcp_entry(existing)
+    if server_url is not None and entry.get("url") != server_url.rstrip("/") + "/mcp":
+        entry["url"] = f"${{{WORKBUDDY_SERVER_URL_ENV}:-{server_url}}}/mcp"
     if isinstance(existing, dict):
         servers_dict[WORKBUDDY_PLUGIN_NAME] = {**cast(dict[str, Any], existing), **entry}
     else:

--- a/src/powercontext/client/cli.py
+++ b/src/powercontext/client/cli.py
@@ -173,6 +173,7 @@ class _ClientOptions:
     api_token: SecretStr | None
     timeout: float
     json_output: bool
+    allow_insecure_http: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -180,6 +181,7 @@ class _ClientOverrides:
     server_url: str | None = None
     timeout: float | None = None
     json_output: bool = False
+    allow_insecure_http: bool | None = None
 
 
 def configure_client(
@@ -188,6 +190,7 @@ def configure_client(
     server_url: str | None,
     timeout: float | None,
     json_output: bool,
+    allow_insecure_http: bool | None = None,
 ) -> None:
     """Store lazy Server connection overrides for content commands."""
 
@@ -195,6 +198,7 @@ def configure_client(
         server_url=server_url,
         timeout=timeout,
         json_output=json_output,
+        allow_insecure_http=allow_insecure_http,
     )
 
 
@@ -822,7 +826,9 @@ async def _create_remote_skill_target(
     options = _options(context)
     token = None if options.api_token is None else options.api_token.get_secret_value()
     try:
-        async with PowerContextClient(options.server_url, token=token, timeout=options.timeout) as client:
+        async with PowerContextClient(
+            options.server_url, token=token, timeout=options.timeout, allow_insecure_http=options.allow_insecure_http
+        ) as client:
             enrollment = await client.create_remote_skill_target(
                 CreateRemoteSkillTargetRequest(scope_id=scope_id, agent_kind=agent_kind, display_name=name)
             )
@@ -976,7 +982,9 @@ async def _enroll_remote_skill_target(
     watch_interval: float,
     allow_insecure_http: bool,
 ) -> None:
-    options = _options(context)
+    # Enrollment applies its own endpoint-bound consent check below before it
+    # sends an enrollment code or creates a Receiver configuration.
+    options = _options(context, allow_insecure_http=True)
     try:
         insecure_http = require_remote_skill_server_url(
             options.server_url,
@@ -1237,14 +1245,20 @@ def _read_receiver_config(path: Path) -> RemoteSkillReceiverConfig:
     return RemoteSkillReceiverConfig.model_validate(value)
 
 
-def _options(context: typer.Context) -> _ClientOptions:
+def _options(context: typer.Context, *, allow_insecure_http: bool | None = None) -> _ClientOptions:
     overrides = context.meta.get("powercontext.client.overrides", _ClientOverrides())
-    settings = ClientSettings()
+    if allow_insecure_http is None:
+        allow_insecure_http = overrides.allow_insecure_http
+    settings = ClientSettings(
+        **({} if overrides.server_url is None else {"server_url": overrides.server_url}),
+        **({} if allow_insecure_http is None else {"allow_insecure_http": allow_insecure_http}),
+    )
     return _ClientOptions(
-        server_url=settings.server_url if overrides.server_url is None else overrides.server_url,
+        server_url=settings.server_url,
         api_token=settings.api_token,
         timeout=settings.timeout if overrides.timeout is None else overrides.timeout,
         json_output=overrides.json_output,
+        allow_insecure_http=settings.allow_insecure_http,
     )
 
 
@@ -1252,7 +1266,9 @@ async def _execute(context: typer.Context, operation: _ClientOperation) -> None:
     options = _options(context)
     try:
         token = None if options.api_token is None else options.api_token.get_secret_value()
-        async with PowerContextClient(options.server_url, token=token, timeout=options.timeout) as client:
+        async with PowerContextClient(
+            options.server_url, token=token, timeout=options.timeout, allow_insecure_http=options.allow_insecure_http
+        ) as client:
             response = await operation(client)
     except ClientError as exc:
         typer.echo(_error_message(exc), err=True)
@@ -1402,7 +1418,9 @@ async def _export_managed_skill(
     options = _options(context)
     try:
         token = None if options.api_token is None else options.api_token.get_secret_value()
-        async with PowerContextClient(options.server_url, token=token, timeout=options.timeout) as client:
+        async with PowerContextClient(
+            options.server_url, token=token, timeout=options.timeout, allow_insecure_http=options.allow_insecure_http
+        ) as client:
             response = await client.get_skill(request)
             if response.content.package is None:
                 exported = export_skill(

--- a/src/powercontext/client/client.py
+++ b/src/powercontext/client/client.py
@@ -28,6 +28,7 @@ from pydantic import TypeAdapter, ValidationError
 from powercontext.client.errors import InvalidResponseError, TransportError, server_response_error
 from powercontext.client.tags import ArtifactTagSetResponse
 from powercontext.client.tracing import ClientSpan
+from powercontext.client.transport_policy import resolve_client_transport
 from powercontext.http import (
     AccessAuditPage,
     AccessBinding,
@@ -310,15 +311,17 @@ class PowerContextClient:
 
     def __init__(
         self,
-        base_url: str,
+        base_url: str | None = None,
         *,
         token: str | None = None,
         timeout: float = 10.0,
         http_client: httpx.AsyncClient | None = None,
         trust_transport_security: bool = False,
-        allow_insecure_http: bool = False,
+        allow_insecure_http: bool | None = None,
     ) -> None:
-        self._base_url = base_url.rstrip("/")
+        self._base_url, allow_insecure_http = resolve_client_transport(
+            "client", server_url=base_url, allow_insecure_http=allow_insecure_http
+        )
         # Plaintext HTTP is only trusted on loopback -- for *any* request, not just an authenticated
         # one. The request body itself carries Memory content, so a missing bearer token does not make
         # an unencrypted non-loopback request safe. When this facade opens the transport itself,
@@ -330,8 +333,7 @@ class PowerContextClient:
         # evidence of safety: the guard stays on for caller-supplied transports too, and a caller that
         # knows its transport is secure must say so explicitly via ``trust_transport_security`` rather
         # than have safety inferred from the argument being set. ``allow_insecure_http`` is the
-        # separate, explicit cleartext escape hatch used by a remote Skill Receiver after its own
-        # protected-network consent check; it does not claim that the transport is secure.
+        # separate, explicit cleartext opt-in; it does not claim that the transport is secure.
         transport_trusted = http_client is not None and trust_transport_security
         if not transport_trusted and not allow_insecure_http and is_plaintext_non_loopback(self._base_url):
             raise ValueError("refusing to send requests over unencrypted non-loopback HTTP")  # noqa: TRY003

--- a/src/powercontext/client/settings.py
+++ b/src/powercontext/client/settings.py
@@ -16,34 +16,25 @@
 
 from __future__ import annotations
 
-from urllib.parse import urlsplit
+from typing import ClassVar, Self
 
-from pydantic import Field, HttpUrl, SecretStr, TypeAdapter, ValidationError, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field, SecretStr, model_validator
+from pydantic_settings import SettingsConfigDict
 
+from powercontext.client.transport_policy import ClientTransportSettings, normalize_client_url
 from powercontext.transport import is_plaintext_non_loopback
 
-_HTTP_URL = TypeAdapter(HttpUrl)
 
-
-def normalize_server_url(value: str) -> str:
+def normalize_server_url(value: str, *, allow_insecure_http: bool = False) -> str:
     """Validate and normalize a Server URL for outbound Client and CLI requests."""
 
-    try:
-        normalized = str(_HTTP_URL.validate_python(value)).rstrip("/")
-    except ValidationError as error:
-        raise ValueError("PowerContext Server URL must be a valid HTTP or HTTPS URL") from error  # noqa: TRY003
-    parsed = urlsplit(normalized)
-    if parsed.username is not None or parsed.password is not None:
-        raise ValueError("PowerContext Server URL must not contain credentials")  # noqa: TRY003
-    if parsed.query or parsed.fragment:
-        raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
-    if is_plaintext_non_loopback(normalized):
+    normalized = normalize_client_url(value)
+    if not allow_insecure_http and is_plaintext_non_loopback(normalized):
         raise ValueError("Unencrypted PowerContext Server URLs must be loopback addresses")  # noqa: TRY003
     return normalized
 
 
-class ClientSettings(BaseSettings):
+class ClientSettings(ClientTransportSettings):
     """Configuration for Client CLI requests."""
 
     model_config = SettingsConfigDict(
@@ -52,14 +43,15 @@ class ClientSettings(BaseSettings):
         hide_input_in_errors=True,
     )
 
+    transport_url_field: ClassVar[str] = "server_url"
     server_url: str = "http://127.0.0.1:8000"
     api_token: SecretStr | None = Field(default=None, repr=False)
     timeout: float = Field(default=10.0, gt=0)
 
-    @field_validator("server_url")
-    @classmethod
-    def validate_server_url(cls, value: str) -> str:
-        return normalize_server_url(value)
+    @model_validator(mode="after")
+    def validate_server_url(self) -> Self:
+        self.server_url = normalize_server_url(self.server_url, allow_insecure_http=self.allow_insecure_http)
+        return self
 
 
 __all__ = ["ClientSettings", "normalize_server_url"]

--- a/src/powercontext/client/transport_policy.py
+++ b/src/powercontext/client/transport_policy.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Resolve non-secret Client connection settings and endpoint-bound HTTP consent."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, ClassVar
+from urllib.parse import urlsplit
+
+from pydantic import HttpUrl, ModelWrapValidatorHandler, PrivateAttr, TypeAdapter, ValidationError, model_validator
+from pydantic_settings import BaseSettings, InitSettingsSource, PydanticBaseSettingsSource
+from typing_extensions import override
+
+_HTTP_URL = TypeAdapter(HttpUrl)
+_DEFAULT_SERVER_URL = "http://127.0.0.1:8000"
+
+
+def client_config_file() -> Path:
+    """Return the shared, non-secret host settings file."""
+
+    override = os.environ.get("POWERCONTEXT_CLIENT_CONFIG_FILE")
+    return Path(override).expanduser() if override else Path.home() / ".config" / "powercontext" / "clients.json"
+
+
+def normalize_client_url(value: str) -> str:
+    """Validate an HTTP(S) endpoint without deciding whether plaintext is allowed."""
+
+    try:
+        normalized = str(_HTTP_URL.validate_python(value)).rstrip("/")
+    except ValidationError as error:
+        raise ValueError("PowerContext Server URL must be a valid HTTP or HTTPS URL") from error  # noqa: TRY003
+    parsed = urlsplit(normalized)
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("PowerContext Server URL must not contain credentials")  # noqa: TRY003
+    if parsed.query or parsed.fragment:
+        raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
+    return normalized
+
+
+def _endpoint(value: str) -> str:
+    return normalize_client_url(value).removesuffix("/mcp").rstrip("/")
+
+
+def parse_client_boolean(value: object) -> bool:
+    """Parse an explicit boolean or a conventional environment boolean string."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.strip().lower() in {"1", "true", "yes", "on"}:
+            return True
+        if value.strip().lower() in {"0", "false", "no", "off"}:
+            return False
+    raise ValueError("PowerContext allow_insecure_http must be a boolean (true/false, 1/0, yes/no, on/off)")  # noqa: TRY003
+
+
+def load_client_settings(host: str) -> dict[str, Any]:
+    """Read one host's saved endpoint and consent; credentials are never returned."""
+
+    try:
+        raw = json.loads(client_config_file().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as error:
+        raise ValueError("Cannot read PowerContext Client configuration") from error  # noqa: TRY003
+    if (
+        not isinstance(raw, dict)
+        or type(raw.get("version")) is not int
+        or raw["version"] != 1
+        or not isinstance(raw.get("hosts"), dict)
+    ):
+        raise ValueError("PowerContext Client configuration must have version 1 and a hosts object")  # noqa: TRY003
+    saved = raw["hosts"].get(host, {})
+    if not isinstance(saved, dict):
+        raise ValueError("PowerContext Client host configuration must be an object")  # noqa: TRY003, TRY004
+    result: dict[str, Any] = {}
+    if "server_url" in saved:
+        result["server_url"] = normalize_client_url(saved["server_url"])
+    if "allow_insecure_http" in saved:
+        if not isinstance(saved["allow_insecure_http"], bool):
+            raise ValueError("Saved PowerContext allow_insecure_http must be a JSON boolean")  # noqa: TRY003
+        result["allow_insecure_http"] = saved["allow_insecure_http"]
+    return result
+
+
+def _prefix(host: str) -> str:
+    host = {"claude-code": "claude"}.get(host, host)
+    return "POWERCONTEXT_" + host.upper().replace("-", "_") + "_"
+
+
+def _environment_consent(host: str) -> str | None:
+    for key in (_prefix(host) + "ALLOW_INSECURE_HTTP", "POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP"):
+        if key in os.environ:
+            return os.environ[key]
+    return None
+
+
+def resolve_client_transport(
+    host: str,
+    *,
+    server_url: str | None = None,
+    allow_insecure_http: bool | None = None,
+) -> tuple[str, bool]:
+    """Resolve constructor, host environment, common environment, then saved settings.
+
+    This validates URL syntax and consent values. The caller applies the plaintext
+    guard so a separately vouched custom transport can retain its own security policy.
+    """
+
+    saved = load_client_settings(host)
+    if server_url is None:
+        keys = [_prefix(host) + "BASE_URL", _prefix(host) + "SERVER_URL"]
+        if host in {"dsh", "pi", "opencode", "openclaw"}:
+            keys.append(_prefix(host) + "ENDPOINT")
+        keys.append("POWERCONTEXT_CLIENT_SERVER_URL")
+        for key in keys:
+            if os.environ.get(key):
+                server_url = os.environ[key]
+                break
+    normalized = normalize_client_url(
+        server_url if server_url is not None else saved.get("server_url", _DEFAULT_SERVER_URL)
+    )
+    if allow_insecure_http is not None:
+        return normalized, parse_client_boolean(allow_insecure_http)
+    environment = _environment_consent(host)
+    if environment is not None:
+        return normalized, parse_client_boolean(environment)
+    if saved.get("server_url") and _endpoint(normalized) == _endpoint(saved["server_url"]):
+        return normalized, saved.get("allow_insecure_http", False)
+    return normalized, False
+
+
+class ClientTransportSettings(BaseSettings):
+    """Shared settings resolution retaining the endpoint attached to saved consent."""
+
+    transport_host: ClassVar[str] = "client"
+    transport_url_field: ClassVar[str] = "base_url"
+    allow_insecure_http: bool = False
+    _saved_consent_endpoint: str | None = PrivateAttr(default=None)
+
+    @classmethod
+    @override
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        # Preserve each host's precedence for unrelated settings while keeping
+        # explicitly provided transport values ahead of its environment source.
+        transport_values = {
+            key: value
+            for key, value in init_settings().items()
+            if key in {cls.transport_url_field, "allow_insecure_http"}
+        }
+        return (
+            InitSettingsSource(settings_cls, init_kwargs=transport_values),
+            *super().settings_customise_sources(
+                settings_cls, init_settings, env_settings, dotenv_settings, file_secret_settings
+            ),
+        )
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def resolve_transport_settings(cls, values: Any, handler: ModelWrapValidatorHandler[Any]) -> Any:
+        if not isinstance(values, dict):
+            return handler(values)
+        explicit_consent = values.get("allow_insecure_http")
+        server_url, allowed = resolve_client_transport(
+            cls.transport_host,
+            server_url=values.get(cls.transport_url_field),
+            allow_insecure_http=None if explicit_consent is None else parse_client_boolean(explicit_consent),
+        )
+        resolved = handler({**values, cls.transport_url_field: server_url, "allow_insecure_http": allowed})
+        if allowed and explicit_consent is None and _environment_consent(cls.transport_host) is None:
+            resolved._saved_consent_endpoint = _endpoint(server_url)
+        return resolved
+
+    def resolve_transport(
+        self, *, server_url: str | None = None, allow_insecure_http: bool | None = None
+    ) -> tuple[str, bool]:
+        """Apply invocation overrides without transferring saved consent to a new endpoint."""
+
+        normalized = normalize_client_url(
+            server_url if server_url is not None else getattr(self, self.transport_url_field)
+        )
+        allowed = self.allow_insecure_http if allow_insecure_http is None else parse_client_boolean(allow_insecure_http)
+        if (
+            allow_insecure_http is None
+            and self._saved_consent_endpoint is not None
+            and _endpoint(normalized) != self._saved_consent_endpoint
+        ):
+            allowed = False
+        return normalized, allowed
+
+
+__all__ = [
+    "ClientTransportSettings",
+    "client_config_file",
+    "load_client_settings",
+    "normalize_client_url",
+    "parse_client_boolean",
+    "resolve_client_transport",
+]

--- a/src/powercontext/transport.py
+++ b/src/powercontext/transport.py
@@ -16,9 +16,10 @@
 
 Every surface that opens or configures an HTTP connection to a Server -- the
 Python Client, the CLI, and the Agent integrations -- follows the same rule:
-plaintext HTTP is only trusted on a loopback address. Bearer credentials must
-never leave the machine over an unencrypted connection, and an unauthenticated
-Server must not bind to a routable address without an explicit opt-in.
+plaintext HTTP is accepted on loopback by default. A Client may explicitly opt
+into plaintext on another address; this does not disable HTTPS certificate
+verification. An unauthenticated Server must not bind to a routable address
+without its separate explicit opt-in.
 """
 
 from __future__ import annotations

--- a/tests/claude_code_plugin/test_contract.py
+++ b/tests/claude_code_plugin/test_contract.py
@@ -137,6 +137,23 @@ def test_environment_override_controls_prompt_capture(
     assert settings_module.ClaudeCodePluginSettings.from_environment().capture_prompts is False
 
 
+def test_saved_plugin_http_option_only_authorizes_its_own_endpoint(settings_module, monkeypatch, tmp_path):
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(tmp_path / "clients.json"))
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_SERVER_URL", "http://memory.example:8000")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_ALLOW_INSECURE_HTTP", "true")
+    assert settings_module.ClaudeCodePluginSettings.from_environment().allow_insecure_http is True
+
+    monkeypatch.setenv("POWERCONTEXT_CLAUDE_SERVER_URL", "http://another.example:8000")
+    with pytest.raises(ValueError):
+        settings_module.ClaudeCodePluginSettings.from_environment()
+
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", "true")
+    assert settings_module.ClaudeCodePluginSettings.from_environment().server_url == "http://another.example:8000"
+    monkeypatch.setenv("POWERCONTEXT_CLAUDE_ALLOW_INSECURE_HTTP", "false")
+    with pytest.raises(ValueError):
+        settings_module.ClaudeCodePluginSettings.from_environment()
+
+
 def test_claude_integration_does_not_embed_machine_specific_windows_paths() -> None:
     roots = (
         REPOSITORY_ROOT / ".claude-plugin",

--- a/tests/codex_plugin/conftest.py
+++ b/tests/codex_plugin/conftest.py
@@ -49,7 +49,8 @@ def isolated_diagnostic_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
 
 
 @pytest.fixture
-def settings_module() -> ModuleType:
+def settings_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    monkeypatch.syspath_prepend(str(PLUGIN_ROOT))
     return _load_module("powercontext_codex_settings", PLUGIN_ROOT / "settings.py")
 
 

--- a/tests/codex_plugin/test_client_transport.py
+++ b/tests/codex_plugin/test_client_transport.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transport policy at independently installed Python plugin entry points."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+HOSTS = {
+    "codex": ("settings.py", "CodexPluginSettings", "CODEX"),
+    "claude-code": ("claude_code_settings.py", "ClaudeCodePluginSettings", "CLAUDE"),
+    "workbuddy": ("hooks/workbuddy_settings.py", "WorkBuddyPluginSettings", "WORKBUDDY"),
+    "hermes": ("__init__.py", "PowerContextClient", "HERMES"),
+}
+
+
+@pytest.fixture(params=HOSTS)
+def plugin(request, monkeypatch, tmp_path):
+    host = request.param
+    filename, class_name, prefix = HOSTS[host]
+    for key in os.environ:
+        if key.startswith(("POWERCONTEXT_", "CLAUDE_PLUGIN_OPTION_")):
+            monkeypatch.delenv(key)
+    config_path = tmp_path / "clients.json"
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(config_path))
+    plugin_path = ROOT / "integrations" / host / "plugins" / "powercontext"
+    monkeypatch.syspath_prepend(str(plugin_path))
+    monkeypatch.syspath_prepend(str((plugin_path / filename).parent))
+    name = f"transport_test_{prefix.lower()}"
+    spec = importlib.util.spec_from_file_location(name, plugin_path / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    constructor = getattr(module, class_name)
+
+    def create(url="http://memory.example:8000", **kwargs):
+        if host == "codex":
+            mcp_path = tmp_path / ".mcp.json"
+            value = json.loads((plugin_path / ".mcp.json").read_text())
+            value["mcpServers"]["powercontext"]["url"] = url.rstrip("/").removesuffix("/mcp") + "/mcp"
+            mcp_path.write_text(json.dumps(value))
+            monkeypatch.setattr(module, "_MCP_CONFIGURATION_PATH", mcp_path)
+            return constructor(**kwargs)
+        if host == "hermes":
+            return constructor(url, **kwargs)
+        return constructor(server_url=url, **kwargs)
+
+    def save(url="http://memory.example:8000/mcp/", consent=True):
+        config_path.write_text(
+            json.dumps({"version": 1, "hosts": {host: {"server_url": url, "allow_insecure_http": consent}}})
+        )
+
+    return host, prefix, constructor, create, save
+
+
+def test_remote_http_needs_explicit_consent(plugin):
+    _host, _prefix, _constructor, create, _save = plugin
+    with pytest.raises(ValueError):
+        create()
+    settings = create(allow_insecure_http=True)
+    assert settings.allow_insecure_http is True
+
+
+def test_common_environment_allows_http_and_host_false_overrides_it(plugin, monkeypatch):
+    _host, prefix, _constructor, create, _save = plugin
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", "true")
+    assert create().allow_insecure_http is True
+    monkeypatch.setenv(f"POWERCONTEXT_{prefix}_ALLOW_INSECURE_HTTP", "false")
+    with pytest.raises(ValueError):
+        create()
+    assert create(allow_insecure_http=True).allow_insecure_http is True
+
+
+def test_explicit_false_overrides_environment_consent(plugin, monkeypatch):
+    _host, prefix, _constructor, create, _save = plugin
+    monkeypatch.setenv(f"POWERCONTEXT_{prefix}_ALLOW_INSECURE_HTTP", "true")
+    with pytest.raises(ValueError):
+        create(allow_insecure_http=False)
+
+
+@pytest.mark.parametrize("value", ["perhaps", "", "2"])
+def test_invalid_transport_boolean_is_rejected_even_for_https(plugin, monkeypatch, value):
+    _host, prefix, _constructor, create, _save = plugin
+    monkeypatch.setenv(f"POWERCONTEXT_{prefix}_ALLOW_INSECURE_HTTP", value)
+    with pytest.raises(ValueError, match="bool"):
+        create("https://memory.example")
+
+
+def test_saved_consent_is_bound_to_the_normalized_server_endpoint(plugin):
+    _host, _prefix, _constructor, create, save = plugin
+    save()
+    assert create("http://memory.example:8000/").allow_insecure_http is True
+    with pytest.raises(ValueError):
+        create("http://another.example:8000")
+    with pytest.raises(ValueError):
+        create("http://memory.example:8000/another")
+
+
+def test_environment_false_overrides_saved_consent(plugin, monkeypatch):
+    _host, _prefix, _constructor, create, save = plugin
+    save()
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", "false")
+    with pytest.raises(ValueError):
+        create()
+
+
+def test_saved_transport_boolean_requires_a_json_boolean(plugin):
+    _host, _prefix, _constructor, create, save = plugin
+    save(consent="false")
+    with pytest.raises(ValueError, match="bool"):
+        create("https://memory.example")
+
+
+@pytest.mark.parametrize("url", ["http://localhost:8000", "http://127.23.4.5:8000", "http://[::1]:8000"])
+def test_loopback_stays_available_without_consent(plugin, url):
+    _host, _prefix, _constructor, create, _save = plugin
+    assert create(url).allow_insecure_http is False
+
+
+def test_nonloopback_addresses_are_not_accepted_by_string_prefix(plugin):
+    _host, _prefix, _constructor, create, _save = plugin
+    for url in ("http://localhost.example", "http://127.0.0.1.example", "http://[::]"):
+        with pytest.raises(ValueError):
+            create(url)
+
+
+@pytest.mark.parametrize("url", ["http://user:secret@memory.example", "http://memory.example?token=secret"])
+def test_opt_in_does_not_allow_credentials_or_ambiguous_urls(plugin, url):
+    _host, _prefix, _constructor, create, _save = plugin
+    with pytest.raises(ValueError):
+        create(url, allow_insecure_http=True)
+
+
+def test_environment_loader_uses_the_persisted_url(plugin):
+    host, _prefix, constructor, _create, save = plugin
+    if host not in {"claude-code", "workbuddy"}:
+        pytest.skip("Codex uses its MCP file; Hermes uses its provider configuration")
+    save()
+    settings = constructor.from_environment()
+    assert settings.server_url == "http://memory.example:8000"
+    assert settings.allow_insecure_http is True
+
+
+def test_environment_endpoint_change_does_not_reuse_saved_consent(plugin, monkeypatch):
+    host, prefix, constructor, _create, save = plugin
+    if host not in {"claude-code", "workbuddy"}:
+        pytest.skip("Endpoint source is tested through the constructor")
+    save()
+    monkeypatch.setenv(f"POWERCONTEXT_{prefix}_SERVER_URL", "http://another.example:8000")
+    with pytest.raises(ValueError):
+        constructor.from_environment()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,15 @@ import pytest
 _REAL_E2E_ROOT = Path(__file__).parent / "e2e" / "real_experience_skill"
 
 
+@pytest.fixture(autouse=True)
+def isolated_client_connection_settings(tmp_path, monkeypatch, request):
+    """Never consume or overwrite the developer's persistent setup consent."""
+
+    if not request.config.getoption("run_real_e2e"):
+        monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(tmp_path / "client-settings.json"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("powercontext-real-e2e")
     group.addoption(

--- a/tests/e2e/test_pydantic_ai_chain.py
+++ b/tests/e2e/test_pydantic_ai_chain.py
@@ -128,9 +128,16 @@ def test_pydantic_ai_capture_checkpoint_recall_and_search_chain(
                     *,
                     token: str | None = None,
                     timeout: float = 10,
+                    allow_insecure_http: bool | None = None,
                 ) -> None:
                     del timeout
-                    super().__init__(base_url, token=token, http_client=transport, trust_transport_security=True)
+                    super().__init__(
+                        base_url,
+                        token=token,
+                        http_client=transport,
+                        trust_transport_security=True,
+                        allow_insecure_http=allow_insecure_http,
+                    )
 
             monkeypatch.setattr(toolset_module, "PowerContextClient", AsgiPowerContextClient)
             settings = PowerContextSettings(
@@ -226,9 +233,16 @@ def test_pydantic_ai_final_flush_catches_up_across_more_than_ten_source_windows(
                     *,
                     token: str | None = None,
                     timeout: float = 10,
+                    allow_insecure_http: bool | None = None,
                 ) -> None:
                     del timeout
-                    super().__init__(base_url, token=token, http_client=transport, trust_transport_security=True)
+                    super().__init__(
+                        base_url,
+                        token=token,
+                        http_client=transport,
+                        trust_transport_security=True,
+                        allow_insecure_http=allow_insecure_http,
+                    )
 
             monkeypatch.setattr(toolset_module, "PowerContextClient", AsgiPowerContextClient)
             capture_settings = PowerContextSettings(

--- a/tests/integrations/test_hermes_provider.py
+++ b/tests/integrations/test_hermes_provider.py
@@ -1223,6 +1223,7 @@ def test_http_client_dispatches_operation_paths_and_get_query(hermes_modules):
     client = provider_module.PowerContextClient(
         "http://powercontext.test:8000",
         transport=transport,
+        allow_insecure_http=True,
     )
     result = client.request_operation("get_stats", {"scope_id": "hermes:test", "period": "7d"})
 
@@ -1243,6 +1244,7 @@ def test_http_client_classifies_malformed_success_response_separately(hermes_mod
 
     client = provider_module.PowerContextClient(
         "http://powercontext.test:8000",
+        allow_insecure_http=True,
         transport=lambda _request, _timeout: Response(),
     )
 
@@ -1262,6 +1264,7 @@ def test_http_client_preserves_domain_error_details(hermes_modules):
 
     client = provider_module.PowerContextClient(
         "http://powercontext.test:8000",
+        allow_insecure_http=True,
         transport=lambda _request, _timeout: Response(),
     )
 
@@ -1290,6 +1293,7 @@ def test_http_client_forwards_authorization_and_preserves_access_denial(hermes_m
 
     client = provider_module.PowerContextClient(
         "http://powercontext.test:8000",
+        allow_insecure_http=True,
         authorization="Bearer integration-token",
         transport=transport,
     )
@@ -1300,6 +1304,77 @@ def test_http_client_forwards_authorization_and_preserves_access_denial(hermes_m
     assert caught.value.status == 403
     assert caught.value.code == "access_denied"
     assert caught.value.server_message == "scope access denied"
+
+
+@pytest.mark.parametrize("saved_in_native_config", [True, False])
+def test_provider_uses_endpoint_bound_persisted_transport_consent(
+    hermes_modules, monkeypatch, tmp_path, saved_in_native_config
+):
+    provider_module, _cli_module = hermes_modules
+    url = "http://memory.example:8000"
+    config_path = tmp_path / "clients.json"
+    config_path.write_text(
+        json.dumps({"version": 1, "hosts": {"hermes": {"server_url": url, "allow_insecure_http": True}}})
+    )
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(config_path))
+    requests = []
+
+    def request(client, path, *_args, **_kwargs):
+        requests.append((client.base_url, path))
+        return {"scope_id": "scp_00000000000000000000000000"}
+
+    monkeypatch.setattr(provider_module.PowerContextClient, "_request", request)
+    config = {"flush_on_session_end": False}
+    if saved_in_native_config:
+        config.update({"base_url": url, "allow_insecure_http": True})
+        config_path.unlink()
+    provider = provider_module.PowerContextMemoryProvider(config)
+    try:
+        provider.initialize("session-transport", hermes_home=str(tmp_path))
+        assert requests[0][0] == url
+    finally:
+        provider.shutdown()
+
+    monkeypatch.setenv("POWERCONTEXT_HERMES_BASE_URL", "http://another.example:8000")
+    provider = provider_module.PowerContextMemoryProvider(config)
+    with pytest.raises(ValueError):
+        provider.initialize("session-changed", hermes_home=str(tmp_path))
+
+
+def test_provider_common_false_overrides_native_http_consent(hermes_modules, monkeypatch, tmp_path):
+    provider_module, _cli_module = hermes_modules
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", "false")
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(tmp_path / "clients.json"))
+    provider = provider_module.PowerContextMemoryProvider({
+        "base_url": "http://memory.example:8000",
+        "allow_insecure_http": True,
+    })
+    with pytest.raises(ValueError):
+        provider.initialize("session-transport", hermes_home=str(tmp_path))
+
+
+@pytest.mark.parametrize("change_in_setup", [True, False])
+def test_provider_endpoint_changes_clear_old_native_consent(hermes_modules, monkeypatch, tmp_path, change_in_setup):
+    provider_module, _cli_module = hermes_modules
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(tmp_path / "clients.json"))
+    config_path = tmp_path / "powercontext" / "config.json"
+    config_path.parent.mkdir()
+    config_path.write_text(
+        json.dumps({"base_url": "http://old.example", "allow_insecure_http": True, "flush_on_session_end": False})
+    )
+    monkeypatch.setattr(
+        provider_module.PowerContextClient,
+        "_request",
+        lambda *_args, **_kwargs: {"scope_id": "scp_00000000000000000000000000"},
+    )
+    provider = provider_module.PowerContextMemoryProvider({} if change_in_setup else {"base_url": "http://new.example"})
+    if change_in_setup:
+        provider.save_config({"base_url": "http://new.example"}, str(tmp_path))
+    try:
+        with pytest.raises(ValueError):
+            provider.initialize("session-changed", hermes_home=str(tmp_path))
+    finally:
+        provider.shutdown()
 
 
 @pytest.mark.parametrize("assembly", [{"sections": []}, {"sections": [{"family": "memory", "limit": 3}]}])

--- a/tests/pydantic_ai_adapter/fakes.py
+++ b/tests/pydantic_ai_adapter/fakes.py
@@ -120,10 +120,12 @@ class RecordingClient:
         *,
         token: str | None = None,
         timeout: float = 10,
+        allow_insecure_http: bool = False,
     ) -> None:
         self.base_url = base_url
         self.token = token
         self.timeout = timeout
+        self.allow_insecure_http = allow_insecure_http
         self.closed = False
         self.resolve_scope_requests: list[Any] = []
         self.search_requests: list[Any] = []

--- a/tests/test_cli_workbuddy.py
+++ b/tests/test_cli_workbuddy.py
@@ -32,6 +32,7 @@ from powercontext.cli.system import doctor_app, setup_app
 _HOOK_MODULES = (
     "workbuddy_powercontext_hook.py",
     "workbuddy_settings.py",
+    "powercontext_client_config.py",
     "prepared_context.py",
 )
 

--- a/tests/test_client_transport_policy.py
+++ b/tests/test_client_transport_policy.py
@@ -1,0 +1,273 @@
+"""Client transport consent, precedence, and endpoint binding."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from powercontext.client import PowerContextClient
+from powercontext.client.settings import ClientSettings
+
+
+@pytest.fixture(autouse=True)
+def isolated_client_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    path = tmp_path / "clients.json"
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(path))
+    for prefix in ("CLIENT", "LANGCHAIN", "LANGGRAPH", "PYDANTIC_AI", "BUB"):
+        for suffix in ("SERVER_URL", "BASE_URL", "ALLOW_INSECURE_HTTP"):
+            monkeypatch.delenv(f"POWERCONTEXT_{prefix}_{suffix}", raising=False)
+    return path
+
+
+def test_client_common_environment_allows_plaintext_but_explicit_false_denies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", "true")
+    client = PowerContextClient("http://memory.example")
+    asyncio.run(client.aclose())
+    with pytest.raises(ValueError, match="non-loopback"):
+        PowerContextClient("http://memory.example", allow_insecure_http=False)
+
+
+def test_client_settings_accept_explicit_plaintext_consent() -> None:
+    settings = ClientSettings(server_url="http://memory.example/", allow_insecure_http=True)
+    assert settings.server_url == "http://memory.example"
+    assert settings.allow_insecure_http is True
+
+
+@pytest.mark.parametrize("value", ["perhaps", "", "2"])
+def test_invalid_common_boolean_fails_even_on_https(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", value)
+    with pytest.raises(ValueError, match="boolean"):
+        PowerContextClient("https://memory.example")
+
+
+def test_saved_consent_is_bound_to_the_selected_endpoint(
+    isolated_client_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from powercontext.client.transport_policy import resolve_client_transport
+
+    isolated_client_config.write_text(
+        json.dumps({
+            "version": 1,
+            "hosts": {
+                "langchain": {
+                    "server_url": "http://memory.example/mcp/",
+                    "allow_insecure_http": True,
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+    assert resolve_client_transport("langchain", server_url="http://memory.example/") == (
+        "http://memory.example",
+        True,
+    )
+    assert resolve_client_transport("langchain", server_url="http://other.example") == (
+        "http://other.example",
+        False,
+    )
+    monkeypatch.setenv("POWERCONTEXT_LANGCHAIN_BASE_URL", "http://other.example")
+    assert resolve_client_transport("langchain") == ("http://other.example", False)
+
+
+def test_host_false_overrides_common_true_and_explicit_constructor_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    from powercontext.client.transport_policy import resolve_client_transport
+
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", "true")
+    monkeypatch.setenv("POWERCONTEXT_LANGGRAPH_ALLOW_INSECURE_HTTP", "false")
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "https://common.example")
+    monkeypatch.setenv("POWERCONTEXT_LANGGRAPH_BASE_URL", "http://graph.example")
+    assert resolve_client_transport("langgraph") == ("http://graph.example", False)
+    assert resolve_client_transport("langgraph", server_url="http://explicit.example", allow_insecure_http=True) == (
+        "http://explicit.example",
+        True,
+    )
+
+
+@pytest.mark.parametrize("host", ["dsh", "pi", "opencode", "openclaw"])
+def test_typescript_host_endpoint_alias_precedes_common_url(host: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    from powercontext.client.transport_policy import resolve_client_transport
+
+    prefix = "POWERCONTEXT_" + host.upper()
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "https://common.example")
+    monkeypatch.setenv(prefix + "_ENDPOINT", "https://host.example")
+    assert resolve_client_transport(host) == ("https://host.example", False)
+    monkeypatch.setenv(prefix + "_SERVER_URL", "https://server.example")
+    assert resolve_client_transport(host) == ("https://server.example", False)
+    monkeypatch.setenv(prefix + "_BASE_URL", "https://base.example")
+    assert resolve_client_transport(host) == ("https://base.example", False)
+
+
+@pytest.mark.parametrize("allow", ["true", 1, None])
+def test_saved_consent_must_be_a_json_boolean(isolated_client_config: Path, allow: object) -> None:
+    from powercontext.client.transport_policy import resolve_client_transport
+
+    isolated_client_config.write_text(
+        json.dumps({
+            "version": 1,
+            "hosts": {
+                "client": {
+                    "server_url": "http://memory.example",
+                    "allow_insecure_http": allow,
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="boolean"):
+        resolve_client_transport("client")
+
+
+def test_saved_client_url_and_consent_work_without_environment(isolated_client_config: Path) -> None:
+    isolated_client_config.write_text(
+        json.dumps({
+            "version": 1,
+            "hosts": {
+                "client": {
+                    "server_url": "http://memory.example",
+                    "allow_insecure_http": True,
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+    settings = ClientSettings()
+    assert (settings.server_url, settings.allow_insecure_http) == ("http://memory.example", True)
+    with pytest.raises(ValidationError):
+        ClientSettings(server_url="http://other.example")
+
+
+def test_https_certificate_validation_stays_enabled_with_http_consent() -> None:
+    async def scenario() -> None:
+        async def reject_certificate(request: httpx.Request) -> httpx.Response:
+            message = "certificate verify failed"
+            raise httpx.ConnectError(message, request=request)
+
+        from powercontext.client import TransportError
+
+        async with (
+            httpx.AsyncClient(transport=httpx.MockTransport(reject_certificate)) as http_client,
+            PowerContextClient(
+                "https://memory.example",
+                allow_insecure_http=True,
+                http_client=http_client,
+            ) as client,
+        ):
+            with pytest.raises(TransportError):
+                await client.get_liveness()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("host", ["langchain", "langgraph", "pydantic-ai"])
+def test_framework_settings_resolve_common_and_host_http_consent(host: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    classes = {
+        "langchain": ("powercontext_langchain.settings", "PowerContextLangChainSettings"),
+        "langgraph": ("powercontext_langgraph.settings", "PowerContextLangGraphSettings"),
+        "pydantic-ai": ("powercontext_pydantic_ai.settings", "PowerContextSettings"),
+    }
+    module, name = classes[host]
+    settings_class = getattr(importlib.import_module(module), name)
+    prefix = "POWERCONTEXT_" + host.upper().replace("-", "_")
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "http://memory.example")
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", "true")
+    settings = settings_class()
+    assert settings.base_url == "http://memory.example"
+    assert settings.allow_insecure_http is True
+    monkeypatch.setenv(prefix + "_ALLOW_INSECURE_HTTP", "false")
+    assert settings_class().allow_insecure_http is False
+    assert settings_class(allow_insecure_http=True).allow_insecure_http is True
+
+
+@pytest.mark.parametrize("host", ["langchain", "langgraph"])
+def test_invocation_url_does_not_inherit_saved_http_consent(host: str, isolated_client_config: Path) -> None:
+    module = importlib.import_module("powercontext_" + host)
+    client_module = importlib.import_module("powercontext_" + host + ".client")
+    settings_class = getattr(
+        module, "PowerContextLangChainSettings" if host == "langchain" else "PowerContextLangGraphSettings"
+    )
+    isolated_client_config.write_text(
+        json.dumps({
+            "version": 1,
+            "hosts": {
+                host: {
+                    "server_url": "http://memory.example",
+                    "allow_insecure_http": True,
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+    settings = settings_class()
+    original = client_module.resolve_config(settings=settings)
+    assert (original.base_url, original.allow_insecure_http) == ("http://memory.example", True)
+    client = client_module.open_client(original)
+    asyncio.run(client.aclose())
+    changed = client_module.resolve_config(module.PowerContextScope(base_url="http://other.example"), settings=settings)
+    with pytest.raises(ValueError, match="non-loopback"):
+        client_module.open_client(changed)
+    explicit = client_module.resolve_config(
+        module.PowerContextScope(base_url="http://other.example", allow_insecure_http=True),
+        settings=settings,
+    )
+    client = client_module.open_client(explicit)
+    asyncio.run(client.aclose())
+
+
+@pytest.mark.parametrize("host", ["langchain", "langgraph"])
+def test_framework_shared_transport_applies_explicit_http_opt_in(host: str) -> None:
+    module = importlib.import_module("powercontext_" + host)
+    client_module = importlib.import_module("powercontext_" + host + ".client")
+    config = client_module.resolve_config(
+        module.PowerContextScope(base_url="http://memory.example", allow_insecure_http=True)
+    )
+
+    async def scenario() -> None:
+        transport = httpx.MockTransport(lambda _: httpx.Response(200, json={"status": "ok"}))
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            with client_module.shared_http_client(http_client):
+                async with client_module.open_client(config) as client:
+                    assert (await client.get_liveness()).status == "ok"
+
+    asyncio.run(scenario())
+
+
+def test_pydantic_ai_does_not_transfer_saved_consent_when_copying_settings(
+    isolated_client_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import powercontext_pydantic_ai.toolset as toolset_module
+    from powercontext_pydantic_ai import PowerContext, PowerContextSettings
+    from pydantic_ai import Agent
+    from pydantic_ai.messages import ModelResponse, TextPart
+    from pydantic_ai.models.function import FunctionModel
+
+    from tests.pydantic_ai_adapter.fakes import RecordingClient
+
+    isolated_client_config.write_text(
+        json.dumps({
+            "version": 1,
+            "hosts": {
+                "pydantic-ai": {
+                    "server_url": "http://memory.example",
+                    "allow_insecure_http": True,
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+    settings = PowerContextSettings().model_copy(update={"base_url": "http://other.example"})
+    RecordingClient.reset()
+    monkeypatch.setattr(toolset_module, "PowerContextClient", RecordingClient)
+
+    async def respond(_messages, _info):
+        return ModelResponse(parts=[TextPart("complete")])
+
+    agent = Agent(FunctionModel(respond), capabilities=[PowerContext(settings=settings)])
+    asyncio.run(agent.run("use the configured Server"))
+    assert RecordingClient.instances[0].base_url == "http://other.example"
+    assert RecordingClient.instances[0].allow_insecure_http is False

--- a/tests/test_client_transport_policy.py
+++ b/tests/test_client_transport_policy.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Client transport consent, precedence, and endpoint binding."""
 
 from __future__ import annotations

--- a/tests/test_native_transport_diagnostics.py
+++ b/tests/test_native_transport_diagnostics.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Doctor resolves native endpoints without making network or configuration changes."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_native_settings(monkeypatch, tmp_path):
+    for key in os.environ:
+        if key.startswith(("POWERCONTEXT_", "CLAUDE_PLUGIN_OPTION_", "DSH_", "OPENCLAW_")):
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(tmp_path / "clients.json"))
+    for name in ("CODEX_HOME", "CLAUDE_CONFIG_DIR", "HERMES_HOME", "WORKBUDDY_HOME", "DSH_HOME", "OPENCLAW_STATE_DIR"):
+        monkeypatch.setenv(name, str(tmp_path / name))
+
+
+def _write(path: Path, data: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _resolve(host: str) -> tuple[str, bool]:
+    from powercontext.cli.native_transport import resolve_host_transport
+
+    return resolve_host_transport(host)
+
+
+def _save_shared(tmp_path: Path, host: str, url: str, consent: bool) -> None:
+    _write(
+        tmp_path / "clients.json", {"version": 1, "hosts": {host: {"server_url": url, "allow_insecure_http": consent}}}
+    )
+
+
+@pytest.mark.parametrize("host", ["claude-code", "hermes", "openclaw"])
+def test_native_http_configuration_is_not_mistaken_for_loopback(host, tmp_path, monkeypatch):
+    url = "http://memory.example:8000"
+    if host == "claude-code":
+        _write(
+            tmp_path / "CLAUDE_CONFIG_DIR/settings.json",
+            {
+                "pluginConfigs": {
+                    "powercontext@powercontext": {"options": {"server_url": url, "allow_insecure_http": True}}
+                },
+            },
+        )
+        prefix, url_key = "CLAUDE", "SERVER_URL"
+    elif host == "hermes":
+        _write(tmp_path / "HERMES_HOME/powercontext/config.json", {"base_url": url, "allow_insecure_http": True})
+        prefix, url_key = "HERMES", "BASE_URL"
+    else:
+        _write(
+            tmp_path / "OPENCLAW_STATE_DIR/openclaw.json",
+            {
+                "plugins": {
+                    "entries": {"memory-powercontext": {"config": {"endpoint": url, "allowInsecureHttp": True}}}
+                },
+            },
+        )
+        prefix, url_key = "OPENCLAW", "BASE_URL"
+    assert _resolve(host) == (url, True)
+    monkeypatch.setenv(f"POWERCONTEXT_{prefix}_{url_key}", "http://another.example")
+    assert _resolve(host) == ("http://another.example", False)
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", "true")
+    assert _resolve(host) == ("http://another.example", True)
+    monkeypatch.setenv(f"POWERCONTEXT_{prefix}_ALLOW_INSECURE_HTTP", "false")
+    assert _resolve(host) == ("http://another.example", False)
+
+
+def test_claude_option_environment_overrides_native_options(tmp_path, monkeypatch):
+    _write(
+        tmp_path / "CLAUDE_CONFIG_DIR/settings.json",
+        {
+            "pluginConfigs": {"powercontext@powercontext": {"options": {"server_url": "https://old.example"}}},
+        },
+    )
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_SERVER_URL", "http://memory.example/mcp/")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_ALLOW_INSECURE_HTTP", "true")
+    assert _resolve("claude-code") == ("http://memory.example", True)
+
+
+def test_hermes_native_url_precedes_common_url(tmp_path, monkeypatch):
+    custom = _write(tmp_path / "custom-hermes.json", {"base_url": "http://memory.example", "allow_insecure_http": True})
+    monkeypatch.setenv("POWERCONTEXT_HERMES_CONFIG", str(custom))
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "https://common.example")
+    assert _resolve("hermes") == ("http://memory.example", True)
+
+
+def test_openclaw_config_path_and_common_url_precedence(tmp_path, monkeypatch):
+    custom = _write(
+        tmp_path / "custom-openclaw.json",
+        {
+            "plugins": {"entries": {"memory-powercontext": {"config": {"endpoint": "https://native.example"}}}},
+        },
+    )
+    monkeypatch.setenv("OPENCLAW_CONFIG_PATH", str(custom))
+    assert _resolve("openclaw") == ("https://native.example", False)
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "http://common.example")
+    assert _resolve("openclaw") == ("http://common.example", False)
+
+
+def test_codex_installed_mcp_endpoint_is_authoritative(tmp_path, monkeypatch):
+    _write(
+        tmp_path / "CODEX_HOME/plugins/cache/local/powercontext/0.1.0/.mcp.json",
+        {
+            "mcpServers": {"powercontext": {"url": "http://memory.example:8000/mcp"}},
+        },
+    )
+    _save_shared(tmp_path, "codex", "http://memory.example:8000/", True)
+    monkeypatch.setenv("POWERCONTEXT_CODEX_SERVER_URL", "https://irrelevant.example")
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "https://irrelevant-common.example")
+    assert _resolve("codex") == ("http://memory.example:8000", True)
+
+
+@pytest.mark.parametrize("second_url", ["http://memory.example/mcp/", "http://another.example/mcp"])
+def test_codex_multiple_cache_versions_require_an_unambiguous_endpoint(tmp_path, second_url):
+    for version, url in (("1", "http://memory.example/mcp"), ("2", second_url)):
+        _write(
+            tmp_path / f"CODEX_HOME/plugins/cache/local/powercontext/{version}/.mcp.json",
+            {
+                "mcpServers": {"powercontext": {"url": url}},
+            },
+        )
+    if "another" in second_url:
+        with pytest.raises(ValueError, match="determine"):
+            _resolve("codex")
+    else:
+        assert _resolve("codex") == ("http://memory.example", False)
+
+
+def test_workbuddy_native_mcp_template_matches_hook_endpoint(tmp_path, monkeypatch):
+    _write(
+        tmp_path / "WORKBUDDY_HOME/mcp.json",
+        {
+            "mcpServers": {"powercontext": {"url": "${POWERCONTEXT_WORKBUDDY_SERVER_URL:-http://memory.example}/mcp"}},
+        },
+    )
+    _save_shared(tmp_path, "workbuddy", "http://memory.example", True)
+    assert _resolve("workbuddy") == ("http://memory.example", True)
+    monkeypatch.setenv("POWERCONTEXT_WORKBUDDY_SERVER_URL", "http://another.example")
+    assert _resolve("workbuddy") == ("http://another.example", False)
+
+
+def test_workbuddy_divergent_mcp_and_hook_urls_are_reported_unknown(tmp_path):
+    _write(
+        tmp_path / "WORKBUDDY_HOME/mcp.json",
+        {
+            "mcpServers": {"powercontext": {"url": "http://native.example/mcp"}},
+        },
+    )
+    _save_shared(tmp_path, "workbuddy", "https://hook.example", False)
+    with pytest.raises(ValueError, match="determine"):
+        _resolve("workbuddy")
+
+
+@pytest.mark.parametrize(
+    "relative_path", ["cordis.patch.yml", "profiles/web/cordis.patch.yml", "profiles/custom/cordis.patch.yml"]
+)
+def test_dsh_runtime_overlays_are_not_assumed_to_use_loopback(tmp_path, monkeypatch, relative_path):
+    path = tmp_path / "DSH_HOME" / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("plugins:\n  powercontext:\n    baseUrl: http://memory.example\n")
+    if "custom" in relative_path:
+        monkeypatch.setenv("DSH_PROFILE", "custom")
+    with pytest.raises(ValueError, match="determine"):
+        _resolve("dsh")
+
+
+@pytest.mark.parametrize(
+    "contents", ["# No profile overrides\n[]\n", "# No profile overrides\n", "[] # empty patches\n"]
+)
+def test_dsh_empty_generated_overlay_does_not_hide_saved_transport(tmp_path, contents):
+    path = tmp_path / "DSH_HOME/profiles/web/cordis.patch.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text(contents)
+    _save_shared(tmp_path, "dsh", "http://memory.example", True)
+    assert _resolve("dsh") == ("http://memory.example", True)
+
+
+@pytest.mark.parametrize(
+    "contents", ["{secret-token: 'secret-value'}", '{"plugins": []}', '{"$include": "private.json"}']
+)
+def test_unsupported_native_config_is_reported_without_secret_content(tmp_path, contents):
+    path = tmp_path / "OPENCLAW_STATE_DIR/openclaw.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(contents)
+    with pytest.raises(ValueError) as caught:
+        _resolve("openclaw")
+    assert "secret-value" not in str(caught.value)
+    assert "private.json" not in str(caught.value)
+
+
+@pytest.mark.parametrize("consent", ["perhaps", 2, None])
+def test_openclaw_native_boolean_is_validated(tmp_path, consent):
+    _write(
+        tmp_path / "OPENCLAW_STATE_DIR/openclaw.json",
+        {
+            "plugins": {
+                "entries": {
+                    "memory-powercontext": {
+                        "config": {"endpoint": "https://memory.example", "allowInsecureHttp": consent}
+                    }
+                }
+            },
+        },
+    )
+    with pytest.raises(ValueError):
+        _resolve("openclaw")
+
+
+def test_missing_native_config_preserves_shared_endpoint_and_consent(tmp_path):
+    _save_shared(tmp_path, "pi", "http://memory.example", True)
+    assert _resolve("pi") == ("http://memory.example", True)
+
+
+def test_openclaw_without_an_endpoint_is_unconfigured_instead_of_loopback():
+    with pytest.raises(ValueError, match="not configured"):
+        _resolve("openclaw")
+
+
+@pytest.mark.parametrize(
+    "contents", ["# default profile\n[]\n", "- id: powercontext\n  config:\n    baseUrl: http://old.example\n"]
+)
+def test_dsh_setup_preflight_accepts_inert_defaults_and_requires_manual_custom_configuration(tmp_path, contents):
+    from powercontext.cli.native_transport import validate_dsh_setup_transport
+
+    path = tmp_path / "DSH_HOME/profiles/web/cordis.patch.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text(contents)
+    if "old.example" in contents:
+        with pytest.raises(ValueError, match="manually"):
+            validate_dsh_setup_transport()
+    else:
+        validate_dsh_setup_transport()
+    assert path.read_text() == contents

--- a/tests/test_openclaw_cli.py
+++ b/tests/test_openclaw_cli.py
@@ -68,6 +68,7 @@ def test_configure_openclaw_preserves_existing_tools_and_adds_missing_tools(monk
     openclaw_cli.configure_openclaw(
         executable="openclaw",
         server_url="http://127.0.0.1:8765",
+        allow_insecure_http=False,
     )
 
     allowlist_call = run_openclaw.call_args_list[1]
@@ -101,6 +102,7 @@ def test_configure_openclaw_initializes_local_gateway_when_mode_is_missing(
     openclaw_cli.configure_openclaw(
         executable="openclaw",
         server_url="http://127.0.0.1:8765",
+        allow_insecure_http=False,
     )
 
     settings = json.loads(run_openclaw.call_args_list[0].args[4])
@@ -144,6 +146,7 @@ def test_install_openclaw_plugin_builds_installs_and_configures(
     configure.assert_called_once_with(
         executable="/usr/bin/openclaw",
         server_url="http://127.0.0.1:8765",
+        allow_insecure_http=False,
     )
 
 
@@ -213,6 +216,7 @@ def test_setup_openclaw_exposes_source_ref_and_runtime_options(monkeypatch: pyte
         source="oceanbase/powercontext",
         ref="tested-ref",
         server_url="http://127.0.0.1:8765",
+        allow_insecure_http=False,
     )
 
 
@@ -360,6 +364,7 @@ def test_doctor_openclaw_reports_an_installed_plugin_as_json(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("POWERCONTEXT_OPENCLAW_BASE_URL", "http://127.0.0.1:8000")
     run_process = Mock(
         return_value=CompletedProcess(_OPENCLAW_PLUGIN_LIST_COMMAND, 0, _openclaw_plugin_list_output(), "")
     )

--- a/tests/test_setup_select.py
+++ b/tests/test_setup_select.py
@@ -298,17 +298,21 @@ def test_setup_select_passes_source_ref_and_host_specific_defaults(monkeypatch) 
     ])
 
     assert result.exit_code == 0
-    installers["codex"].assert_called_once_with(source="oceanbase/powercontext", ref="tested-ref")
+    installers["codex"].assert_called_once_with(
+        source="oceanbase/powercontext", ref="tested-ref", server_url="http://127.0.0.1:8000"
+    )
     installers["claude-code"].assert_called_once_with(
         source="oceanbase/powercontext",
         ref="tested-ref",
         server_url="http://127.0.0.1:8000",
         capture_prompts=True,
+        allow_insecure_http=False,
     )
     installers["openclaw"].assert_called_once_with(
         source="oceanbase/powercontext",
         ref="tested-ref",
         server_url="http://127.0.0.1:8000",
+        allow_insecure_http=False,
     )
     installers["opencode"].assert_called_once_with(source="oceanbase/powercontext", ref="tested-ref")
 
@@ -330,6 +334,7 @@ def test_setup_select_passes_server_override_to_openclaw(monkeypatch) -> None:
         source="oceanbase/powercontext",
         ref="master",
         server_url="https://memory.example",
+        allow_insecure_http=False,
     )
 
 

--- a/tests/test_setup_transport.py
+++ b/tests/test_setup_transport.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Setup consent must be explicit, endpoint-bound, and usable in a new session."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from powercontext.cli.app import create_cli
+from powercontext.cli.system import setup_app
+
+
+@pytest.fixture(autouse=True)
+def isolate_client_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_CONFIG_FILE", str(tmp_path / "clients.json"))
+    monkeypatch.delenv("POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP", raising=False)
+    monkeypatch.delenv("POWERCONTEXT_CLIENT_SERVER_URL", raising=False)
+
+
+@pytest.mark.parametrize("host", ["codex", "claude-code", "dsh", "openclaw", "opencode", "pi", "hermes", "workbuddy"])
+def test_every_setup_rejects_remote_http_without_consent_before_install(host):
+    result = CliRunner().invoke(
+        create_cli([setup_app]), ["setup", host, "--server-url", "http://192.0.2.10:8000", "--json"]
+    )
+    assert result.exit_code == 1
+    assert "--allow-insecure-http" in result.output
+
+
+def test_json_setup_never_prompts_even_with_tty(monkeypatch):
+    from powercontext.cli import transport
+
+    monkeypatch.setattr(transport.sys.stdin, "isatty", lambda: True)
+    confirm = Mock(side_effect=AssertionError("JSON setup must not prompt"))
+    monkeypatch.setattr(transport.typer, "confirm", confirm)
+    with pytest.raises(RuntimeError, match="--allow-insecure-http"):
+        transport.prepare_setup_transport("pi", server_url="http://192.0.2.10", json_output=True)
+
+
+def test_interactive_consent_is_default_no_and_not_saved_until_completed(monkeypatch):
+    from powercontext.cli import transport
+
+    monkeypatch.setattr(transport.sys.stdin, "isatty", lambda: True)
+    confirm = Mock(return_value=False)
+    monkeypatch.setattr(transport.typer, "confirm", confirm)
+    with pytest.raises(RuntimeError):
+        transport.prepare_setup_transport("pi", server_url="http://192.0.2.10")
+    assert confirm.call_args.kwargs["default"] is False
+    assert not transport.client_config_file().exists()
+    confirm.return_value = True
+    settings = transport.prepare_setup_transport("pi", server_url="http://192.0.2.10")
+    assert not transport.client_config_file().exists()
+    transport.save_setup_transport(settings)
+    assert json.loads(transport.client_config_file().read_text())["hosts"]["pi"] == {
+        "server_url": "http://192.0.2.10",
+        "allow_insecure_http": True,
+    }
+
+
+def test_saved_consent_does_not_follow_changed_url(monkeypatch):
+    from powercontext.cli import transport
+
+    settings = transport.prepare_setup_transport("pi", server_url="http://192.0.2.10", allow_insecure_http=True)
+    transport.save_setup_transport(settings)
+    assert transport.prepare_setup_transport("pi", json_output=True).allow_insecure_http
+    with pytest.raises(RuntimeError, match="--allow-insecure-http"):
+        transport.prepare_setup_transport("pi", server_url="http://192.0.2.11", json_output=True)
+
+
+def test_setup_saves_only_nonsecret_fields_and_preserves_other_hosts(monkeypatch):
+    from powercontext.cli import transport
+
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_AUTHORIZATION", "Bearer test-secret")
+    for host in ("pi", "dsh"):
+        transport.save_setup_transport(transport.prepare_setup_transport(host, server_url="https://example.test"))
+    content = transport.client_config_file().read_text()
+    assert "secret" not in content
+    assert set(json.loads(content)["hosts"]) == {"pi", "dsh"}
+
+
+def test_explicit_no_does_not_prompt_to_override_refusal(monkeypatch):
+    from powercontext.cli import transport
+
+    monkeypatch.setattr(transport.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(transport.typer, "confirm", Mock(side_effect=AssertionError("explicit no")))
+    with pytest.raises(RuntimeError):
+        transport.prepare_setup_transport("pi", server_url="http://192.0.2.10", allow_insecure_http=False)
+
+
+def test_environment_false_does_not_prompt_to_override_refusal(monkeypatch):
+    from powercontext.cli import transport
+
+    monkeypatch.setenv("POWERCONTEXT_PI_ALLOW_INSECURE_HTTP", "false")
+    monkeypatch.setattr(transport.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(transport.typer, "confirm", Mock(side_effect=AssertionError("explicit environment no")))
+    with pytest.raises(RuntimeError):
+        transport.prepare_setup_transport("pi", server_url="http://192.0.2.10")
+
+
+def test_hermes_setup_synchronizes_native_endpoint_and_preserves_preferences(tmp_path, monkeypatch):
+    from powercontext.cli.transport import SetupTransport, save_setup_transport
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "powercontext/config.json"
+    path.parent.mkdir()
+    path.write_text(json.dumps({"base_url": "https://old.example", "capture": False}))
+    save_setup_transport(SetupTransport("hermes", "http://192.0.2.10", True))
+    assert json.loads(path.read_text()) == {
+        "base_url": "http://192.0.2.10",
+        "capture": False,
+        "allow_insecure_http": True,
+    }
+
+
+@pytest.mark.parametrize("failed_file", ["shared", "native"])
+def test_failed_persistence_restores_native_settings(tmp_path, monkeypatch, failed_file):
+    import powercontext.cli.system as system
+    from powercontext.cli.transport import SetupTransport, client_config_file, save_setup_transport
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    native = tmp_path / "powercontext/config.json"
+    native.parent.mkdir()
+    original = '{"base_url":"https://old.example","capture":false}'
+    native.write_text(original)
+    write = system._write_bytes_atomically
+
+    def fail_shared(path, content):
+        if path == (client_config_file() if failed_file == "shared" else native):
+            raise OSError("simulated disk failure")  # noqa: TRY003
+        write(path, content)
+
+    monkeypatch.setattr(system, "_write_bytes_atomically", fail_shared)
+    with pytest.raises(RuntimeError):
+        save_setup_transport(SetupTransport("hermes", "http://192.0.2.10", True))
+    assert native.read_text() == original
+    assert not client_config_file().exists()
+
+
+def test_codex_setup_updates_native_mcp_endpoint_without_touching_headers(tmp_path, monkeypatch):
+    from powercontext.cli.system import _configure_codex_endpoint
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    path = tmp_path / "plugins/cache/powercontext/powercontext/0.1.0/.mcp.json"
+    path.parent.mkdir(parents=True)
+    original = {
+        "mcpServers": {
+            "powercontext": {
+                "type": "http",
+                "url": "http://127.0.0.1:8000/mcp",
+                "env_http_headers": {"Authorization": "POWERCONTEXT_CODEX_AUTHORIZATION"},
+            }
+        }
+    }
+    path.write_text(json.dumps(original))
+    _configure_codex_endpoint("powercontext", "0.1.0", "http://192.0.2.10:8000")
+    changed = json.loads(path.read_text())["mcpServers"]["powercontext"]
+    assert changed["url"] == "http://192.0.2.10:8000/mcp"
+    assert changed["env_http_headers"] == original["mcpServers"]["powercontext"]["env_http_headers"]
+
+
+def test_workbuddy_setup_aligns_mcp_with_selected_endpoint(tmp_path):
+    from powercontext.cli.workbuddy import _merge_workbuddy_mcp
+
+    path = tmp_path / "mcp.json"
+    path.write_text(json.dumps({"mcpServers": {"other": {"url": "https://other.test"}}}))
+    _merge_workbuddy_mcp(path, server_url="http://192.0.2.10:8000")
+    servers = json.loads(path.read_text())["mcpServers"]
+    assert "http://192.0.2.10:8000" in servers["powercontext"]["url"]
+    assert servers["other"] == {"url": "https://other.test"}
+
+
+def test_doctor_reports_insecure_opt_in_as_degraded():
+    from powercontext.cli.transport import prepare_setup_transport, save_setup_transport, transport_diagnostic
+
+    save_setup_transport(prepare_setup_transport("pi", server_url="http://192.0.2.10", allow_insecure_http=True))
+    diagnostic = transport_diagnostic("pi")
+    assert diagnostic.status == "degraded"
+    assert "unencrypted" in diagnostic.detail
+
+
+def test_doctor_connects_only_after_explicit_opt_in(monkeypatch):
+    import powercontext.cli.system as system
+
+    probe = Mock(return_value=system.Diagnostic(status=system.DiagnosticStatus.OK, detail="reachable"))
+    monkeypatch.setattr(system, "_server_liveness_diagnostic", probe)
+    monkeypatch.setattr(system, "_server_readiness_diagnostic", probe)
+    diagnostics = system.run_diagnostics(server_url="http://192.0.2.10")
+    assert diagnostics["server_liveness"].status == "failed"
+    probe.assert_not_called()
+    diagnostics = system.run_diagnostics(server_url="http://192.0.2.10", allow_insecure_http=True)
+    assert diagnostics["server_liveness"].ok
+    assert diagnostics["transport"].status == "degraded"
+
+
+def test_doctor_reads_openclaw_native_endpoint_and_binds_consent(tmp_path, monkeypatch):
+    from powercontext.cli.transport import transport_diagnostic
+
+    path = tmp_path / "openclaw.json"
+    monkeypatch.setenv("OPENCLAW_CONFIG_PATH", str(path))
+    path.write_text(
+        json.dumps({
+            "plugins": {
+                "entries": {
+                    "memory-powercontext": {"config": {"endpoint": "http://192.0.2.10", "allowInsecureHttp": True}}
+                }
+            }
+        })
+    )
+    assert transport_diagnostic("openclaw").status == "degraded"
+    monkeypatch.setenv("POWERCONTEXT_OPENCLAW_BASE_URL", "http://192.0.2.11")
+    assert transport_diagnostic("openclaw").status == "failed"
+
+
+def test_doctor_does_not_claim_safety_for_unreadable_native_configuration(tmp_path, monkeypatch):
+    from powercontext.cli.transport import transport_diagnostic
+
+    path = tmp_path / "openclaw.json"
+    monkeypatch.setenv("OPENCLAW_CONFIG_PATH", str(path))
+    path.write_text("{ this is not plain JSON }")
+    assert transport_diagnostic("openclaw").status != "ok"
+
+
+def test_dsh_setup_checks_the_web_profile_even_with_another_runtime_profile(tmp_path, monkeypatch):
+    from powercontext.cli.transport import prepare_setup_transport
+
+    monkeypatch.setenv("DSH_HOME", str(tmp_path))
+    monkeypatch.setenv("DSH_PROFILE", "custom")
+    patch = tmp_path / "profiles/web/cordis.patch.yml"
+    patch.parent.mkdir(parents=True)
+    patch.write_text("- id: powercontext-dsh\n  config:\n    baseUrl: https://old.example\n")
+    with pytest.raises(RuntimeError, match="DSH"):
+        prepare_setup_transport("dsh", server_url="https://new.example", json_output=True)

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -40,6 +40,17 @@ from powercontext.service.model import (
 )
 
 
+@pytest.fixture(autouse=True)
+def isolated_codex_plugin_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
+    for marketplace in ("powercontext", "powercontext-local"):
+        cache = tmp_path / "codex" / "plugins" / "cache" / marketplace / "powercontext" / "0.1.0"
+        cache.mkdir(parents=True)
+        (cache / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"powercontext": {"type": "http", "url": "http://127.0.0.1:8000/mcp"}}})
+        )
+
+
 def test_server_defaults_to_persistent_user_storage(
     tmp_path: Path,
     monkeypatch,
@@ -234,6 +245,7 @@ def test_setup_claude_code_reports_mutations_then_installs_and_verifies(
             "options": {
                 "server_url": "http://127.0.0.1:9000",
                 "capture_prompts": False,
+                "allow_insecure_http": False,
             }
         }
     }
@@ -486,6 +498,7 @@ def test_setup_claude_code_preserves_unrelated_settings_when_updating_options(tm
         "options": {
             "server_url": "http://127.0.0.1:8000",
             "capture_prompts": False,
+            "allow_insecure_http": False,
             "other": 1,
         },
     }

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -62,11 +62,15 @@ def _load_plugin_module(name: str, path: Path) -> tuple[ModuleType | None, str]:
     # Register before executing: a slotted dataclass (the Claude Code plugin) resolves its own
     # module via sys.modules during class creation and fails to import otherwise.
     sys.modules[module_name] = module
+    previous_path = sys.path.copy()
     try:
+        sys.path.insert(0, str(path.parent))
         spec.loader.exec_module(module)
     except Exception as error:  # pragma: no cover - exercised only when a plugin is unavailable.
         sys.modules.pop(module_name, None)
         return None, repr(error)
+    finally:
+        sys.path[:] = previous_path
     return module, ""
 
 


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1534.

# Rationale for this change

A remote PowerContext Server can be reachable from an Agent machine while PowerContext-owned hooks and clients reject its non-loopback HTTP URL. Users currently discover this late, and environment-only workarounds are not durable across sessions. The default should remain secure, with an explicit, visible opt-in for controlled plaintext deployments.

# What changes are included in this PR?

- Add endpoint-bound client transport consent, strict boolean parsing, common/host environment configuration and non-secret per-host persistence.
- Add `--server-url` and `--allow-insecure-http/--no-allow-insecure-http` to all eight setup targets and `setup select`; resolve the effective URL before installation, prompt with default No only in a TTY, and never prompt in JSON/noninteractive mode.
- Save endpoint and consent in `~/.config/powercontext/clients.json` (or `POWERCONTEXT_CLIENT_CONFIG_FILE`), preserving unrelated hosts and rolling back paired native writes on failure.
- Keep installed native MCP and hook endpoints aligned for Codex, Claude Code and WorkBuddy; synchronize Hermes/OpenClaw native settings.
- Apply the policy to standalone Python hooks, DSH/Pi/OpenCode/OpenClaw clients, the Python Client, LangChain, LangGraph, Pydantic AI and Bub. Rebuild shipped DSH/OpenCode bundles.
- Prevent saved/native permission for endpoint A from authorizing endpoint B after an environment/settings override. Explicit false remains authoritative.
- Add read-only native transport diagnostics. Explicitly insecure HTTP is `degraded`; unsupported or ambiguous native configuration is not reported as safe.
- Document the transport boundary for MiniMax and generic Agent Plugin, whose native MCP transport belongs to the host; add bilingual remote-installation guidance and refresh integration pages.

# Are there any user-facing changes?

Yes. HTTPS and IPv4/IPv6 loopback HTTP remain available by default; non-loopback HTTP needs explicit consent. This intentionally tightens DSH/OpenClaw paths that previously accepted remote plaintext HTTP without consent.

Example:

```bash
powercontext setup claude-code --server-url http://192.0.2.10:8000 --allow-insecure-http --json
```

The flag does not disable TLS certificate verification, configure credentials, change Server binding/authentication, or override host-owned MCP policy. `doctor` returns a nonzero status for `degraded` plaintext transport even when the endpoint is reachable.

Codex uses its installed `.mcp.json` as the common hook/MCP endpoint; rerun setup after an update replaces it. DSH's standard empty patch is supported, but custom runtime overlays require manual alignment/removal before setup: the installer fails before mutation rather than silently saving an endpoint that the native override would ignore. Unsupported JSON5/includes and ambiguous cached endpoints are reported as unknown.

# How was this change tested?

- Full Python/doctest run: `python -m pytest --doctest-modules`, deselecting the four baseline failures listed below: **2,205 passed, 64 skipped, 4 deselected**; three packaging cases failed during dependency download (`pypi.org` TLS EOF for hatchling/hatch-vcs), not test assertions about the implementation. Re-ran all three package suites with `UV_FROZEN=true UV_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple python -m pytest tests/langchain_middleware/test_packaging.py tests/langgraph_adapter/test_packaging.py tests/pydantic_ai_adapter/test_packaging.py -q`: **3 passed**.
- Targeted setup/native-policy suites: **180 passed**; final native/setup profile and rollback regressions: **51 passed**. Core/SDK tests and wheel checks passed; Bub evaluation-adapter tests: **13 passed**.
- TypeScript package suites: **DSH 220**, **Pi 77**, **OpenCode 52**, **OpenClaw 65**; includes DSH live-server cases and Pi CLI loading. Rebuilt the shipped bundles and ran applicable package typechecks.
- `prek run -a`, `ruff check`, `ruff format --check`, `ty check`, `ty check integrations/pydantic-ai/src`, and `git diff --check`: passed.
- Website `pnpm lint` and `pnpm build`: passed; **785 public pages and internal links** verified. Integration-manifest consistency checks passed.
- Separately reproduced all four deselected failures on a clean detached **c33df8d3** baseline with baseline source imports verified: three Receiver systemd service tests hit the Linux-only guard on macOS; the installed OpenCode 1.2.15 rejects the test's deliberate `invalid/model` before its capture callback. These unrelated cases are unchanged.

Acceptance boundaries: validated on macOS with Python 3.12; no production deployment or blanket fresh-session acceptance across every real Agent/native MCP implementation is claimed. TLS verification regression tests are mocked rather than a live certificate-handshake test.

# AI usage statement

OpenAI Codex assisted with implementation, tests, documentation, and parallel code review under human-provided requirements. Review findings led to additional endpoint-binding, environment-refusal, native-diagnostics and persistence-rollback regressions.
