### PR TITLE
feat(website): enable bilingual static documentation search

### DIFF
--- a/website/src/app/search-index.json/route.ts
+++ b/website/src/app/search-index.json/route.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createFromSource } from 'fumadocs-core/search/server';
+import { source } from '@/lib/source';
+
+export const dynamic = 'force-static';
+
+export const { staticGET: GET } = createFromSource(source);

--- a/website/src/components/provider.tsx
+++ b/website/src/components/provider.tsx
@@ -53,7 +53,10 @@ export function Provider({ children, lang }: { children: ReactNode; lang: Langua
   }
 
   return (
-    <RootProvider i18n={{ ...provider, onLocaleChange }} search={{ enabled: false }}>
+    <RootProvider
+      i18n={{ ...provider, onLocaleChange }}
+      search={{ options: { type: 'static', api: '/search-index.json' } }}
+    >
       {children}
     </RootProvider>
   );

--- a/website/src/lib/i18n.ts
+++ b/website/src/lib/i18n.ts
@@ -31,7 +31,14 @@ export const i18n = defineI18n({
 
 export const i18nUI = defineI18nUI(i18n, {
   en: { displayName: 'English' },
-  zh: { displayName: '简体中文' },
+  zh: {
+    displayName: '简体中文',
+    'Search(search trigger)': '搜索文档',
+    'Open Search(search trigger)(aria-label)': '搜索文档',
+    'Search(search dialog)': '搜索文档',
+    'Close Search(search dialog)(aria-label)': '关闭搜索',
+    'No results found(search dialog)': '未找到相关结果',
+  },
 });
 
 export function isLanguage(value: string): value is Language {


### PR DESCRIPTION
# Which issue or RFC does this PR close?

None.

# Rationale for this change

Let readers search English and Chinese documentation by content.

# What changes are included in this PR?

Enable Fumadocs' built-in static search and Chinese search labels. Generate the index during build; GitHub Pages publishes it with `website/out`, without committing generated indexes.

# Are there any user-facing changes?

Readers can search documentation, RFCs, and development guides in the current language using the native search dialog. No breaking changes.

# How was this change tested?

`pnpm types:check`, `pnpm lint`, `pnpm build`, and `uv run prek run -a` passed. Verified index delivery, bilingual body-text search, language filtering, and section links on a static server.

# AI usage statement

Implemented and validated with OpenAI Codex (GPT-6).
