### PR TITLE
perf(website): split search indexes by language

### DIFF
--- a/website/src/app/(localized)/[lang]/search-index.json/route.ts
+++ b/website/src/app/(localized)/[lang]/search-index.json/route.ts
@@ -15,8 +15,27 @@
  */
 
 import { createFromSource } from 'fumadocs-core/search/server';
+import { notFound } from 'next/navigation';
+import { isLanguage, languages } from '@/lib/i18n';
 import { source } from '@/lib/source';
 
 export const dynamic = 'force-static';
+export const dynamicParams = false;
 
-export const { staticGET: GET } = createFromSource(source);
+export function generateStaticParams() {
+  return languages.map((lang) => ({ lang }));
+}
+
+export async function GET(_request: Request, { params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params;
+  if (!isLanguage(lang)) notFound();
+
+  const search = createFromSource({
+    ...source,
+    getPages: () => source.getPages(lang),
+  }, {
+    sort: { enabled: false },
+  });
+
+  return search.staticGET();
+}

--- a/website/src/components/provider.tsx
+++ b/website/src/components/provider.tsx
@@ -55,7 +55,7 @@ export function Provider({ children, lang }: { children: ReactNode; lang: Langua
   return (
     <RootProvider
       i18n={{ ...provider, onLocaleChange }}
-      search={{ options: { type: 'static', api: '/search-index.json' } }}
+      search={{ options: { type: 'static', api: `/${lang}/search-index.json` } }}
     >
       {children}
     </RootProvider>


### PR DESCRIPTION
# Which issue or RFC does this PR close?

None. Related: #1540.

# Rationale for this change

The shared search index requires a 5.10 MiB gzip download before searching either language.

# What changes are included in this PR?

Export separate English and Chinese indexes and disable unused field-sorting indexes. The native search dialog loads only the current language: 1.70 MiB gzip for English, 1.81 MiB for Chinese (about 65–67% less). Generated indexes remain untracked and ship with the GitHub Pages build.

# Are there any user-facing changes?

Smaller search downloads with the existing UI and full documentation, RFC, and development-guide coverage. The index URL changes from `/search-index.json` to `/{lang}/search-index.json`.

# How was this change tested?

`pnpm build`, `pnpm types:check`, `pnpm lint`, and `uv run prek run -a` passed. Verified bilingual body-text matches and section links. Chromium testing against the static export confirmed Chinese search and language switching request only the corresponding index.

# AI usage statement

Implemented and validated with OpenAI Codex (GPT-6).
