### PR TITLE
chore(release): prepare v1.0.0rc1

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -63,9 +63,10 @@ jobs:
               version = tag.removeprefix("powercontext-v")
           else:
               version = tag.removeprefix("v")
-          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", version):
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:(?:a|b|rc)[0-9]+)?", version):
               raise SystemExit(
-                  "release_tag must use vX.Y.Z, powercontext-vX.Y.Z, or X.Y.Z semantic versioning"
+                  "release_tag must use X.Y.Z with optional aN, bN, or rcN suffix and "
+                  "optional v or powercontext-v prefix (for example, powercontext-v1.0.0rc1)"
               )
 
           package = os.environ["RELEASE_PACKAGE"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,10 @@ jobs:
               release_version = release_tag.removeprefix("powercontext-v")
           else:
               release_version = release_tag.removeprefix("v")
-          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", release_version):
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:(?:a|b|rc)[0-9]+)?", release_version):
               raise SystemExit(
-                  "Release tag must use vX.Y.Z, powercontext-vX.Y.Z, or X.Y.Z semantic versioning"
+                  "Release tag must use X.Y.Z with optional aN, bN, or rcN suffix and "
+                  "optional v or powercontext-v prefix (for example, powercontext-v1.0.0rc1)"
               )
 
           package_version = subprocess.check_output(

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ You decide what will matter later and what needs to move with the task. PowerCon
 
 ## Works with your agents
 
-Install the latest released [PowerContext](https://pypi.org/project/powercontext/):
+Install [PowerContext](https://pypi.org/project/powercontext/) 1.0.0 RC1 for pre-release testing:
 
 ```bash
-uv tool install "powercontext[cli,server]==0.2.0"
+uv tool install "powercontext[cli,server]==1.0.0rc1"
 ```
 
 Start a local Server in its own terminal:
@@ -41,7 +41,7 @@ The Server stores context in a local SQLite database by default.
 Then set up an agent integration from the matching release. For example:
 
 ```bash
-powercontext setup codex --ref powercontext-v0.2.0
+powercontext setup codex --ref powercontext-v1.0.0rc1
 ```
 
 Keep the PowerContext tool and agent integration on the same Git ref. For `master` installation, other agents,

--- a/README_CN.md
+++ b/README_CN.md
@@ -24,10 +24,10 @@ PowerContext 让上下文跟随工作，跨越不同的对话。你回来时，�
 
 ## 与你使用的 Agent 一起工作
 
-安装最新发布的 [PowerContext](https://pypi.org/project/powercontext/)：
+安装 [PowerContext](https://pypi.org/project/powercontext/) 1.0.0 RC1，参与预发布测试：
 
 ```bash
-uv tool install "powercontext[cli,server]==0.2.0"
+uv tool install "powercontext[cli,server]==1.0.0rc1"
 ```
 
 在单独的终端中启动本地 Server：
@@ -41,7 +41,7 @@ Server 默认将上下文保存到本地 SQLite 数据库。
 然后从同一个发布版本配置 Agent 集成。例如：
 
 ```bash
-powercontext setup codex --ref powercontext-v0.2.0
+powercontext setup codex --ref powercontext-v1.0.0rc1
 ```
 
 PowerContext 工具与 Agent 集成应始终使用同一个 Git ref。`master` 安装、其他 Agent 和个人服务配置见

--- a/README_JP.md
+++ b/README_JP.md
@@ -24,10 +24,10 @@ PowerContext は、会話をまたいでもコンテキストを作業ととも�
 
 ## 利用中の Agent と接続する
 
-最新リリースの [PowerContext](https://pypi.org/project/powercontext/) をインストールします：
+プレリリースの検証用に [PowerContext](https://pypi.org/project/powercontext/) 1.0.0 RC1 をインストールします：
 
 ```bash
-uv tool install "powercontext[cli,server]==0.2.0"
+uv tool install "powercontext[cli,server]==1.0.0rc1"
 ```
 
 別のターミナルでローカル Server を起動します：
@@ -41,7 +41,7 @@ Server はデフォルトで、コンテキストをローカルの SQLite デ�
 次に同じリリースから Agent との連携を設定します。例：
 
 ```bash
-powercontext setup codex --ref powercontext-v0.2.0
+powercontext setup codex --ref powercontext-v1.0.0rc1
 ```
 
 PowerContext ツールと Agent 連携には、常に同じ Git ref を使用してください。`master` のインストール、他の Agent、

--- a/docs/en/docs/get-started/install-and-run.md
+++ b/docs/en/docs/get-started/install-and-run.md
@@ -21,11 +21,14 @@ Embedded seekDB is unavailable on Windows.
 
 ## Choose a version
 
-Keep a released package and integration on the same tag. For example, install `0.2.0`:
+Keep a released package and integration on the same tag. To test the `1.0.0rc1` release candidate:
 
 ```bash
-uv tool install "powercontext[cli,server]==0.2.0"
+uv tool install "powercontext[cli,server]==1.0.0rc1"
+powercontext setup codex --ref powercontext-v1.0.0rc1
 ```
+
+RC1 is a pre-release. Select it explicitly by version; use `0.2.0` and `powercontext-v0.2.0` for the stable release.
 
 The following examples use `master`, including unreleased capabilities. Check the
 [capability matrix](../integrations/capabilities.md); `master_only` and `experimental` capabilities

--- a/docs/zh/docs/get-started/install-and-run.md
+++ b/docs/zh/docs/get-started/install-and-run.md
@@ -19,11 +19,14 @@ Windows 的 CLI、Server 和个人服务支持为试验性；各 Agent Host 仍�
 
 ## 选择版本
 
-发布版与集成使用相同 tag。例如安装 `0.2.0`：
+发布版与集成使用相同 tag。测试 `1.0.0rc1` 候选版：
 
 ```bash
-uv tool install "powercontext[cli,server]==0.2.0"
+uv tool install "powercontext[cli,server]==1.0.0rc1"
+powercontext setup codex --ref powercontext-v1.0.0rc1
 ```
+
+RC1 是预发布版本，需要显式指定版本号。使用稳定版时，将版本和 tag 分别替换为 `0.2.0` 和 `powercontext-v0.2.0`。
 
 后续示例使用 `master`，包含尚未发布的能力。核对[能力矩阵](../integrations/capabilities.md)，
 不要将 `master_only` 或 `experimental` 能力当作发布版承诺。

--- a/openapi/powercontext.yaml
+++ b/openapi/powercontext.yaml
@@ -16,7 +16,7 @@ openapi: 3.0.3
 info:
   title: PowerContext API
   description: Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.
-  version: 0.2.0
+  version: 1.0.0rc1
 security:
   - BearerAuth: []
   - {}

--- a/scripts/ci_release_smoke.py
+++ b/scripts/ci_release_smoke.py
@@ -34,7 +34,7 @@ from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 
 from powercontext.client import PowerContextClient
-from powercontext.http import MemorySearchMode, RememberMemoryRequest, SearchMemoryRequest
+from powercontext.http import CreateScopeRequest, MemorySearchMode, RememberMemoryRequest, SearchMemoryRequest
 
 
 def _available_port() -> int:
@@ -98,12 +98,19 @@ def _stop_process(process: subprocess.Popen[str]) -> None:
 
 
 async def _exercise_public_interfaces(base_url: str) -> None:
-    scope_id = "release-verification"
     memory_text = "PowerContext release verification stores and retrieves this exact memory."
     async with PowerContextClient(base_url) as client:
         readiness = await client.get_readiness()
         if readiness.status.value not in {"ready", "degraded"}:
             raise RuntimeError(f"Unexpected readiness status: {readiness.status.value}")  # noqa: TRY003
+        scope = await client.create_scope(
+            CreateScopeRequest(
+                title="Release verification",
+                summary="Disposable Scope for the published package smoke test.",
+                idempotency_key="release-verification",
+            )
+        )
+        scope_id = scope.scope_id
         remembered = await client.remember_memory(
             RememberMemoryRequest(scope_id=scope_id, kind="fact", text=memory_text)
         )

--- a/src/powercontext/cli/config.py
+++ b/src/powercontext/cli/config.py
@@ -1018,7 +1018,7 @@ def _print_next_steps(path: Path) -> None:
             installed = version("powercontext")
             setup = (
                 f"powercontext setup dsh --source oceanbase/powercontext --ref powercontext-v{installed}"
-                if re.fullmatch(r"\d+\.\d+\.\d+", installed)
+                if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:(?:a|b|rc)[0-9]+)?", installed)
                 else "powercontext setup dsh --source /path/to/matching-powercontext-checkout"
             )
         typer.echo(f"\n{name}:\n  {setup}")

--- a/src/powercontext/http/_generated/operations.py
+++ b/src/powercontext/http/_generated/operations.py
@@ -171,7 +171,7 @@ from powercontext.http._generated.models import (
 OPENAPI_VERSION = "3.0.3"
 API_TITLE = "PowerContext API"
 API_DESCRIPTION = "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities."
-API_VERSION = "0.2.0"
+API_VERSION = "1.0.0rc1"
 
 RequestT = TypeVar("RequestT")
 ResponseT = TypeVar("ResponseT")

--- a/src/powercontext/http/_generated/schema.py
+++ b/src/powercontext/http/_generated/schema.py
@@ -7,7 +7,7 @@ OPENAPI_SCHEMA: dict[str, JsonValue] = {
     "info": {
         "title": "PowerContext API",
         "description": "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.",
-        "version": "0.2.0",
+        "version": "1.0.0rc1",
     },
     "paths": {
         "/v1/scopes/{scope_id}/subject-sources": {

--- a/tests/e2e/test_release_smoke.py
+++ b/tests/e2e/test_release_smoke.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exercise release verification against a fresh Server database before publishing."""
+
+import os
+from importlib.metadata import version
+
+from ci_release_smoke import run_smoke
+
+
+def test_release_smoke_creates_its_scope_in_a_fresh_database(monkeypatch) -> None:
+    for key in tuple(os.environ):
+        if key.startswith("POWERCONTEXT_"):
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1,localhost")
+
+    run_smoke(version("powercontext"), timeout_seconds=60)

--- a/tests/test_ci_release_verification.py
+++ b/tests/test_ci_release_verification.py
@@ -15,10 +15,15 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 from types import ModuleType
 
 import pytest
+import yaml
 
 
 def _load_script(name: str) -> ModuleType:
@@ -31,6 +36,88 @@ def _load_script(name: str) -> ModuleType:
 
 
 smoke = _load_script("ci_release_smoke")
+
+
+@pytest.fixture
+def run_release_step(tmp_path: Path):
+    """Run the workflow's version checks without building or publishing packages."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to execute release workflow steps")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    uvx = bin_dir / "uvx"
+    uvx.write_text(f'#!{sys.executable}\nimport os\nprint(os.environ["TEST_PACKAGE_VERSION"])\n')
+    uvx.chmod(0o755)
+    output = tmp_path / "output"
+
+    def run(workflow_name: str, tag: str, package_version: str):
+        output.write_text("")
+        workflow = yaml.safe_load(
+            (Path(__file__).parents[1] / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
+        )
+        job, step_name = (
+            ("release-build", "Verify package version from Release tag")
+            if workflow_name == "release.yml"
+            else ("verify", "Resolve release metadata")
+        )
+        command = next(step["run"] for step in workflow["jobs"][job]["steps"] if step.get("name") == step_name)
+        result = subprocess.run(
+            [bash, "-eu", "-c", command],
+            env={
+                **os.environ,
+                "PATH": os.pathsep.join((str(bin_dir), str(Path(sys.executable).parent), os.environ.get("PATH", ""))),
+                "RELEASE_TAG": tag,
+                "RELEASE_PACKAGE": "powercontext",
+                "TEST_PACKAGE_VERSION": package_version,
+                "GITHUB_OUTPUT": str(output),
+            },
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        return result, output.read_text()
+
+    return run
+
+
+@pytest.mark.parametrize("workflow", ["release.yml", "release-verify.yml"])
+@pytest.mark.parametrize(
+    ("tag", "version"),
+    [
+        ("powercontext-v1.0.0rc1", "1.0.0rc1"),
+        ("v1.0.0b2", "1.0.0b2"),
+        ("1.0.0a1", "1.0.0a1"),
+        ("powercontext-v1.0.0", "1.0.0"),
+        ("v0.0.2", "0.0.2"),
+    ],
+)
+def test_release_workflows_accept_python_release_versions(run_release_step, workflow, tag, version) -> None:
+    result, output = run_release_step(workflow, tag, version)
+    assert result.returncode == 0, result.stderr
+    if workflow == "release-verify.yml":
+        assert dict(line.split("=", 1) for line in output.splitlines()) == {
+            "package": "powercontext",
+            "version": version,
+            "wheel": f"powercontext-{version}-py3-none-any.whl",
+            "sdist": f"powercontext-{version}.tar.gz",
+        }
+
+
+@pytest.mark.parametrize("workflow", ["release.yml", "release-verify.yml"])
+@pytest.mark.parametrize("version", ["1.0.0-rc.1", "1.0.0+local", "1.0.0.dev1", "1.0.0rc"])
+def test_release_workflows_reject_unsupported_versions(run_release_step, workflow, version) -> None:
+    result, output = run_release_step(workflow, f"powercontext-v{version}", version)
+    assert result.returncode != 0
+    assert "Release tag must use" in result.stderr or "release_tag must use" in result.stderr
+    assert output == ""
+
+
+def test_release_workflow_rejects_vcs_version_mismatch(run_release_step) -> None:
+    result, _ = run_release_step("release.yml", "powercontext-v1.0.0rc1", "1.0.0rc2")
+    assert result.returncode != 0
+    assert "does not match VCS version" in result.stderr
 
 
 @pytest.mark.skipif(smoke.os.name == "nt", reason="POSIX venv symlink regression")

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -63,15 +63,15 @@ def test_init_creates_a_model_free_deployment_and_explains_capability_limits(tmp
     assert shown.exit_code == 0
 
 
-@pytest.mark.parametrize("installed", ["0.2.0", "0.2.1.dev1+g1234567"])
+@pytest.mark.parametrize("installed", ["0.2.0", "1.0.0rc1", "0.2.1.dev1+g1234567"])
 def test_init_matches_dsh_setup_to_installed_server(installed: str, tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(config_cli, "version", lambda _name: installed)
     monkeypatch.setattr(config_cli, "collect_configuration", lambda **_kwargs: _configuration())
     result = CliRunner().invoke(config_cli.app, ["init", "--output", str(tmp_path / "server.env")], input="\n")
     assert result.exit_code == 0
     command = next(line.strip() for line in result.output.splitlines() if "powercontext setup dsh" in line)
-    if installed == "0.2.0":
-        assert command.endswith("--ref powercontext-v0.2.0")
+    if installed in {"0.2.0", "1.0.0rc1"}:
+        assert command.endswith(f"--ref powercontext-v{installed}")
     else:
         assert "--source /path/to/matching-powercontext-checkout" in command
     assert "--ref master" not in command


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Release preparation for PowerContext 1.0.0 RC1; no linked issue or RFC.

# Rationale for this change

The release workflows reject the Python pre-release version `1.0.0rc1`, preventing publication and verification of the first 1.0.0 release candidate. The post-release smoke test also writes to a Scope that has never been created, which fails with `scope_not_found` on a fresh Server.

# What changes are included in this PR?

- Accept canonical `aN`, `bN`, and `rcN` release suffixes in both workflows, retain exact tag/package version matching, and reject unsupported version forms before publishing.
- Update the three READMEs, English/Chinese installation guides, OpenAPI version, and generated API metadata to `1.0.0rc1`.
- Make `config init` recommend the matching DSH integration tag for installed pre-releases.
- Create a disposable Scope through the public API before the release smoke test stores and searches Memory.
- Add regression coverage for workflow version validation, the RC installation guidance, and the complete release smoke flow against a fresh database.

# Are there any user-facing changes?

Installation examples explicitly select `powercontext[cli,server]==1.0.0rc1` and `powercontext-v1.0.0rc1` for matching integrations. The documentation identifies RC1 as a pre-release. This change does not publish a GitHub Release or a PyPI package.

# How was this change tested?

- `python -m pytest -q tests/test_ci_release_verification.py tests/test_config_cli.py tests/e2e/test_release_smoke.py` — 60 passed.
- `make contract-test` — generated artifacts checked; 47 passed.
- `make check` — lock consistency, integration manifest tests, pre-commit hooks, and type checks passed.
- `make docs-test` with Node 24 — build passed; 779 exported pages and their internal links verified.
- Built wheel and sdist from a disposable repository tagged `powercontext-v1.0.0rc1`; both report version `1.0.0rc1` and pass `twine check`.
- Installed the wheel with CLI/Server dependencies in a clean Python 3.14 environment; dependency checks, CLI version, Server, MCP, and SQLite Memory smoke verification passed. The final wheel matches the tested wheel byte for byte.

# AI usage statement

Implemented and validated with OpenAI Codex (GPT-6).
