### PR TITLE
feat(setup): persist PowerContext Agent authorization

### DIFF
--- a/integrations/claude-code/plugins/powercontext/claude_code_settings.py
+++ b/integrations/claude-code/plugins/powercontext/claude_code_settings.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 import ipaddress
 import json
 import os
+import stat
 from dataclasses import dataclass
+from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
 from powercontext_client_config import load_client_settings, parse_boolean, resolve_allow_insecure_http
@@ -95,7 +97,12 @@ class ClaudeCodePluginSettings:
             )
             or saved.get("server_url")
             or "http://127.0.0.1:8000",
-            authorization=_first_environment("POWERCONTEXT_CLAUDE_AUTHORIZATION"),
+            authorization=_first_environment("POWERCONTEXT_CLAUDE_AUTHORIZATION")
+            or _stored_authorization(
+                server_url=_first_environment("POWERCONTEXT_CLAUDE_SERVER_URL", "CLAUDE_PLUGIN_OPTION_SERVER_URL")
+                or "http://127.0.0.1:8000",
+                root=Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude")).expanduser(),
+            ),
             scope_id=_first_environment("POWERCONTEXT_CLAUDE_SCOPE_ID"),
             context_assembly=_environment_object("POWERCONTEXT_CLAUDE_CONTEXT_ASSEMBLY"),
             capture_prompts=_environment_bool(
@@ -186,6 +193,24 @@ def _authorization_header(value: str | None) -> str | None:
     ):
         raise ValueError("Claude Code authorization must be a valid Bearer header")  # noqa: TRY003
     return normalized
+
+
+def _stored_authorization(*, server_url: str, root: Path) -> str | None:
+    path = root / "powercontext" / "credentials.json"
+    try:
+        if path.is_symlink() or not path.is_file() or (os.name != "nt" and stat.S_IMODE(path.stat().st_mode) & 0o077):
+            return None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("version") != 1:
+            return None
+        stored_url, authorization = payload.get("server_url"), payload.get("authorization")
+        if not isinstance(stored_url, str) or not isinstance(authorization, str):
+            return None
+        if _http_base_url(stored_url) != _http_base_url(server_url):
+            return None
+        return _authorization_header(authorization)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return None
 
 
 def _http_base_url(value: str, *, allow_insecure_http: bool = False) -> str:

--- a/integrations/codex/plugins/powercontext/settings.py
+++ b/integrations/codex/plugins/powercontext/settings.py
@@ -17,6 +17,9 @@
 from __future__ import annotations
 
 import ipaddress
+import json
+import os
+import stat
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlsplit, urlunsplit
@@ -85,7 +88,9 @@ class _McpEndpointSettingsSource(PydanticBaseSettingsSource):
 
     @override
     def __call__(self) -> dict[str, Any]:
-        return {"server_url": _server_url_from_mcp_configuration()}
+        server_url = _server_url_from_mcp_configuration()
+        authorization = _stored_authorization(server_url)
+        return {"server_url": server_url, **({"authorization": authorization} if authorization else {})}
 
 
 class CodexPluginSettings(BaseSettings):
@@ -179,6 +184,35 @@ class CodexPluginSettings(BaseSettings):
 def _server_url_from_mcp_configuration() -> str:
     configuration = _McpConfiguration.model_validate_json(_MCP_CONFIGURATION_PATH.read_text())
     return _http_base_url(configuration.mcp_servers["powercontext"].url, allow_insecure_http=True)
+
+
+def _stored_authorization(server_url: str) -> str | None:
+    path = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")).expanduser() / "powercontext" / "credentials.json"
+    try:
+        if path.is_symlink() or not path.is_file() or (os.name != "nt" and stat.S_IMODE(path.stat().st_mode) & 0o077):
+            return None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("version") != 1:
+            return None
+        stored_url, authorization = payload.get("server_url"), payload.get("authorization")
+        if not isinstance(stored_url, str) or not isinstance(authorization, str):
+            return None
+        if _http_base_url(f"{stored_url.rstrip('/')}/mcp", allow_insecure_http=True) != _http_base_url(
+            server_url, allow_insecure_http=True
+        ):
+            return None
+        scheme, separator, credential = authorization.partition(" ")
+        if (
+            scheme.casefold() != "bearer"
+            or not separator
+            or not credential
+            or any(character.isspace() for character in credential)
+        ):
+            return None
+        else:
+            return authorization
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return None
 
 
 def _http_base_url(mcp_url: str, *, allow_insecure_http: bool = False) -> str:

--- a/integrations/dsh/plugins/powercontext/lib/index.js
+++ b/integrations/dsh/plugins/powercontext/lib/index.js
@@ -15,7 +15,7 @@
  */
 
 import { createRequire } from "node:module";
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { createHash } from "node:crypto";
@@ -2516,6 +2516,21 @@ function contextAssembly(raw, fallback) {
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("PowerContext context assembly must be a JSON object");
 	return structuredClone(value);
 }
+function storedAuthorization(env, baseUrl) {
+	const path = join(env.DSH_HOME?.trim() || join(homedir(), ".dsh"), "powercontext", "credentials.json");
+	try {
+		if (process.platform !== "win32" && (statSync(path).mode & 63) !== 0) return void 0;
+		const parsed = JSON.parse(readFileSync(path, "utf8"));
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return void 0;
+		const payload = parsed;
+		if (payload.version !== 1 || typeof payload.server_url !== "string" || stripSlash(payload.server_url) !== baseUrl) return void 0;
+		if (typeof payload.authorization !== "string") return void 0;
+		const authorization = payload.authorization;
+		return /^Bearer [^\s]+$/.test(authorization) ? authorization : void 0;
+	} catch {
+		return;
+	}
+}
 function resolveConfig(config = {}, env = process.env) {
 	const transport = resolveTransport("dsh", env, config.baseUrl, config.allowInsecureHttp, DEFAULTS.baseUrl);
 	const maxBytes = config.maxBytes ?? DEFAULTS.maxBytes;
@@ -2529,7 +2544,7 @@ function resolveConfig(config = {}, env = process.env) {
 		},
 		baseUrl: transport.baseUrl,
 		allowInsecureHttp: transport.allowInsecureHttp,
-		authorization: envString(env, "POWERCONTEXT_DSH_AUTHORIZATION") ?? optionalText(config.authorization),
+		authorization: envString(env, "POWERCONTEXT_DSH_AUTHORIZATION") ?? optionalText(config.authorization) ?? storedAuthorization(env, transport.baseUrl),
 		scopeId: envString(env, "POWERCONTEXT_DSH_SCOPE_ID") ?? optionalText(config.scopeId),
 		timeoutMs: config.timeoutMs ?? DEFAULTS.timeoutMs,
 		requestTimeoutMs: config.requestTimeoutMs ?? DEFAULTS.requestTimeoutMs,

--- a/integrations/dsh/plugins/powercontext/src/config.ts
+++ b/integrations/dsh/plugins/powercontext/src/config.ts
@@ -15,6 +15,9 @@
  */
 
 import { resolveTransport } from './transport.ts'
+import { readFileSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 
 export interface PluginConfig {
   contextAssembly?: Record<string, unknown>
@@ -93,6 +96,23 @@ function contextAssembly(raw: string | undefined, fallback?: Record<string, unkn
   return structuredClone(value as Record<string, unknown>)
 }
 
+function storedAuthorization(env: NodeJS.ProcessEnv, baseUrl: string): string | undefined {
+  const root = env.DSH_HOME?.trim() || join(homedir(), '.dsh')
+  const path = join(root, 'powercontext', 'credentials.json')
+  try {
+    if (process.platform !== 'win32' && (statSync(path).mode & 0o077) !== 0) return undefined
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'))
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
+    const payload = parsed as Record<string, unknown>
+    if (payload.version !== 1 || typeof payload.server_url !== 'string' || stripSlash(payload.server_url) !== baseUrl) return undefined
+    if (typeof payload.authorization !== 'string') return undefined
+    const authorization = payload.authorization
+    return /^Bearer [^\s]+$/.test(authorization) ? authorization : undefined
+  } catch {
+    return undefined
+  }
+}
+
 export function resolveConfig(
   config: PluginConfig = {},
   env: NodeJS.ProcessEnv = process.env,
@@ -111,7 +131,10 @@ export function resolveConfig(
     },
     baseUrl: transport.baseUrl!,
     allowInsecureHttp: transport.allowInsecureHttp,
-    authorization: envString(env, 'POWERCONTEXT_DSH_AUTHORIZATION') ?? optionalText(config.authorization),
+    authorization:
+      envString(env, 'POWERCONTEXT_DSH_AUTHORIZATION') ??
+      optionalText(config.authorization) ??
+      storedAuthorization(env, transport.baseUrl!),
     scopeId: envString(env, 'POWERCONTEXT_DSH_SCOPE_ID') ?? optionalText(config.scopeId),
     timeoutMs: config.timeoutMs ?? DEFAULTS.timeoutMs,
     requestTimeoutMs: config.requestTimeoutMs ?? DEFAULTS.requestTimeoutMs,

--- a/src/powercontext/cli/authorization.py
+++ b/src/powercontext/cli/authorization.py
@@ -28,8 +28,25 @@ from powercontext.client.settings import normalize_server_url
 
 AuthorizationStatus = Literal["configured", "not_configured", "url_mismatch", "invalid", "unsafe_permissions"]
 SetupAuthorizationStatus = Literal[
-    "configured", "preserved", "not_configured", "url_mismatch", "invalid", "unsafe_permissions"
+    "configured", "preserved", "cleared", "not_configured", "url_mismatch", "invalid", "unsafe_permissions"
 ]
+
+_AUTHORIZATION_ENVIRONMENTS = {
+    "codex": "POWERCONTEXT_CODEX_AUTHORIZATION",
+    "claude-code": "POWERCONTEXT_CLAUDE_AUTHORIZATION",
+    "opencode": "POWERCONTEXT_OPENCODE_AUTHORIZATION",
+    "pi": "POWERCONTEXT_PI_AUTHORIZATION",
+    "workbuddy": "POWERCONTEXT_WORKBUDDY_AUTHORIZATION",
+    "dsh": "POWERCONTEXT_DSH_AUTHORIZATION",
+}
+_SERVER_URL_ENVIRONMENTS = {
+    "codex": "POWERCONTEXT_CODEX_SERVER_URL",
+    "claude-code": "POWERCONTEXT_CLAUDE_SERVER_URL",
+    "opencode": "POWERCONTEXT_OPENCODE_BASE_URL",
+    "pi": "POWERCONTEXT_PI_BASE_URL",
+    "workbuddy": "POWERCONTEXT_WORKBUDDY_SERVER_URL",
+    "dsh": "POWERCONTEXT_DSH_BASE_URL",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -159,6 +176,18 @@ def configure_stored_authorization(host: str, *, server_url: str, value: str | N
     return resolution.status
 
 
+def setup_authorization_value(host: str) -> str | None:
+    """Read the host-specific setup token, falling back to the shared token."""
+
+    return os.environ.get(_AUTHORIZATION_ENVIRONMENTS[host]) or os.environ.get("POWERCONTEXT_CLIENT_API_TOKEN")
+
+
+def setup_server_url(host: str, default: str) -> str:
+    """Resolve the endpoint used by a host before binding its credential."""
+
+    return os.environ.get(_SERVER_URL_ENVIRONMENTS[host], default)
+
+
 __all__ = [
     "AuthorizationResolution",
     "AuthorizationStatus",
@@ -167,5 +196,7 @@ __all__ = [
     "credential_path",
     "normalize_authorization",
     "read_stored_authorization",
+    "setup_authorization_value",
+    "setup_server_url",
     "write_stored_authorization",
 ]

--- a/src/powercontext/cli/authorization.py
+++ b/src/powercontext/cli/authorization.py
@@ -69,6 +69,7 @@ def credential_path(host: str) -> Path:
         "opencode": Path(os.environ.get("OPENCODE_CONFIG_DIR", Path.home() / ".config" / "opencode")).expanduser(),
         "pi": Path(os.environ.get("PI_CODING_AGENT_DIR", Path.home() / ".pi" / "agent")).expanduser(),
         "workbuddy": Path(os.environ.get("WORKBUDDY_HOME", Path.home() / ".workbuddy")).expanduser(),
+        "dsh": Path(os.environ.get("DSH_HOME", Path.home() / ".dsh")).expanduser(),
     }
     try:
         root = roots[host]

--- a/src/powercontext/cli/authorization.py
+++ b/src/powercontext/cli/authorization.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""User-owned PowerContext authorization persistence for Agent Hosts."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from powercontext.client.settings import normalize_server_url
+
+AuthorizationStatus = Literal["configured", "not_configured", "url_mismatch", "invalid", "unsafe_permissions"]
+SetupAuthorizationStatus = Literal[
+    "configured", "preserved", "not_configured", "url_mismatch", "invalid", "unsafe_permissions"
+]
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationResolution:
+    """Redacted result of resolving one persisted credential."""
+
+    status: AuthorizationStatus
+    authorization: str | None
+
+
+def normalize_authorization(value: str) -> str:
+    """Return a complete Bearer header without exposing invalid input in errors."""
+
+    if not isinstance(value, str) or any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ValueError("authorization must be a non-empty single-token credential")  # noqa: TRY003
+    normalized = value.strip()
+    if normalized.casefold() == "bearer":
+        raise ValueError("authorization must be a non-empty single-token credential")  # noqa: TRY003
+    credential = normalized[7:] if normalized.casefold().startswith("bearer ") else normalized
+    if (
+        not credential
+        or not credential.isascii()
+        or not credential.isprintable()
+        or any(character.isspace() for character in credential)
+        or len(credential) > 8192
+    ):
+        raise ValueError("authorization must be a non-empty single-token credential")  # noqa: TRY003
+    return f"Bearer {credential}"
+
+
+def credential_path(host: str) -> Path:
+    """Return a PowerContext-owned credential path below the host config root."""
+
+    roots = {
+        "codex": Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")).expanduser(),
+        "claude-code": Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude")).expanduser(),
+        "opencode": Path(os.environ.get("OPENCODE_CONFIG_DIR", Path.home() / ".config" / "opencode")).expanduser(),
+        "pi": Path(os.environ.get("PI_CODING_AGENT_DIR", Path.home() / ".pi" / "agent")).expanduser(),
+        "workbuddy": Path(os.environ.get("WORKBUDDY_HOME", Path.home() / ".workbuddy")).expanduser(),
+    }
+    try:
+        root = roots[host]
+    except KeyError as error:
+        raise ValueError("unsupported persisted authorization host") from error  # noqa: TRY003
+    return root / "powercontext" / "credentials.json"
+
+
+def write_stored_authorization(path: Path, *, server_url: str, value: str) -> None:
+    """Atomically persist one URL-bound authorization record."""
+
+    path = Path(path).expanduser()
+    if path.exists() and (path.is_symlink() or not path.is_file()):
+        raise ValueError("credential path must be a regular file")  # noqa: TRY003
+    normalized_url = normalize_server_url(server_url)
+    authorization = normalize_authorization(value)
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    if os.name != "nt":
+        parent.chmod(0o700)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=parent)
+    temporary = Path(temporary_name)
+    try:
+        if os.name != "nt":
+            os.fchmod(fd, 0o600)
+        payload = {
+            "version": 1,
+            "server_url": normalized_url,
+            "authorization": authorization,
+        }
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def read_stored_authorization(path: Path, *, server_url: str) -> AuthorizationResolution:
+    """Resolve a credential only when its file and URL binding are safe."""
+
+    path = Path(path).expanduser()
+    if not path.exists():
+        return AuthorizationResolution("not_configured", None)
+    if path.is_symlink() or not path.is_file():
+        return AuthorizationResolution("invalid", None)
+    if os.name != "nt" and stat.S_IMODE(path.stat().st_mode) & 0o077:
+        return AuthorizationResolution("unsafe_permissions", None)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("version") != 1:
+            raise ValueError("invalid persisted authorization record")  # noqa: TRY003, TRY301
+        stored_url = normalize_server_url(payload["server_url"])
+        authorization = normalize_authorization(payload["authorization"])
+        effective_url = normalize_server_url(server_url)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return AuthorizationResolution("invalid", None)
+    if stored_url != effective_url:
+        return AuthorizationResolution("url_mismatch", None)
+    return AuthorizationResolution("configured", authorization)
+
+
+def clear_stored_authorization(path: Path) -> Literal["cleared", "not_configured"]:
+    """Delete a PowerContext-owned credential without following symlinks."""
+
+    path = Path(path).expanduser()
+    if not path.exists():
+        return "not_configured"
+    if path.is_symlink() or not path.is_file():
+        raise ValueError("credential path must be a regular file")  # noqa: TRY003
+    path.unlink()
+    return "cleared"
+
+
+def configure_stored_authorization(host: str, *, server_url: str, value: str | None = None) -> SetupAuthorizationStatus:
+    """Persist a setup-only token, or report the existing URL-bound credential state."""
+
+    path = credential_path(host)
+    if value is not None and value.strip():
+        write_stored_authorization(path, server_url=server_url, value=value)
+        return "configured"
+    resolution = read_stored_authorization(path, server_url=server_url)
+    if resolution.status == "configured":
+        return "preserved"
+    return resolution.status
+
+
+__all__ = [
+    "AuthorizationResolution",
+    "AuthorizationStatus",
+    "clear_stored_authorization",
+    "configure_stored_authorization",
+    "credential_path",
+    "normalize_authorization",
+    "read_stored_authorization",
+    "write_stored_authorization",
+]

--- a/src/powercontext/cli/config_wizard_agents.py
+++ b/src/powercontext/cli/config_wizard_agents.py
@@ -133,21 +133,20 @@ _HOST_METADATA = {
         "CONTEXT_ASSEMBLY",
         executables=("hermes",),
     ),
+    "workbuddy": AgentSpec(
+        "workbuddy",
+        "WorkBuddy",
+        "WorkBuddy",
+        "POWERCONTEXT_WORKBUDDY",
+        "SERVER_URL",
+        "AUTHORIZATION",
+        "CAPTURE_PROMPTS",
+        "SCOPE_ID",
+        "CONTEXT_ASSEMBLY",
+    ),
 }
 
-WORKBUDDY = AgentSpec(
-    "workbuddy",
-    "WorkBuddy",
-    "WorkBuddy",
-    "POWERCONTEXT_WORKBUDDY",
-    "SERVER_URL",
-    "AUTHORIZATION",
-    "CAPTURE_PROMPTS",
-    "SCOPE_ID",
-    "CONTEXT_ASSEMBLY",
-)
-
-AGENT_SPECS: tuple[AgentSpec, ...] = (*(_HOST_METADATA[host.name] for host in FIRST_CLASS_HOSTS), WORKBUDDY)
+AGENT_SPECS: tuple[AgentSpec, ...] = tuple(_HOST_METADATA[host.name] for host in FIRST_CLASS_HOSTS)
 AGENT_SPEC_BY_ID = {spec.identifier: spec for spec in AGENT_SPECS}
 
 

--- a/src/powercontext/cli/dsh.py
+++ b/src/powercontext/cli/dsh.py
@@ -48,6 +48,7 @@ class DshSetupResult:
     plugin: str
     plugin_path: str
     data_dir: str
+    authorization_state: str = "not_attempted"
 
 
 def install_dsh_plugin(*, source: str, ref: str) -> DshSetupResult:
@@ -62,10 +63,17 @@ def install_dsh_plugin(*, source: str, ref: str) -> DshSetupResult:
     plugin_dir = resolve_dsh_plugin_dir(source=source, ref=ref)
     require_built_plugin(plugin_dir)
     _run_dsh("plugin", "--profile", DSH_PROFILE, "add", str(plugin_dir))
+    from powercontext.cli.authorization import configure_stored_authorization
+
     return DshSetupResult(
         plugin=DSH_PLUGIN_NAME,
         plugin_path=str(plugin_dir),
         data_dir=str(data_dir),
+        authorization_state=configure_stored_authorization(
+            "dsh",
+            server_url="http://127.0.0.1:8000",
+            value=os.environ.get("POWERCONTEXT_CLIENT_API_TOKEN"),
+        ),
     )
 
 

--- a/src/powercontext/cli/dsh.py
+++ b/src/powercontext/cli/dsh.py
@@ -63,7 +63,11 @@ def install_dsh_plugin(*, source: str, ref: str) -> DshSetupResult:
     plugin_dir = resolve_dsh_plugin_dir(source=source, ref=ref)
     require_built_plugin(plugin_dir)
     _run_dsh("plugin", "--profile", DSH_PROFILE, "add", str(plugin_dir))
-    from powercontext.cli.authorization import configure_stored_authorization
+    from powercontext.cli.authorization import (
+        configure_stored_authorization,
+        setup_authorization_value,
+        setup_server_url,
+    )
 
     return DshSetupResult(
         plugin=DSH_PLUGIN_NAME,
@@ -71,8 +75,8 @@ def install_dsh_plugin(*, source: str, ref: str) -> DshSetupResult:
         data_dir=str(data_dir),
         authorization_state=configure_stored_authorization(
             "dsh",
-            server_url="http://127.0.0.1:8000",
-            value=os.environ.get("POWERCONTEXT_CLIENT_API_TOKEN"),
+            server_url=setup_server_url("dsh", "http://127.0.0.1:8000"),
+            value=setup_authorization_value("dsh"),
         ),
     )
 

--- a/src/powercontext/cli/hosts.py
+++ b/src/powercontext/cli/hosts.py
@@ -44,6 +44,7 @@ FIRST_CLASS_HOSTS: tuple[HostSpec, ...] = (
     HostSpec("opencode", "OpenCode"),
     HostSpec("pi", "Pi"),
     HostSpec("hermes", "Hermes"),
+    HostSpec("workbuddy", "WorkBuddy"),
 )
 HOST_NAMES: tuple[str, ...] = tuple(host.name for host in FIRST_CLASS_HOSTS)
 _HOST_INDEX: dict[str, str] = {str(index): host.name for index, host in enumerate(FIRST_CLASS_HOSTS, start=1)}
@@ -319,6 +320,10 @@ def install_host(
         from powercontext.cli.hermes import install_hermes_plugin
 
         return install_hermes_plugin(source=source, ref=ref)
+    if name == "workbuddy":
+        from powercontext.cli.workbuddy import install_workbuddy_plugin
+
+        return install_workbuddy_plugin(source=source, ref=ref)
     raise SetupSelectError.unknown_host(name)
 
 
@@ -343,6 +348,10 @@ def verify_host(name: str) -> None:
         from powercontext.cli.hermes import run_hermes_diagnostics
 
         diagnostics = run_hermes_diagnostics()
+    elif name == "workbuddy":
+        from powercontext.cli.workbuddy import run_workbuddy_diagnostics
+
+        diagnostics = run_workbuddy_diagnostics()
     elif name == "opencode":
         from powercontext.cli.opencode import run_opencode_diagnostics
 

--- a/src/powercontext/cli/hosts.py
+++ b/src/powercontext/cli/hosts.py
@@ -48,7 +48,7 @@ FIRST_CLASS_HOSTS: tuple[HostSpec, ...] = (
 )
 HOST_NAMES: tuple[str, ...] = tuple(host.name for host in FIRST_CLASS_HOSTS)
 _HOST_INDEX: dict[str, str] = {str(index): host.name for index, host in enumerate(FIRST_CLASS_HOSTS, start=1)}
-_INTEGRATION_KEYS = frozenset({"plugin", "package", "skill"})
+_INTEGRATION_KEYS = frozenset({"plugin", "package", "skill", "settings", "mcp"})
 _PATH_MISSING = "is not installed or is not on PATH"
 
 
@@ -428,6 +428,10 @@ def diagnose_host(name: str) -> dict[str, Diagnostic]:
         from powercontext.cli.hermes import run_hermes_diagnostics
 
         return run_hermes_diagnostics()
+    if name == "workbuddy":
+        from powercontext.cli.workbuddy import run_workbuddy_diagnostics
+
+        return run_workbuddy_diagnostics()
     raise SetupSelectError.unknown_host(name)
 
 
@@ -444,7 +448,8 @@ def split_host_diagnostics(
 def classify_host_presence(cli: Diagnostic, integrations: tuple[tuple[str, Diagnostic], ...]) -> str:
     """Mark a host missing only when PATH lookup failed and the integration was skipped."""
 
-    if _PATH_MISSING in cli.detail and all(diagnostic.status.value == "skipped" for _, diagnostic in integrations):
+    missing_cli = _PATH_MISSING in cli.detail or "WorkBuddy hooks are not installed" in cli.detail
+    if missing_cli and all(diagnostic.status.value == "skipped" for _, diagnostic in integrations):
         return "missing"
     return "present"
 

--- a/src/powercontext/cli/opencode.py
+++ b/src/powercontext/cli/opencode.py
@@ -59,6 +59,7 @@ class OpenCodeSetupResult:
     plugin_path: str
     skill_path: str
     data_dir: str
+    authorization_state: str = "not_attempted"
 
 
 def opencode_executable() -> str:
@@ -100,11 +101,18 @@ def install_opencode_plugin(*, source: str, ref: str) -> OpenCodeSetupResult:
     require_replaceable_skill(skill_target)
     _install_plugin(plugin_dir / OPENCODE_BUNDLE, plugin_target)
     _install_skill(plugin_dir / OPENCODE_SKILL.parent, skill_target)
+    from powercontext.cli.authorization import configure_stored_authorization
+
     return OpenCodeSetupResult(
         plugin=OPENCODE_PLUGIN_NAME,
         plugin_path=str(plugin_dir),
         skill_path=str(skill_target),
         data_dir=str(data_dir),
+        authorization_state=configure_stored_authorization(
+            "opencode",
+            server_url="http://127.0.0.1:8000",
+            value=os.environ.get("POWERCONTEXT_CLIENT_API_TOKEN"),
+        ),
     )
 
 

--- a/src/powercontext/cli/opencode.py
+++ b/src/powercontext/cli/opencode.py
@@ -101,7 +101,11 @@ def install_opencode_plugin(*, source: str, ref: str) -> OpenCodeSetupResult:
     require_replaceable_skill(skill_target)
     _install_plugin(plugin_dir / OPENCODE_BUNDLE, plugin_target)
     _install_skill(plugin_dir / OPENCODE_SKILL.parent, skill_target)
-    from powercontext.cli.authorization import configure_stored_authorization
+    from powercontext.cli.authorization import (
+        configure_stored_authorization,
+        setup_authorization_value,
+        setup_server_url,
+    )
 
     return OpenCodeSetupResult(
         plugin=OPENCODE_PLUGIN_NAME,
@@ -110,8 +114,8 @@ def install_opencode_plugin(*, source: str, ref: str) -> OpenCodeSetupResult:
         data_dir=str(data_dir),
         authorization_state=configure_stored_authorization(
             "opencode",
-            server_url="http://127.0.0.1:8000",
-            value=os.environ.get("POWERCONTEXT_CLIENT_API_TOKEN"),
+            server_url=setup_server_url("opencode", "http://127.0.0.1:8000"),
+            value=setup_authorization_value("opencode"),
         ),
     )
 

--- a/src/powercontext/cli/pi.py
+++ b/src/powercontext/cli/pi.py
@@ -72,7 +72,11 @@ def install_pi_plugin(*, source: str, ref: str) -> PiSetupResult:
     require_pi_package(package_dir)
     _run_pi("install", str(package_dir))
     _remove_existing_pi_packages(keep=package_dir)
-    from powercontext.cli.authorization import configure_stored_authorization
+    from powercontext.cli.authorization import (
+        configure_stored_authorization,
+        setup_authorization_value,
+        setup_server_url,
+    )
 
     return PiSetupResult(
         package=PI_PACKAGE_NAME,
@@ -80,8 +84,8 @@ def install_pi_plugin(*, source: str, ref: str) -> PiSetupResult:
         data_dir=str(data_dir),
         authorization_state=configure_stored_authorization(
             "pi",
-            server_url="http://127.0.0.1:8000",
-            value=os.environ.get("POWERCONTEXT_CLIENT_API_TOKEN"),
+            server_url=setup_server_url("pi", "http://127.0.0.1:8000"),
+            value=setup_authorization_value("pi"),
         ),
     )
 

--- a/src/powercontext/cli/pi.py
+++ b/src/powercontext/cli/pi.py
@@ -49,6 +49,7 @@ class PiSetupResult:
     package: str
     package_path: str
     data_dir: str
+    authorization_state: str = "not_attempted"
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,10 +72,17 @@ def install_pi_plugin(*, source: str, ref: str) -> PiSetupResult:
     require_pi_package(package_dir)
     _run_pi("install", str(package_dir))
     _remove_existing_pi_packages(keep=package_dir)
+    from powercontext.cli.authorization import configure_stored_authorization
+
     return PiSetupResult(
         package=PI_PACKAGE_NAME,
         package_path=str(package_dir),
         data_dir=str(data_dir),
+        authorization_state=configure_stored_authorization(
+            "pi",
+            server_url="http://127.0.0.1:8000",
+            value=os.environ.get("POWERCONTEXT_CLIENT_API_TOKEN"),
+        ),
     )
 
 

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -333,6 +333,7 @@ class CodexSetupResult:
     plugin: str
     plugin_version: str
     data_dir: str
+    authorization_state: str = "not_attempted"
 
 
 @dataclass(frozen=True, slots=True)
@@ -343,6 +344,7 @@ class ClaudeCodeSetupResult:
     settings_file: str
     cache_dir: str
     data_dir: str
+    authorization_state: str = "not_attempted"
 
 
 @dataclass(frozen=True, slots=True)
@@ -1077,11 +1079,23 @@ def install_codex_plugin(*, source: str, ref: str, server_url: str | None = None
     plugin = _run_codex_json("plugin", "add", f"{PLUGIN_NAME}@{marketplace_name}")
     if server_url is not None:
         _configure_codex_endpoint(marketplace_name, _required_string(plugin, "version"), server_url)
+    from powercontext.cli.authorization import (
+        configure_stored_authorization,
+        setup_authorization_value,
+        setup_server_url,
+    )
+
+    authorization_state = configure_stored_authorization(
+        "codex",
+        server_url=setup_server_url("codex", server_url or DEFAULT_CLAUDE_CODE_SERVER_URL),
+        value=setup_authorization_value("codex"),
+    )
     return CodexSetupResult(
         marketplace=marketplace_name,
         plugin=_required_string(plugin, "name"),
         plugin_version=_required_string(plugin, "version"),
         data_dir=str(data_dir),
+        authorization_state=authorization_state,
     )
 
 
@@ -1175,6 +1189,11 @@ def install_claude_code_plugin(
         raise
 
     plan = _claude_setup_plan()
+    from powercontext.cli.authorization import configure_stored_authorization, setup_authorization_value
+
+    authorization_state = configure_stored_authorization(
+        "claude-code", server_url=server_url, value=setup_authorization_value("claude-code")
+    )
     return ClaudeCodeSetupResult(
         marketplace=CLAUDE_MARKETPLACE_NAME,
         plugin=PLUGIN_NAME,
@@ -1182,6 +1201,7 @@ def install_claude_code_plugin(
         settings_file=plan["settings_file"],
         cache_dir=plan["cache_dir"],
         data_dir=plan["data_dir"],
+        authorization_state=authorization_state,
     )
 
 

--- a/src/powercontext/cli/workbuddy.py
+++ b/src/powercontext/cli/workbuddy.py
@@ -132,7 +132,11 @@ def install_workbuddy_plugin(*, source: str, ref: str, server_url: str | None = 
         _remove_path(hooks_backup)
         _remove_path(skill_backup)
 
-    from powercontext.cli.authorization import configure_stored_authorization
+    from powercontext.cli.authorization import (
+        configure_stored_authorization,
+        setup_authorization_value,
+        setup_server_url,
+    )
 
     return WorkBuddySetupResult(
         plugin=WORKBUDDY_PLUGIN_NAME,
@@ -142,8 +146,8 @@ def install_workbuddy_plugin(*, source: str, ref: str, server_url: str | None = 
         data_dir=str(data_dir),
         authorization_state=configure_stored_authorization(
             "workbuddy",
-            server_url="http://127.0.0.1:8000",
-            value=os.environ.get("POWERCONTEXT_CLIENT_API_TOKEN"),
+            server_url=setup_server_url("workbuddy", "http://127.0.0.1:8000"),
+            value=setup_authorization_value("workbuddy"),
         ),
     )
 

--- a/src/powercontext/cli/workbuddy.py
+++ b/src/powercontext/cli/workbuddy.py
@@ -79,6 +79,7 @@ class WorkBuddySetupResult:
     workbuddy_home: str
     hooks_dir: str
     data_dir: str
+    authorization_state: str = "not_attempted"
 
 
 def install_workbuddy_plugin(*, source: str, ref: str, server_url: str | None = None) -> WorkBuddySetupResult:
@@ -131,12 +132,19 @@ def install_workbuddy_plugin(*, source: str, ref: str, server_url: str | None = 
         _remove_path(hooks_backup)
         _remove_path(skill_backup)
 
+    from powercontext.cli.authorization import configure_stored_authorization
+
     return WorkBuddySetupResult(
         plugin=WORKBUDDY_PLUGIN_NAME,
         plugin_path=str(plugin_dir),
         workbuddy_home=str(home),
         hooks_dir=str(hooks_dir),
         data_dir=str(data_dir),
+        authorization_state=configure_stored_authorization(
+            "workbuddy",
+            server_url="http://127.0.0.1:8000",
+            value=os.environ.get("POWERCONTEXT_CLIENT_API_TOKEN"),
+        ),
     )
 
 

--- a/tests/claude_code_plugin/test_contract.py
+++ b/tests/claude_code_plugin/test_contract.py
@@ -154,6 +154,23 @@ def test_saved_plugin_http_option_only_authorizes_its_own_endpoint(settings_modu
         settings_module.ClaudeCodePluginSettings.from_environment()
 
 
+@pytest.mark.parametrize(
+    "record",
+    [[], {"version": 1}, {"version": 1, "server_url": "http://127.0.0.1:8000"}],
+)
+def test_claude_settings_ignore_malformed_persisted_authorization_records(
+    settings_module: ModuleType,
+    tmp_path: Path,
+    record: object,
+) -> None:
+    credential = tmp_path / "powercontext" / "credentials.json"
+    credential.parent.mkdir()
+    credential.write_text(json.dumps(record), encoding="utf-8")
+    credential.chmod(0o600)
+
+    assert settings_module._stored_authorization(server_url="http://127.0.0.1:8000", root=tmp_path) is None
+
+
 def test_claude_integration_does_not_embed_machine_specific_windows_paths() -> None:
     roots = (
         REPOSITORY_ROOT / ".claude-plugin",

--- a/tests/codex_plugin/test_contract.py
+++ b/tests/codex_plugin/test_contract.py
@@ -154,6 +154,42 @@ def test_codex_settings_normalize_the_mcp_path_to_http_base(
     assert settings_module._http_base_url("https://memory.example/api/mcp/") == "https://memory.example/api"
 
 
+@pytest.mark.parametrize(
+    "record",
+    [[], {"version": 1}, {"version": 1, "server_url": "http://127.0.0.1:8000"}],
+)
+def test_codex_settings_ignore_malformed_persisted_authorization_records(
+    settings_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    record: object,
+) -> None:
+    credential = tmp_path / "powercontext" / "credentials.json"
+    credential.parent.mkdir()
+    credential.write_text(json.dumps(record), encoding="utf-8")
+    credential.chmod(0o600)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+    assert settings_module._stored_authorization("http://127.0.0.1:8000") is None
+
+
+def test_codex_settings_match_persisted_base_url_with_mcp_endpoint(
+    settings_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    credential = tmp_path / "powercontext" / "credentials.json"
+    credential.parent.mkdir()
+    credential.write_text(
+        json.dumps({"version": 1, "server_url": "http://127.0.0.1:8000", "authorization": "Bearer saved"}),
+        encoding="utf-8",
+    )
+    credential.chmod(0o600)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+    assert settings_module._stored_authorization("http://127.0.0.1:8000/mcp") == "Bearer saved"
+
+
 def test_codex_hooks_fix_session_and_data_plane_bindings() -> None:
     configuration = json.loads((PLUGIN_ROOT / "hooks" / "hooks.json").read_text())
 

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import json
@@ -12,6 +26,8 @@ from powercontext.cli.authorization import (
     credential_path,
     normalize_authorization,
     read_stored_authorization,
+    setup_authorization_value,
+    setup_server_url,
     write_stored_authorization,
 )
 
@@ -81,6 +97,15 @@ def test_clear_stored_authorization_is_idempotent(tmp_path: Path) -> None:
 
     assert clear_stored_authorization(path) == "cleared"
     assert clear_stored_authorization(path) == "not_configured"
+
+
+def test_setup_uses_host_specific_credentials_and_endpoints(monkeypatch) -> None:
+    monkeypatch.setenv("POWERCONTEXT_OPENCODE_AUTHORIZATION", "Bearer host-token")
+    monkeypatch.setenv("POWERCONTEXT_OPENCODE_BASE_URL", "https://memory.example/api")
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_API_TOKEN", "Bearer shared-token")
+
+    assert setup_authorization_value("opencode") == "Bearer host-token"
+    assert setup_server_url("opencode", "http://127.0.0.1:8000") == "https://memory.example/api"
 
 
 def test_credential_path_uses_host_owned_roots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from powercontext.cli.authorization import (
+    AuthorizationResolution,
+    clear_stored_authorization,
+    credential_path,
+    normalize_authorization,
+    read_stored_authorization,
+    write_stored_authorization,
+)
+
+
+def test_normalize_authorization_accepts_bare_tokens_and_headers() -> None:
+    assert normalize_authorization("  secret-token  ") == "Bearer secret-token"
+    assert normalize_authorization("bearer secret-token") == "Bearer secret-token"
+
+
+@pytest.mark.parametrize("value", ["", "Bearer", "Bearer a b", "token\n", "Bearer \x00token"])
+def test_normalize_authorization_rejects_invalid_values_without_echoing(value: str) -> None:
+    with pytest.raises(ValueError, match="authorization") as error:
+        normalize_authorization(value)
+    if value:
+        assert value not in str(error.value)
+
+
+def test_write_and_read_stored_authorization_is_atomic_and_private(tmp_path: Path) -> None:
+    path = tmp_path / "powercontext" / "credentials.json"
+
+    write_stored_authorization(path, server_url="http://127.0.0.1:8000", value="secret-token")
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert json.loads(path.read_text()) == {
+        "version": 1,
+        "server_url": "http://127.0.0.1:8000",
+        "authorization": "Bearer secret-token",
+    }
+    resolution = read_stored_authorization(path, server_url="http://127.0.0.1:8000")
+    assert resolution == AuthorizationResolution("configured", "Bearer secret-token")
+
+
+def test_read_stored_authorization_ignores_a_different_server_url(tmp_path: Path) -> None:
+    path = tmp_path / "credentials.json"
+    write_stored_authorization(path, server_url="https://one.example", value="secret-token")
+
+    assert read_stored_authorization(path, server_url="https://two.example") == AuthorizationResolution(
+        "url_mismatch", None
+    )
+
+
+def test_read_stored_authorization_fails_closed_for_unsafe_files(tmp_path: Path) -> None:
+    path = tmp_path / "credentials.json"
+    path.write_text(
+        json.dumps({"version": 1, "server_url": "https://one.example", "authorization": "Bearer secret-token"})
+    )
+    path.chmod(0o644)
+
+    assert read_stored_authorization(path, server_url="https://one.example") == AuthorizationResolution(
+        "unsafe_permissions", None
+    )
+
+
+def test_write_stored_authorization_rejects_a_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text("{}")
+    path = tmp_path / "credentials.json"
+    path.symlink_to(target)
+
+    with pytest.raises(ValueError, match="credential"):
+        write_stored_authorization(path, server_url="https://one.example", value="secret-token")
+
+
+def test_clear_stored_authorization_is_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "credentials.json"
+    write_stored_authorization(path, server_url="https://one.example", value="secret-token")
+
+    assert clear_stored_authorization(path) == "cleared"
+    assert clear_stored_authorization(path) == "not_configured"
+
+
+def test_credential_path_uses_host_owned_roots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path / "pi"))
+    monkeypatch.setenv("WORKBUDDY_HOME", str(tmp_path / "workbuddy"))
+
+    assert credential_path("codex") == tmp_path / "codex" / "powercontext" / "credentials.json"
+    assert credential_path("claude-code") == tmp_path / "claude" / "powercontext" / "credentials.json"
+    assert credential_path("pi") == tmp_path / "pi" / "powercontext" / "credentials.json"
+    assert credential_path("workbuddy") == tmp_path / "workbuddy" / "powercontext" / "credentials.json"

--- a/tests/test_cli_workbuddy.py
+++ b/tests/test_cli_workbuddy.py
@@ -105,6 +105,7 @@ def test_setup_workbuddy_installs_from_a_local_checkout(tmp_path: Path, monkeypa
         "workbuddy_home": str(home),
         "hooks_dir": str(home / "hooks"),
         "data_dir": str(tmp_path / "data"),
+        "authorization_state": "not_configured",
     }
 
     hooks_dir = home / "hooks"

--- a/tests/test_config_wizard_agents.py
+++ b/tests/test_config_wizard_agents.py
@@ -21,11 +21,8 @@ from powercontext.cli.config_wizard_agents import AGENT_SPECS
 from powercontext.cli.hosts import FIRST_CLASS_HOSTS
 
 
-def test_wizard_catalog_covers_first_class_hosts_and_workbuddy() -> None:
-    assert tuple(spec.identifier for spec in AGENT_SPECS) == (
-        *(host.name for host in FIRST_CLASS_HOSTS),
-        "workbuddy",
-    )
+def test_wizard_catalog_covers_first_class_hosts() -> None:
+    assert tuple(spec.identifier for spec in AGENT_SPECS) == tuple(host.name for host in FIRST_CLASS_HOSTS)
 
 
 def test_openclaw_keeps_its_plugin_configuration_contract() -> None:

--- a/tests/test_doctor_integrations.py
+++ b/tests/test_doctor_integrations.py
@@ -25,10 +25,11 @@ import powercontext.cli.openclaw as openclaw_cli
 import powercontext.cli.opencode as opencode_cli
 import powercontext.cli.pi as pi_cli
 import powercontext.cli.system as system_cli
+import powercontext.cli.workbuddy as workbuddy_cli
 from powercontext.cli.app import create_cli
 from powercontext.cli.system import Diagnostic, DiagnosticStatus, doctor_app
 
-FIRST_CLASS_HOSTS = ("codex", "claude-code", "dsh", "openclaw", "opencode", "pi", "hermes")
+FIRST_CLASS_HOSTS = ("codex", "claude-code", "dsh", "openclaw", "opencode", "pi", "hermes", "workbuddy")
 CLI_KEYS = {
     "codex": "codex",
     "claude-code": "claude_code",
@@ -37,6 +38,7 @@ CLI_KEYS = {
     "opencode": "opencode",
     "pi": "pi",
     "hermes": "hermes",
+    "workbuddy": "hooks",
 }
 INTEGRATION_KEYS = {
     "codex": ("plugin",),
@@ -46,6 +48,7 @@ INTEGRATION_KEYS = {
     "opencode": ("plugin", "skill"),
     "pi": ("package",),
     "hermes": ("plugin",),
+    "workbuddy": ("settings", "mcp", "skill"),
 }
 PATH_MISSING = {
     "codex": "Codex CLI is not installed or is not on PATH",
@@ -55,6 +58,7 @@ PATH_MISSING = {
     "opencode": "OpenCode CLI is not installed or is not on PATH",
     "pi": "Pi CLI is not installed or is not on PATH",
     "hermes": "Hermes CLI is not installed or is not on PATH",
+    "workbuddy": "WorkBuddy hooks are not installed",
 }
 
 
@@ -119,6 +123,7 @@ def _patch_diagnostics(monkeypatch, **replacements: Mock) -> dict[str, Mock]:
     monkeypatch.setattr(opencode_cli, "run_opencode_diagnostics", probes["opencode"])
     monkeypatch.setattr(pi_cli, "run_pi_diagnostics", probes["pi"])
     monkeypatch.setattr(hermes_cli, "run_hermes_diagnostics", probes["hermes"])
+    monkeypatch.setattr(workbuddy_cli, "run_workbuddy_diagnostics", probes["workbuddy"])
     return probes
 
 

--- a/tests/test_setup_select.py
+++ b/tests/test_setup_select.py
@@ -144,6 +144,7 @@ def test_setup_select_installs_only_the_requested_hosts(monkeypatch) -> None:
             {"host": "opencode", "status": "skipped"},
             {"host": "pi", "status": "skipped"},
             {"host": "hermes", "status": "skipped"},
+            {"host": "workbuddy", "status": "skipped"},
         ]
     }
     installers["codex"].assert_called_once()
@@ -179,6 +180,7 @@ def test_setup_select_continues_after_a_selected_host_fails(monkeypatch) -> None
             {"host": "opencode", "status": "skipped"},
             {"host": "pi", "status": "skipped"},
             {"host": "hermes", "status": "installed"},
+            {"host": "workbuddy", "status": "skipped"},
         ]
     }
     installers["dsh"].assert_called_once()

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -1021,6 +1021,7 @@ def test_setup_dsh_adds_plugin_from_a_local_checkout(tmp_path: Path, monkeypatch
         "plugin": "powercontext-dsh",
         "plugin_path": str(plugin),
         "data_dir": str(tmp_path / "data"),
+        "authorization_state": "not_configured",
     }
     assert run_dsh.call_args_list[0].args == (
         "plugin",

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -110,6 +110,7 @@ def test_setup_codex_installs_from_a_remote_ref_and_prepares_storage(
         "plugin": "powercontext",
         "plugin_version": "0.1.0",
         "data_dir": str(data_dir),
+        "authorization_state": "not_configured",
     }
     assert data_dir.is_dir()
     assert run_codex.call_args_list[0].args == (
@@ -126,6 +127,34 @@ def test_setup_codex_installs_from_a_remote_ref_and_prepares_storage(
         "powercontext@powercontext",
     )
     assert run_codex.call_args_list[2].args == ("plugin", "list")
+
+
+def test_setup_codex_persists_setup_only_token_in_codex_owned_storage(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("POWERCONTEXT_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
+    monkeypatch.setenv("POWERCONTEXT_CLIENT_API_TOKEN", "setup-token")
+    monkeypatch.setattr(system_cli, "which", lambda _name: "/usr/bin/codex")
+    monkeypatch.setattr(
+        system_cli,
+        "_run_codex_json",
+        Mock(
+            side_effect=[
+                {"marketplaceName": "powercontext"},
+                {"name": "powercontext", "version": "0.1.0"},
+            ]
+        ),
+    )
+
+    result = system_cli.install_codex_plugin(source="oceanbase/powercontext", ref="master")
+
+    assert result.authorization_state == "configured"
+    assert (
+        json.loads((tmp_path / "codex" / "powercontext" / "credentials.json").read_text())["authorization"]
+        == "Bearer setup-token"
+    )
 
 
 def test_setup_codex_uses_an_absolute_local_marketplace_without_a_ref(
@@ -216,6 +245,7 @@ def test_setup_claude_code_reports_mutations_then_installs_and_verifies(
         "settings_file": str(config_dir / "settings.json"),
         "cache_dir": str(config_dir / "plugins" / "cache" / "powercontext" / "powercontext" / "<version>"),
         "data_dir": str(config_dir / "plugins" / "data" / "powercontext-powercontext"),
+        "authorization_state": "not_configured",
     }
     assert "no changes made yet" in result.stderr
     assert str(config_dir / "settings.json") in result.stderr


### PR DESCRIPTION
Closes #1538.

## Summary

- Persist a setup-time PowerContext authorization in a host-owned, URL-bound credential file.
- Load credentials for Codex, Claude Code, DSH, OpenCode, Pi, and WorkBuddy without requiring an export before every session.
- Keep credentials out of plugin configuration and diagnostics; reject unsafe permissions, malformed records, and URL mismatches.
- Add setup authorization state reporting and user-facing quick-start documentation.

## Validation

- make check
- Focused Python suites: 111 passed
- OpenCode: 25 passed
- Pi: 50 passed
- DSH: 177 passed

This PR supersedes the closed draft PR #1539 and contains implementation, tests, and user-facing documentation only.

## AI usage

OpenAI Codex was used to inspect the repository, implement the change, and run validation. The human selected the host-owned credential persistence policy.