### PR TITLE
fix(website): support CRLF frontmatter

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -4,13 +4,14 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm generate && next dev",
-    "build": "pnpm check:links && next build && tsx scripts/redirect-docs.ts && pnpm verify:export",
+    "build": "pnpm test && pnpm check:links && next build && tsx scripts/redirect-docs.ts && pnpm verify:export",
     "check:links": "pnpm generate && tsx scripts/validate-links.ts",
     "generate": "tsx scripts/generate-content.ts",
     "preview": "serve out",
     "types:check": "next typegen && tsc --noEmit",
     "verify:export": "tsx scripts/verify-static-export.ts",
-    "lint": "oxlint"
+    "lint": "oxlint",
+    "test": "tsx --test tests/*.test.ts"
   },
   "dependencies": {
     "fumadocs-core": "16.15.4",

--- a/website/scripts/generate-content.ts
+++ b/website/scripts/generate-content.ts
@@ -64,7 +64,7 @@ async function prepareRfcContent(locale: string) {
       .map(async (entry) => {
         const filePath = path.join(rfcDir, entry.name);
         const content = await readFile(filePath, 'utf8');
-        if (content.startsWith('---\n')) return;
+        if (/^---\r?\n/.test(content)) return;
 
         const title = formatRfcTitle(entry.name, content);
         await writeFile(filePath, `---\ntitle: ${JSON.stringify(title)}\n---\n\n${content}`);
@@ -82,7 +82,7 @@ async function prepareDevelopmentContent(locale: string) {
       .map(async (entry) => {
         const filePath = path.join(developmentDir, entry.name);
         const content = await readFile(filePath, 'utf8');
-        if (content.startsWith('---\n')) return;
+        if (/^---\r?\n/.test(content)) return;
 
         const title = content.match(/^#\s+(.+)$/m)?.[1];
         if (!title) throw new Error(`Development document ${filePath} has no title`);

--- a/website/src/lib/benchmark-content.ts
+++ b/website/src/lib/benchmark-content.ts
@@ -200,7 +200,7 @@ type BenchmarkFrontmatter = {
 
 export async function getBenchmarkContent(lang: Language): Promise<BenchmarkContent> {
   const sourcePath = path.resolve(process.cwd(), '..', 'docs', lang, 'benchmarks', 'index.md');
-  const source = await readFile(sourcePath, 'utf8');
+  const source = (await readFile(sourcePath, 'utf8')).replace(/\r\n/g, '\n');
   const end = source.indexOf('\n---', 4);
 
   if (!source.startsWith('---\n') || end === -1) {

--- a/website/src/lib/home-content.ts
+++ b/website/src/lib/home-content.ts
@@ -64,7 +64,7 @@ type HomeFrontmatter = {
 
 export async function getHomeContent(lang: Language): Promise<HomeContent> {
   const sourcePath = path.resolve(process.cwd(), '..', 'docs', lang, 'index.md');
-  const source = await readFile(sourcePath, 'utf8');
+  const source = (await readFile(sourcePath, 'utf8')).replace(/\r\n/g, '\n');
   const end = source.indexOf('\n---', 4);
 
   if (!source.startsWith('---\n') || end === -1) {

--- a/website/tests/content.test.ts
+++ b/website/tests/content.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { getBenchmarkContent } from '../src/lib/benchmark-content';
+import { getHomeContent } from '../src/lib/home-content';
+
+const repositoryDir = fileURLToPath(new URL('../../', import.meta.url));
+
+for (const { name, relativePath, load, missingContent } of [
+  { name: 'Home', relativePath: 'index.md', load: getHomeContent, missingContent: 'Home content is missing' },
+  {
+    name: 'Benchmark', relativePath: 'benchmarks/index.md', load: getBenchmarkContent,
+    missingContent: 'Benchmark data is missing',
+  },
+]) {
+  for (const lang of ['en', 'zh'] as const) {
+    test(`${name} (${lang}) accepts LF, CRLF, and mixed line endings`, async () => {
+      const source = await readFile(path.join(repositoryDir, 'docs', lang, relativePath), 'utf8');
+      const lf = source.replace(/\r\n/g, '\n');
+      const root = await mkdtemp(path.join(os.tmpdir(), 'pc-content-'));
+      const cwd = process.cwd();
+      try {
+        await mkdir(path.join(root, 'website'));
+        const target = path.join(root, 'docs', lang, relativePath);
+        await mkdir(path.dirname(target), { recursive: true });
+        process.chdir(path.join(root, 'website'));
+        await writeFile(target, lf);
+        const expected = await load(lang);
+        assert.ok(Object.keys(expected).length > 0);
+        for (const content of [
+          lf.replace(/\n/g, '\r\n'),
+          lf.replace(/^---\n/, '---\r\n'),
+          lf.replace(/\n/g, '\r\n').replace(/^---\r\n/, '---\n'),
+        ]) {
+          await writeFile(target, content);
+          assert.deepEqual(await load(lang), expected);
+        }
+      } finally {
+        process.chdir(cwd);
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test(`${name} retains errors for missing or invalid content`, async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'pc-content-'));
+    const cwd = process.cwd();
+    try {
+      await mkdir(path.join(root, 'website'));
+      const target = path.join(root, 'docs', 'en', relativePath);
+      await mkdir(path.dirname(target), { recursive: true });
+      process.chdir(path.join(root, 'website'));
+      for (const newline of ['\n', '\r\n']) {
+        for (const [source, error] of [
+          ['# No frontmatter\n', new RegExp(`${name} frontmatter is missing`)],
+          ['---\nother: {}\n', new RegExp(`${name} frontmatter is missing`)],
+          ['---\nother: {}\n---\n', new RegExp(missingContent)],
+          ['---\ninvalid: [\n---\n', { name: 'YAMLParseError' }],
+        ] as const) {
+          await writeFile(target, source.replace(/\n/g, newline));
+          await assert.rejects(() => load('en'), error);
+        }
+      }
+    } finally {
+      process.chdir(cwd);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
# PR title

fix(website): support CRLF frontmatter

# Which issue or RFC does this PR close?

Closes #1499.

# Rationale for this change

Windows checkouts with `core.autocrlf=true` produce valid CRLF Markdown that the homepage and benchmark loaders reject as missing frontmatter. The loaders assume LF when checking the opening delimiter and slicing the YAML. The content generation script also mistakes existing CRLF frontmatter for an absent header and can prepend a second header.

# What changes are included in this PR?

- Normalize CRLF to LF in memory before locating and parsing homepage and benchmark frontmatter.
- Recognize both LF and CRLF opening delimiters when preparing RFC and development documents, preserving documents that already have frontmatter.
- Add six regression tests covering English and Chinese homepage and benchmark content, equivalent LF/CRLF/mixed line endings, and errors for absent frontmatter, an absent closing delimiter, malformed YAML, and missing page content.
- Run the website tests as part of the existing build command, using the existing `tsx` dependency and Node test runner.

# Are there any user-facing changes?

Homepages and benchmark pages load from CRLF checkouts, and content generation preserves existing CRLF frontmatter. This is a compatibility fix with no new API, configuration, dependencies, or persisted-format changes. Source Markdown files are not rewritten.

# How was this change tested?

Validation was performed on Windows against commit `60044739`, based on upstream `393c08b5`.

- Before the fix, all six regression tests failed; after the fix, `pnpm --dir website test` passed all six tests.
- `pnpm --dir website lint` passed.
- From `website/`, a focused TypeScript check passed: `node node_modules/typescript/bin/tsc --ignoreConfig --noEmit --strict --skipLibCheck --esModuleInterop --module esnext --moduleResolution bundler --target ES2022 --types node tests/content.test.ts`.
- The content generation stage completed. Four existing CRLF-frontmatter documents across English/Chinese RFC and development content were preserved unchanged in the generated output.
- A separate `next build` completed, including its full TypeScript check and generation of 699 static pages. Both localized homepages and benchmark pages were exported.
- Running `scripts/redirect-docs.ts` followed by `scripts/verify-static-export.ts` through `tsx` passed verification of 779 public pages and their internal links.
- `git diff --check` and `uv lock --check` passed.
- Pre-commit checks for the five changed files passed except for the repository-wide `ty-check` hook described below.

Validation limitations:

- `pnpm --dir website build` failed at the source-link validation gate with 704 errors across 164 files. An independent minimal fixture reproduced the Windows scanner defect described in #1500: `(group)/api/page.tsx` was indexed as `/(group)/api` instead of `/api`. The successful separate Next build and export verification do not constitute a passing full build command.
- The repository-wide Python `ty-check` hook reported seven Windows-specific diagnostics in unchanged `artifact_processing.py` and `test_artifact_processing.py` files, involving `PipeConnection` versus `Connection` and `os.WNOHANG`. This PR does not modify those files.
- The Python unit/e2e suites, OpenAPI contract tests, and tox matrix were not run for this website-only change.

# AI usage statement

OpenAI Codex（GPT-6）assisted with issue and branch inspection, reproduction, implementation, regression tests, and validation. Maintainer review is still required.