### PR TITLE
chore(release): prepare v1.0.0rc2

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -66,7 +66,7 @@ jobs:
           if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:(?:a|b|rc)[0-9]+)?", version):
               raise SystemExit(
                   "release_tag must use X.Y.Z with optional aN, bN, or rcN suffix and "
-                  "optional v or powercontext-v prefix (for example, powercontext-v1.0.0rc1)"
+                  "optional v or powercontext-v prefix (for example, powercontext-v1.0.0rc2)"
               )
 
           package = os.environ["RELEASE_PACKAGE"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:(?:a|b|rc)[0-9]+)?", release_version):
               raise SystemExit(
                   "Release tag must use X.Y.Z with optional aN, bN, or rcN suffix and "
-                  "optional v or powercontext-v prefix (for example, powercontext-v1.0.0rc1)"
+                  "optional v or powercontext-v prefix (for example, powercontext-v1.0.0rc2)"
               )
 
           package_version = subprocess.check_output(

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ PowerContext keeps context with the work across conversations. When you return, 
 
 [Website](https://frf12.github.io/powercontext/) · [Installation walkthrough](https://frf12.github.io/powercontext/en/docs/get-started/quickstart/)
 
-The upstream repository provides the guided setup on `master`. The commands and website below use that same
-source version; installing the PyPI release does not install this wizard.
+PowerContext 1.0.0 RC2 includes the guided setup. The commands below install this pre-release and connect
+the matching Agent integration for testing.
 
 ## Pick up where the work left off
 
@@ -30,10 +30,10 @@ You decide what will matter later and what needs to move with the task. PowerCon
 You need Git, [uv](https://docs.astral.sh/uv/getting-started/installation/), and your Agent's CLI.
 Python 3.11+ is required; uv can provision it. macOS and Linux are supported; Windows support is `experimental`.
 
-Install this build and open the interactive configuration wizard in a dedicated directory:
+Install 1.0.0 RC2 and open the interactive configuration wizard in a dedicated directory:
 
 ```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
 mkdir -p powercontext-config
 cd powercontext-config
 powercontext config init --language en --output .env
@@ -71,7 +71,7 @@ covers Codex and Claude Code, Dashboard login, SSH forwarding, HTTPS prerequisit
 For example, the matching Codex installation is:
 
 ```bash
-powercontext setup codex
+powercontext setup codex --ref powercontext-v1.0.0rc2
 powercontext doctor codex
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -16,8 +16,7 @@ PowerContext 让上下文跟随工作，跨越不同的对话。你回来时，�
 
 [网站](https://frf12.github.io/powercontext/zh/) · [完整安装流程](https://frf12.github.io/powercontext/zh/docs/get-started/quickstart/)
 
-上游仓库的 `master` 分支提供配置向导。下面的安装命令和网站文档使用同一份源码；
-直接安装 PyPI 发布版不会得到这套向导。
+PowerContext 1.0.0 RC2 包含交互式配置向导。下面的命令安装这一预发布版本，并接入相同版本的 Agent 集成，供测试使用。
 
 ## 从当前进展继续
 
@@ -30,10 +29,10 @@ PowerContext 让上下文跟随工作，跨越不同的对话。你回来时，�
 准备 Git、[uv](https://docs.astral.sh/uv/getting-started/installation/) 和你使用的 Agent CLI。
 需要 Python 3.11+，uv 可以按需安装。支持 macOS 和 Linux；Windows 支持为 `experimental`。
 
-安装本分支版本，然后在独立目录里打开交互式配置向导：
+安装 1.0.0 RC2，然后在独立目录里打开交互式配置向导：
 
 ```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
 mkdir -p powercontext-config
 cd powercontext-config
 powercontext config init --language zh --output .env
@@ -67,7 +66,7 @@ powercontext capabilities
 SSH 隧道、HTTPS 前提及逐项验收。例如，匹配本版本的 Codex 安装命令是：
 
 ```bash
-powercontext setup codex
+powercontext setup codex --ref powercontext-v1.0.0rc2
 powercontext doctor codex
 ```
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -16,8 +16,8 @@ PowerContext は、会話をまたいでもコンテキストを作業ととも�
 
 [Web サイト](https://frf12.github.io/powercontext/en/) · [インストール手順](https://frf12.github.io/powercontext/en/docs/get-started/quickstart/)
 
-上流の `master` ブランチが対話式セットアップを提供します。
-以下のコマンドと Web サイトは同じソースを使用します。PyPI リリースにはこのウィザードは含まれません。
+PowerContext 1.0.0 RC2 には対話式セットアップが含まれています。
+以下のコマンドで検証用のプレリリースと同じバージョンの Agent 連携をインストールします。
 
 ## 作業の続きをそのまま引き継ぐ
 
@@ -27,10 +27,10 @@ PowerContext は、会話をまたいでもコンテキストを作業ととも�
 
 ## 利用中の Agent と接続する
 
-Git、uv、Agent CLI を用意して、このブランチからインストールします：
+Git、uv、Agent CLI を用意して、1.0.0 RC2 をインストールします：
 
 ```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
 mkdir -p powercontext-config
 cd powercontext-config
 powercontext config init --language en --output .env
@@ -50,7 +50,7 @@ Server を起動したまま、別のターミナルで同じ設定ディレク�
 クライアント環境の読み込み、Scope の作成・紐付け、同じバージョンの Agent プラグインのインストールを行います。例：
 
 ```bash
-powercontext setup codex
+powercontext setup codex --ref powercontext-v1.0.0rc2
 powercontext doctor codex
 ```
 

--- a/docs/en/docs/get-started/install-and-run.md
+++ b/docs/en/docs/get-started/install-and-run.md
@@ -1,6 +1,6 @@
 ---
 title: Install and run
-description: Install PowerContext from Git and run the local Server.
+description: Install PowerContext 1.0.0 RC2 and run the local Server.
 ---
 
 # Install and run
@@ -24,31 +24,38 @@ Embedded seekDB is unavailable on Windows.
 
 ## Choose a version
 
-Keep a released package and integration on the same tag. For example, install `0.2.0`:
+These instructions use PowerContext 1.0.0 RC2 for pre-release testing. Keep the package and Agent integration on
+the same version: package `1.0.0rc2` and Git tag `powercontext-v1.0.0rc2`.
 
 ```bash
-uv tool install "powercontext[cli,server]==0.2.0"
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+powercontext setup codex --ref powercontext-v1.0.0rc2
 ```
 
-The following examples use `master`, including unreleased capabilities. Check the
-[capability matrix](../integrations/capabilities.md); `master_only` and `experimental` capabilities
-are not release guarantees.
+Check the [capability matrix](../integrations/capabilities.md) for host support and maintenance status.
+Capabilities marked `experimental` remain experimental in this release candidate.
 
 ## Install the application
 
 You need Python 3.11 or newer, Git, and [`uv`](https://docs.astral.sh/uv/) on macOS, Linux, or Windows. Then install
-PowerContext directly from a Git ref:
+PowerContext from PyPI:
 
 ```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
 ```
 
-The command does not leave a repository checkout for you to manage. Git uses its normal credential configuration,
+For a source installation of the same version:
+
+```bash
+uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@powercontext-v1.0.0rc2"
+```
+
+The Git command does not leave a repository checkout for you to manage. Git uses its normal credential configuration,
 including credential helpers and SSH settings. For an SSH-based install, replace the HTTPS URL with the Git URL
 approved for your environment. `--force` also refreshes an existing tool from the current commit behind the selected
 Git ref; without it, `uv` may report the same requirement as already installed without fetching a newer `master`.
 
-To install a tested branch or tag, replace `master` after the final `@`.
+To install another branch or tag, replace the ref after the final `@`. The `master` branch can include unreleased changes.
 Follow the [guide for each integration](../integrations/index.md) for Agent installation, connection options, and verification, using the same ref as the Server.
 
 ## Run the local Server
@@ -105,7 +112,7 @@ Embedded seekDB is available on Linux and macOS when a compatible `pylibseekdb` 
 support this embedded backend. Install or replace the tool with the optional seekDB extra:
 
 ```bash
-uv tool install --force "powercontext[cli,server,seekdb] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv tool install --force "powercontext[cli,server,seekdb]==1.0.0rc2"
 ```
 
 When switching from SQLite, remove `POWERCONTEXT_SERVER_DATABASE_URL` from the Server process environment. An explicit
@@ -153,7 +160,13 @@ For a long-running process, Docker, authentication, or remote access, continue w
 
 ## Update or replace an installation
 
-To replace the installed tool with a chosen ref:
+To upgrade to 1.0.0 RC2:
+
+```bash
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+```
+
+To replace the installed tool with another Git ref:
 
 ```bash
 uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@<ref>"
@@ -168,7 +181,7 @@ changes.
 An application that imports the async Client SDK should add it to that application's environment:
 
 ```bash
-uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv add "powercontext[client]==1.0.0rc2"
 ```
 
 Use `builtin` for in-process Python composition, `server` for the service, `client` for the Python SDK, or `cli` for

--- a/docs/en/docs/get-started/quickstart.md
+++ b/docs/en/docs/get-started/quickstart.md
@@ -6,8 +6,8 @@ description: Configure full memory, connect Codex, and verify Source capture, To
 # Quick Start
 
 Start with installation, discuss a project in Codex, watch its input become Source evidence and an evolving topic,
-then recover the decisions in a new session. These instructions use the `master` branch of
-`oceanbase/powercontext` for both the Server and the Agent plugin.
+then recover the decisions in a new session. These instructions use PowerContext 1.0.0 RC2 for pre-release testing,
+with the Agent plugin from the matching `powercontext-v1.0.0rc2` tag.
 
 You need macOS or Linux, Python 3.11+, Git, [uv](https://docs.astral.sh/uv/getting-started/installation/),
 and an installed Codex CLI. Full memory also needs working Generation and Embedding model APIs:
@@ -18,7 +18,7 @@ and recall; that does not enable automatic Topic Memory.
 ## 1. Install and open the wizard
 
 ```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
 mkdir -p ~/powercontext-demo
 cd ~/powercontext-demo
 powercontext config init --language en --output .env
@@ -94,7 +94,7 @@ Reload the client settings and install the matching plugin:
 set -a
 . ./.env
 set +a
-powercontext setup codex
+powercontext setup codex --ref powercontext-v1.0.0rc2
 powercontext doctor codex
 codex
 ```

--- a/docs/zh/docs/get-started/install-and-run.md
+++ b/docs/zh/docs/get-started/install-and-run.md
@@ -1,6 +1,6 @@
 ---
 title: 安装和运行
-description: 从 Git 安装 PowerContext，并运行本地 Server。
+description: 安装 PowerContext 1.0.0 RC2，并运行本地 Server。
 ---
 
 # 安装和运行
@@ -22,29 +22,37 @@ Windows 的 CLI、Server 和个人服务支持为试验性；各 Agent Host 仍�
 
 ## 选择版本
 
-发布版与集成使用相同 tag。例如安装 `0.2.0`：
+本页使用 PowerContext 1.0.0 RC2 预发布版本，供测试使用。包与 Agent 集成保持版本一致：
+Python 包版本为 `1.0.0rc2`，对应 Git tag 为 `powercontext-v1.0.0rc2`。
 
 ```bash
-uv tool install "powercontext[cli,server]==0.2.0"
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+powercontext setup codex --ref powercontext-v1.0.0rc2
 ```
 
-后续示例使用 `master`，包含尚未发布的能力。核对[能力矩阵](../integrations/capabilities.md)，
-不要将 `master_only` 或 `experimental` 能力当作发布版承诺。
+宿主支持范围和维护状态见[能力矩阵](../integrations/capabilities.md)。
+标为 `experimental` 的能力在这个候选版本中仍属于试验性能力。
 
 ## 安装应用
 
 需要在 macOS、Linux 或 Windows 上准备 Python 3.11 或更新版本、Git 和
-[`uv`](https://docs.astral.sh/uv/)，然后从指定 Git ref 直接安装 PowerContext：
+[`uv`](https://docs.astral.sh/uv/)，然后从 PyPI 安装 PowerContext：
 
 ```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
 ```
 
-该命令不会留下需要自行管理的仓库工作副本。Git 会沿用本机的凭据配置，包括 credential helper 和 SSH 设置。
+如需从源码安装同一版本：
+
+```bash
+uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@powercontext-v1.0.0rc2"
+```
+
+Git 安装命令不会留下需要自行管理的仓库工作副本。Git 会沿用本机的凭据配置，包括 credential helper 和 SSH 设置。
 如需使用 SSH，请把 HTTPS URL 换成当前环境允许的 Git URL。`--force` 还会从所选 Git ref 当前指向的 commit
 刷新已安装工具；如果不加该参数，`uv` 可能只提示相同 requirement 已安装，而不会获取更新后的 `master`。
 
-安装指定分支或 tag 时，替换最后一个 `@` 后的 `master`。
+安装其他分支或 tag 时，替换最后一个 `@` 后的 ref。`master` 分支可能包含尚未发布的改动。
 Agent 的安装、连接参数和验证步骤见[各自的集成文档](../integrations/index.md)，并使用与 Server 相同的 ref。
 
 ## 运行本地 Server
@@ -97,7 +105,7 @@ powercontext server run --env-file /path/to/powercontext.env
 后端。安装或替换工具时加入可选的 seekDB extra：
 
 ```bash
-uv tool install --force "powercontext[cli,server,seekdb] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv tool install --force "powercontext[cli,server,seekdb]==1.0.0rc2"
 ```
 
 从 SQLite 切换时，需要从 Server 进程环境中删除 `POWERCONTEXT_SERVER_DATABASE_URL`；seekDB 不接受显式的
@@ -142,7 +150,13 @@ Agent 诊断见[各自的集成文档](../integrations/index.md)；Server 状态
 
 ## 更新或替换安装
 
-使用指定 ref 替换现有工具：
+升级到 1.0.0 RC2：
+
+```bash
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+```
+
+使用其他 Git ref 替换现有工具：
 
 ```bash
 uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@<ref>"
@@ -156,7 +170,7 @@ uv tool install --force "powercontext[cli,server] @ git+https://github.com/ocean
 如果应用需要导入异步 Client SDK，应把它加入该应用自己的环境：
 
 ```bash
-uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv add "powercontext[client]==1.0.0rc2"
 ```
 
 进程内 Python 组合使用 `builtin`，服务使用 `server`，Python SDK 使用 `client`，基于 Server 的命令行使用

--- a/docs/zh/docs/get-started/quickstart.md
+++ b/docs/zh/docs/get-started/quickstart.md
@@ -6,7 +6,8 @@ description: 通过配置向导安装完整记忆能力，接入 Codex，并验�
 # 快速开始
 
 本页从安装开始，带你完成一次真实的记忆体验：在 Codex 中讨论项目，看到原始输入进入 Source、主题记忆生成并演进，
-再在新会话中找回决策。以下命令使用 `oceanbase/powercontext` 的默认安装来源，Server 和 Agent 插件保持同源。
+再在新会话中找回决策。以下命令使用 PowerContext 1.0.0 RC2 预发布版本，Agent 插件使用对应的
+`powercontext-v1.0.0rc2` tag，供测试使用。
 
 需要 macOS 或 Linux、Python 3.11+、Git、[uv](https://docs.astral.sh/uv/getting-started/installation/) 和已安装的 Codex CLI。
 完整记忆还需要可用的 Generation 和 Embedding 模型 API；准备好各自的地址、模型名和 API key。
@@ -16,7 +17,7 @@ Codex 或 Claude 的订阅登录不会自动为 PowerContext Server 提供这些
 ## 1. 安装并进入配置向导
 
 ```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+uv tool install --force "powercontext[cli,server]==1.0.0rc2"
 mkdir -p ~/powercontext-demo
 cd ~/powercontext-demo
 powercontext config init --language zh --output .env
@@ -91,7 +92,7 @@ POWERCONTEXT_CODEX_SCOPE_ID=替换为返回的scope_id
 set -a
 . ./.env
 set +a
-powercontext setup codex
+powercontext setup codex --ref powercontext-v1.0.0rc2
 powercontext doctor codex
 codex
 ```

--- a/openapi/powercontext.yaml
+++ b/openapi/powercontext.yaml
@@ -16,7 +16,7 @@ openapi: 3.0.3
 info:
   title: PowerContext API
   description: Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.
-  version: 1.0.0rc1
+  version: 1.0.0rc2
 security:
   - BearerAuth: []
   - {}

--- a/src/powercontext/http/_generated/operations.py
+++ b/src/powercontext/http/_generated/operations.py
@@ -175,7 +175,7 @@ from powercontext.http._generated.models import (
 OPENAPI_VERSION = "3.0.3"
 API_TITLE = "PowerContext API"
 API_DESCRIPTION = "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities."
-API_VERSION = "1.0.0rc1"
+API_VERSION = "1.0.0rc2"
 
 RequestT = TypeVar("RequestT")
 ResponseT = TypeVar("ResponseT")

--- a/src/powercontext/http/_generated/schema.py
+++ b/src/powercontext/http/_generated/schema.py
@@ -7,7 +7,7 @@ OPENAPI_SCHEMA: dict[str, JsonValue] = {
     "info": {
         "title": "PowerContext API",
         "description": "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.",
-        "version": "1.0.0rc1",
+        "version": "1.0.0rc2",
     },
     "paths": {
         "/v1/scopes/{scope_id}/subject-sources": {

--- a/tests/test_ci_release_verification.py
+++ b/tests/test_ci_release_verification.py
@@ -87,6 +87,7 @@ def run_release_step(tmp_path: Path):
     ("tag", "version"),
     [
         ("powercontext-v1.0.0rc1", "1.0.0rc1"),
+        ("powercontext-v1.0.0rc2", "1.0.0rc2"),
         ("v1.0.0b2", "1.0.0b2"),
         ("1.0.0a1", "1.0.0a1"),
         ("powercontext-v1.0.0", "1.0.0"),

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -63,7 +63,7 @@ def test_init_creates_a_model_free_deployment_and_explains_capability_limits(tmp
     assert shown.exit_code == 0
 
 
-@pytest.mark.parametrize("installed", ["0.2.0", "1.0.0rc1", "0.2.1.dev1+g1234567"])
+@pytest.mark.parametrize("installed", ["0.2.0", "1.0.0rc1", "1.0.0rc2", "0.2.1.dev1+g1234567"])
 def test_init_matches_dsh_setup_to_installed_server(installed: str, tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(config_cli, "version", lambda _name: installed)
     monkeypatch.setattr(config_cli, "collect_configuration", lambda **_kwargs: _configuration())
@@ -72,7 +72,7 @@ def test_init_matches_dsh_setup_to_installed_server(installed: str, tmp_path: Pa
     )
     assert result.exit_code == 0
     command = next(line.strip() for line in result.output.splitlines() if "powercontext setup dsh" in line)
-    if installed in {"0.2.0", "1.0.0rc1"}:
+    if installed in {"0.2.0", "1.0.0rc1", "1.0.0rc2"}:
         assert command.endswith(f"--ref powercontext-v{installed}")
     else:
         assert "--source /path/to/matching-powercontext-checkout" in command

--- a/website/src/app/(localized)/[lang]/changelog/page.tsx
+++ b/website/src/app/(localized)/[lang]/changelog/page.tsx
@@ -28,13 +28,15 @@ import { baseOptions } from '@/lib/site';
 const labels = {
   en: {
     title: 'Changelog',
-    description: 'Tagged PowerContext releases and changes that affect users. Design proposals remain in RFCs until they ship.',
+    description: 'Stable PowerContext releases and changes that affect users.',
+    prereleases: 'For alpha, beta, and RC versions, see',
     read: 'Read more',
     github: 'GitHub release',
   },
   zh: {
     title: '更新日志',
-    description: '这里记录 PowerContext 的正式版本，以及会影响使用方式的变化。尚未交付的设计仍保留在 RFC 中。',
+    description: '这里记录 PowerContext 的正式版本，以及会影响使用方式的变化。',
+    prereleases: 'alpha、beta 和 RC 版本请查看',
     read: '阅读更多',
     github: 'GitHub Release',
   },
@@ -51,7 +53,12 @@ export default async function ChangelogPage({ params }: { params: Promise<{ lang
         <div className="max-w-3xl">
           <header>
             <DocsTitle>{text.title}</DocsTitle>
-            <DocsDescription>{text.description}</DocsDescription>
+            <DocsDescription>
+              {text.description} {text.prereleases}{' '}
+              <Link className="underline underline-offset-4" href="https://github.com/oceanbase/powercontext/releases">
+                GitHub Releases
+              </Link>
+            </DocsDescription>
           </header>
           <Cards className="grid-cols-1">
             {releases.map((release) => (

--- a/website/src/lib/releases.ts
+++ b/website/src/lib/releases.ts
@@ -28,6 +28,38 @@ export interface Release {
 
 export const releases: Release[] = [
   {
+    version: 'v1.0.0rc2',
+    date: '2026-09-10',
+    title: {
+      en: '1.0.0 RC2: guided setup and reviewed learning workflows',
+      zh: '1.0.0 RC2：配置向导与可审核的经验沉淀',
+    },
+    summary: {
+      en: 'This release candidate adds interactive Server and Agent onboarding, persistent Agent authorization, a Topic Memory dashboard, and reviewed workflows from Memory to Experience and Skill.',
+      zh: '这个候选版本新增 Server 与 Agent 交互式配置向导、Agent 授权持久化、Topic Memory 面板，以及从 Memory 到 Experience、Skill 的审核工作流。',
+    },
+    changes: {
+      en: [
+        'Configure storage, model APIs, memory capabilities, Dashboard access, and Agent connections through powercontext config init, with an environment file and next-step instructions.',
+        'Persist PowerContext Agent authorization during setup so installed integrations can reuse their configured credentials.',
+        'Inspect Topic Memory in the Dashboard, including topic content and its supporting evidence.',
+        'Use Dream workflows to prepare Experience and Skill candidates from saved context, review them, and explicitly approve reusable results.',
+        'Require explicit consent for remote plain-HTTP connections across clients and integrations, with --allow-insecure-http for unattended setup.',
+        'Install package 1.0.0rc2 and update Agent integrations from powercontext-v1.0.0rc2, then restart the Server and open a new Agent session. This is a pre-release for testing.',
+      ],
+      zh: [
+        '通过 powercontext config init 配置存储、模型 API、记忆能力、Dashboard 访问和 Agent 连接，生成环境文件与后续操作说明。',
+        '安装集成时持久化 PowerContext Agent 授权，让已安装的集成复用配置好的凭据。',
+        '在 Dashboard 中查看 Topic Memory，包括主题内容及其证据。',
+        '通过 Dream 工作流从已保存的上下文准备 Experience 和 Skill 候选，审核并显式批准可复用的结果。',
+        '客户端和集成连接远程明文 HTTP 时需要显式同意；非交互安装使用 --allow-insecure-http。',
+        '安装 1.0.0rc2 包，并从 powercontext-v1.0.0rc2 更新 Agent 集成，然后重启 Server、开启新 Agent 会话。这是供测试使用的预发布版本。',
+      ],
+    },
+    installCommand: 'uv tool install --force "powercontext[cli,server]==1.0.0rc2"',
+    githubUrl: 'https://github.com/oceanbase/powercontext/releases/tag/powercontext-v1.0.0rc2',
+  },
+  {
     version: 'v0.2.0',
     date: '2026-09-07',
     title: {

--- a/website/src/lib/releases.ts
+++ b/website/src/lib/releases.ts
@@ -26,75 +26,8 @@ export interface Release {
   githubUrl: string;
 }
 
+// Only stable releases belong here; publish pre-release notes on GitHub Releases.
 export const releases: Release[] = [
-  {
-    version: 'v1.0.0rc2',
-    date: '2026-09-10',
-    title: {
-      en: '1.0.0 RC2: guided setup and reviewed learning workflows',
-      zh: '1.0.0 RC2：配置向导与可审核的经验沉淀',
-    },
-    summary: {
-      en: 'This release candidate adds interactive Server and Agent onboarding, persistent Agent authorization, and reviewed workflows from Memory to Experience and Skill.',
-      zh: '这个候选版本新增 Server 与 Agent 交互式配置向导、Agent 授权持久化，以及从 Memory 到 Experience、Skill 的审核工作流。',
-    },
-    changes: {
-      en: [
-        'Configure storage, model APIs, memory capabilities, Dashboard access, and Agent connections through powercontext config init, with an environment file and next-step instructions.',
-        'Persist PowerContext Agent authorization during setup so installed integrations can reuse their configured credentials.',
-        'Use Dream workflows to prepare Experience and Skill candidates from saved context, review them, and explicitly approve reusable results.',
-        'Require explicit consent for remote plain-HTTP connections across clients and integrations, with --allow-insecure-http for unattended setup.',
-        'Install package 1.0.0rc2 and update Agent integrations from powercontext-v1.0.0rc2, then restart the Server and open a new Agent session. This is a pre-release for testing.',
-      ],
-      zh: [
-        '通过 powercontext config init 配置存储、模型 API、记忆能力、Dashboard 访问和 Agent 连接，生成环境文件与后续操作说明。',
-        '安装集成时持久化 PowerContext Agent 授权，让已安装的集成复用配置好的凭据。',
-        '通过 Dream 工作流从已保存的上下文准备 Experience 和 Skill 候选，审核并显式批准可复用的结果。',
-        '客户端和集成连接远程明文 HTTP 时需要显式同意；非交互安装使用 --allow-insecure-http。',
-        '安装 1.0.0rc2 包，并从 powercontext-v1.0.0rc2 更新 Agent 集成，然后重启 Server、开启新 Agent 会话。这是供测试使用的预发布版本。',
-      ],
-    },
-    installCommand: 'uv tool install --force "powercontext[cli,server]==1.0.0rc2"',
-    githubUrl: 'https://github.com/oceanbase/powercontext/releases/tag/powercontext-v1.0.0rc2',
-  },
-  {
-    version: 'v1.0.0rc1',
-    date: '2026-09-10',
-    title: {
-      en: '1.0.0 RC1: Topic Memory and configurable Agent context',
-      zh: '1.0.0 RC1：主题记忆与可配置的 Agent 上下文',
-    },
-    summary: {
-      en: 'The first 1.0.0 release candidate adds Topic Memory, scoped Prompts and Profiles, unified tags, configurable context assembly, and a personal Dashboard for testing context capture, retrieval, and handoff.',
-      zh: '首个 1.0.0 候选版本新增 Topic Memory、按 Scope 管理的 Prompt 和 Profile、统一标签、可配置的上下文组装，以及个人 Dashboard，用于验证上下文积累、检索和交接。',
-    },
-    changes: {
-      en: [
-        'Extract and maintain Topic Memory from Sources, with background Artifact processing supervisors to manage ongoing updates.',
-        'Configure the Prepared Context text delivered to Agents through optional context assembly.',
-        'Manage Prompts and Profiles within Scopes, tag Artifacts and Memory Entries, and discover Scopes and Sources through the API.',
-        'Save Sources and explicit Memory without a model by default, and load local environment files at Server startup. Automatic extraction and vector retrieval require configured inference services.',
-        'Use the opt-in personal Dashboard to inspect saved context, including Topic Memory and its evidence. The Dashboard is disabled by default and requires authentication when enabled.',
-        'Connect MiniMax, use improved DSH configuration diagnostics and installation guidance, and send MCP authorization headers correctly in Claude Code.',
-        'Fix revoked Scope contributions, raw Skill ZIP path validation, and conditional Artifact reads.',
-        'Follow bilingual workflow guides and Jupyter tutorials, and search the documentation site in English or Chinese.',
-        'Back up databases and configuration before upgrading. Install package 1.0.0rc1 with integrations from powercontext-v1.0.0rc1, then restart the Server and Agent sessions. This is a pre-release for testing.',
-      ],
-      zh: [
-        '从 Source 提取并维护 Topic Memory，通过后台 Artifact 处理监督器管理持续更新。',
-        '通过可选的上下文组装，配置 Agent 实际收到的 Prepared Context 文本。',
-        '在 Scope 内管理 Prompt 和 Profile，为 Artifact 与 Memory Entry 添加标签，并通过 API 查询 Scope 和 Source。',
-        '默认无需模型即可保存 Source 和显式 Memory，启动 Server 时支持读取本地环境文件；自动提取和向量检索仍需配置推理服务。',
-        '通过可选的个人 Dashboard 查看已保存的上下文，包括 Topic Memory 及其证据。Dashboard 默认关闭，启用时需要配置认证。',
-        '新增 MiniMax 集成，完善 DSH 配置诊断和安装指引，并修复 Claude Code 的 MCP 认证头传递。',
-        '修复撤销权限后的 Scope 上下文贡献、Skill ZIP 原始路径校验和 Artifact 条件读取问题。',
-        '提供中英文工作流指南、Jupyter 教程和按语言搜索的网站文档。',
-        '升级前备份数据库与配置。安装 1.0.0rc1 包，并从 powercontext-v1.0.0rc1 安装匹配的集成，再重启 Server 和 Agent 会话。这是供测试使用的预发布版本。',
-      ],
-    },
-    installCommand: 'uv tool install --force "powercontext[cli,server]==1.0.0rc1"',
-    githubUrl: 'https://github.com/oceanbase/powercontext/releases/tag/powercontext-v1.0.0rc1',
-  },
   {
     version: 'v0.2.0',
     date: '2026-09-07',

--- a/website/src/lib/releases.ts
+++ b/website/src/lib/releases.ts
@@ -35,14 +35,13 @@ export const releases: Release[] = [
       zh: '1.0.0 RC2：配置向导与可审核的经验沉淀',
     },
     summary: {
-      en: 'This release candidate adds interactive Server and Agent onboarding, persistent Agent authorization, a Topic Memory dashboard, and reviewed workflows from Memory to Experience and Skill.',
-      zh: '这个候选版本新增 Server 与 Agent 交互式配置向导、Agent 授权持久化、Topic Memory 面板，以及从 Memory 到 Experience、Skill 的审核工作流。',
+      en: 'This release candidate adds interactive Server and Agent onboarding, persistent Agent authorization, and reviewed workflows from Memory to Experience and Skill.',
+      zh: '这个候选版本新增 Server 与 Agent 交互式配置向导、Agent 授权持久化，以及从 Memory 到 Experience、Skill 的审核工作流。',
     },
     changes: {
       en: [
         'Configure storage, model APIs, memory capabilities, Dashboard access, and Agent connections through powercontext config init, with an environment file and next-step instructions.',
         'Persist PowerContext Agent authorization during setup so installed integrations can reuse their configured credentials.',
-        'Inspect Topic Memory in the Dashboard, including topic content and its supporting evidence.',
         'Use Dream workflows to prepare Experience and Skill candidates from saved context, review them, and explicitly approve reusable results.',
         'Require explicit consent for remote plain-HTTP connections across clients and integrations, with --allow-insecure-http for unattended setup.',
         'Install package 1.0.0rc2 and update Agent integrations from powercontext-v1.0.0rc2, then restart the Server and open a new Agent session. This is a pre-release for testing.',
@@ -50,7 +49,6 @@ export const releases: Release[] = [
       zh: [
         '通过 powercontext config init 配置存储、模型 API、记忆能力、Dashboard 访问和 Agent 连接，生成环境文件与后续操作说明。',
         '安装集成时持久化 PowerContext Agent 授权，让已安装的集成复用配置好的凭据。',
-        '在 Dashboard 中查看 Topic Memory，包括主题内容及其证据。',
         '通过 Dream 工作流从已保存的上下文准备 Experience 和 Skill 候选，审核并显式批准可复用的结果。',
         '客户端和集成连接远程明文 HTTP 时需要显式同意；非交互安装使用 --allow-insecure-http。',
         '安装 1.0.0rc2 包，并从 powercontext-v1.0.0rc2 更新 Agent 集成，然后重启 Server、开启新 Agent 会话。这是供测试使用的预发布版本。',
@@ -58,6 +56,44 @@ export const releases: Release[] = [
     },
     installCommand: 'uv tool install --force "powercontext[cli,server]==1.0.0rc2"',
     githubUrl: 'https://github.com/oceanbase/powercontext/releases/tag/powercontext-v1.0.0rc2',
+  },
+  {
+    version: 'v1.0.0rc1',
+    date: '2026-09-10',
+    title: {
+      en: '1.0.0 RC1: Topic Memory and configurable Agent context',
+      zh: '1.0.0 RC1：主题记忆与可配置的 Agent 上下文',
+    },
+    summary: {
+      en: 'The first 1.0.0 release candidate adds Topic Memory, scoped Prompts and Profiles, unified tags, configurable context assembly, and a personal Dashboard for testing context capture, retrieval, and handoff.',
+      zh: '首个 1.0.0 候选版本新增 Topic Memory、按 Scope 管理的 Prompt 和 Profile、统一标签、可配置的上下文组装，以及个人 Dashboard，用于验证上下文积累、检索和交接。',
+    },
+    changes: {
+      en: [
+        'Extract and maintain Topic Memory from Sources, with background Artifact processing supervisors to manage ongoing updates.',
+        'Configure the Prepared Context text delivered to Agents through optional context assembly.',
+        'Manage Prompts and Profiles within Scopes, tag Artifacts and Memory Entries, and discover Scopes and Sources through the API.',
+        'Save Sources and explicit Memory without a model by default, and load local environment files at Server startup. Automatic extraction and vector retrieval require configured inference services.',
+        'Use the opt-in personal Dashboard to inspect saved context, including Topic Memory and its evidence. The Dashboard is disabled by default and requires authentication when enabled.',
+        'Connect MiniMax, use improved DSH configuration diagnostics and installation guidance, and send MCP authorization headers correctly in Claude Code.',
+        'Fix revoked Scope contributions, raw Skill ZIP path validation, and conditional Artifact reads.',
+        'Follow bilingual workflow guides and Jupyter tutorials, and search the documentation site in English or Chinese.',
+        'Back up databases and configuration before upgrading. Install package 1.0.0rc1 with integrations from powercontext-v1.0.0rc1, then restart the Server and Agent sessions. This is a pre-release for testing.',
+      ],
+      zh: [
+        '从 Source 提取并维护 Topic Memory，通过后台 Artifact 处理监督器管理持续更新。',
+        '通过可选的上下文组装，配置 Agent 实际收到的 Prepared Context 文本。',
+        '在 Scope 内管理 Prompt 和 Profile，为 Artifact 与 Memory Entry 添加标签，并通过 API 查询 Scope 和 Source。',
+        '默认无需模型即可保存 Source 和显式 Memory，启动 Server 时支持读取本地环境文件；自动提取和向量检索仍需配置推理服务。',
+        '通过可选的个人 Dashboard 查看已保存的上下文，包括 Topic Memory 及其证据。Dashboard 默认关闭，启用时需要配置认证。',
+        '新增 MiniMax 集成，完善 DSH 配置诊断和安装指引，并修复 Claude Code 的 MCP 认证头传递。',
+        '修复撤销权限后的 Scope 上下文贡献、Skill ZIP 原始路径校验和 Artifact 条件读取问题。',
+        '提供中英文工作流指南、Jupyter 教程和按语言搜索的网站文档。',
+        '升级前备份数据库与配置。安装 1.0.0rc1 包，并从 powercontext-v1.0.0rc1 安装匹配的集成，再重启 Server 和 Agent 会话。这是供测试使用的预发布版本。',
+      ],
+    },
+    installCommand: 'uv tool install --force "powercontext[cli,server]==1.0.0rc1"',
+    githubUrl: 'https://github.com/oceanbase/powercontext/releases/tag/powercontext-v1.0.0rc1',
   },
   {
     version: 'v0.2.0',


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Release preparation for PowerContext 1.0.0rc2, following #1543. No separate tracking issue.

# Rationale for this change

The API metadata still identifies RC1, while the installation guides point to `master`. Align the package instructions, API version, and Agent integration refs for testing the second 1.0.0 release candidate.

# What changes are included in this PR?

- Set the OpenAPI version to `1.0.0rc2` and regenerate the Python API metadata.
- Update the English, Chinese, and Japanese READMEs and bilingual installation guides to install `1.0.0rc2` and use `powercontext-v1.0.0rc2` for matching integrations.
- Keep the website changelog limited to stable releases. Explain this policy in English and Chinese and link alpha, beta, and RC readers to GitHub Releases.
- Update release workflow examples and extend the existing release/configuration test cases to cover RC2.

The Python package version is derived from the release tag `powercontext-v1.0.0rc2` through Hatch VCS.

# Are there any user-facing changes?

Installation instructions select RC2 explicitly for testing and describe the included configuration wizard. The package and Agent integration should use matching versions. The website changelog lists stable releases; pre-release notes are available through its GitHub Releases link. This PR changes release metadata and documentation without changing API shapes or storage formats.

# How was this change tested?

- `make check`: passed, including 26 integration-manifest tests, lock consistency, pre-commit hooks, and type checks.
- `make contract-test`: 47 passed.
- Release workflow and configuration tests: 62 passed. The release E2E smoke test passed after rerunning with local socket access enabled.
- `CI=true make docs-test` with Node 24.14.1 and pnpm 11.13.1: passed; verified 790 exported pages and their internal links. Both changelog locales list only stable versions, link to GitHub Releases for pre-releases, and export no RC1/RC2 detail pages.
- Built an isolated checkout with the RC2 release tag: wheel, sdist, and embedded API metadata all report `1.0.0rc2`; both distributions passed `twine check`.
- Installed the wheel in a fresh environment and ran `ci_release_smoke.py --version 1.0.0rc2`: CLI, Server, MCP, and SQLite Memory save/search passed.

# AI usage statement

Prepared and validated with OpenAI Codex (GPT-6).
