### PR TITLE
chore(release): prepare v1.0.0

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -66,7 +66,7 @@ jobs:
           if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:(?:a|b|rc)[0-9]+)?", version):
               raise SystemExit(
                   "release_tag must use X.Y.Z with optional aN, bN, or rcN suffix and "
-                  "optional v or powercontext-v prefix (for example, powercontext-v1.0.0rc2)"
+                  "optional v or powercontext-v prefix (for example, powercontext-v1.0.0)"
               )
 
           package = os.environ["RELEASE_PACKAGE"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:(?:a|b|rc)[0-9]+)?", release_version):
               raise SystemExit(
                   "Release tag must use X.Y.Z with optional aN, bN, or rcN suffix and "
-                  "optional v or powercontext-v prefix (for example, powercontext-v1.0.0rc2)"
+                  "optional v or powercontext-v prefix (for example, powercontext-v1.0.0)"
               )
 
           package_version = subprocess.check_output(

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ PowerContext keeps context with the work across conversations. When you return, 
 
 [Website](https://frf12.github.io/powercontext/) · [Installation walkthrough](https://frf12.github.io/powercontext/en/docs/get-started/quickstart/)
 
-PowerContext 1.0.0 RC2 includes the guided setup. The commands below install this pre-release and connect
-the matching Agent integration for testing.
+PowerContext 1.0.0 includes the guided setup. The commands below install the stable release and connect
+the matching Agent integration.
 
 ## Pick up where the work left off
 
@@ -30,10 +30,10 @@ You decide what will matter later and what needs to move with the task. PowerCon
 You need Git, [uv](https://docs.astral.sh/uv/getting-started/installation/), and your Agent's CLI.
 Python 3.11+ is required; uv can provision it. macOS and Linux are supported; Windows support is `experimental`.
 
-Install 1.0.0 RC2 and open the interactive configuration wizard in a dedicated directory:
+Install 1.0.0 and open the interactive configuration wizard in a dedicated directory:
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server]==1.0.0"
 mkdir -p powercontext-config
 cd powercontext-config
 powercontext config init --language en --output .env
@@ -71,7 +71,7 @@ covers Codex and Claude Code, Dashboard login, SSH forwarding, HTTPS prerequisit
 For example, the matching Codex installation is:
 
 ```bash
-powercontext setup codex --ref powercontext-v1.0.0rc2
+powercontext setup codex --ref powercontext-v1.0.0
 powercontext doctor codex
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -16,7 +16,7 @@ PowerContext 让上下文跟随工作，跨越不同的对话。你回来时，�
 
 [网站](https://frf12.github.io/powercontext/zh/) · [完整安装流程](https://frf12.github.io/powercontext/zh/docs/get-started/quickstart/)
 
-PowerContext 1.0.0 RC2 包含交互式配置向导。下面的命令安装这一预发布版本，并接入相同版本的 Agent 集成，供测试使用。
+PowerContext 1.0.0 包含交互式配置向导。下面的命令安装这一正式版本，并接入相同版本的 Agent 集成。
 
 ## 从当前进展继续
 
@@ -29,10 +29,10 @@ PowerContext 1.0.0 RC2 包含交互式配置向导。下面的命令安装这一
 准备 Git、[uv](https://docs.astral.sh/uv/getting-started/installation/) 和你使用的 Agent CLI。
 需要 Python 3.11+，uv 可以按需安装。支持 macOS 和 Linux；Windows 支持为 `experimental`。
 
-安装 1.0.0 RC2，然后在独立目录里打开交互式配置向导：
+安装 1.0.0，然后在独立目录里打开交互式配置向导：
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server]==1.0.0"
 mkdir -p powercontext-config
 cd powercontext-config
 powercontext config init --language zh --output .env
@@ -66,7 +66,7 @@ powercontext capabilities
 SSH 隧道、HTTPS 前提及逐项验收。例如，匹配本版本的 Codex 安装命令是：
 
 ```bash
-powercontext setup codex --ref powercontext-v1.0.0rc2
+powercontext setup codex --ref powercontext-v1.0.0
 powercontext doctor codex
 ```
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -16,8 +16,8 @@ PowerContext は、会話をまたいでもコンテキストを作業ととも�
 
 [Web サイト](https://frf12.github.io/powercontext/en/) · [インストール手順](https://frf12.github.io/powercontext/en/docs/get-started/quickstart/)
 
-PowerContext 1.0.0 RC2 には対話式セットアップが含まれています。
-以下のコマンドで検証用のプレリリースと同じバージョンの Agent 連携をインストールします。
+PowerContext 1.0.0 には対話式セットアップが含まれています。
+以下のコマンドで正式リリースと同じバージョンの Agent 連携をインストールします。
 
 ## 作業の続きをそのまま引き継ぐ
 
@@ -27,10 +27,10 @@ PowerContext 1.0.0 RC2 には対話式セットアップが含まれています
 
 ## 利用中の Agent と接続する
 
-Git、uv、Agent CLI を用意して、1.0.0 RC2 をインストールします：
+Git、uv、Agent CLI を用意して、1.0.0 をインストールします：
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server]==1.0.0"
 mkdir -p powercontext-config
 cd powercontext-config
 powercontext config init --language en --output .env
@@ -50,7 +50,7 @@ Server を起動したまま、別のターミナルで同じ設定ディレク�
 クライアント環境の読み込み、Scope の作成・紐付け、同じバージョンの Agent プラグインのインストールを行います。例：
 
 ```bash
-powercontext setup codex --ref powercontext-v1.0.0rc2
+powercontext setup codex --ref powercontext-v1.0.0
 powercontext doctor codex
 ```
 

--- a/docs/en/docs/get-started/install-and-run.md
+++ b/docs/en/docs/get-started/install-and-run.md
@@ -1,6 +1,6 @@
 ---
 title: Install and run
-description: Install PowerContext 1.0.0 RC2 and run the local Server.
+description: Install PowerContext 1.0.0 and run the local Server.
 ---
 
 # Install and run
@@ -24,16 +24,16 @@ Embedded seekDB is unavailable on Windows.
 
 ## Choose a version
 
-These instructions use PowerContext 1.0.0 RC2 for pre-release testing. Keep the package and Agent integration on
-the same version: package `1.0.0rc2` and Git tag `powercontext-v1.0.0rc2`.
+These instructions use the stable PowerContext 1.0.0 release. Keep the package and Agent integration on
+the same version: package `1.0.0` and Git tag `powercontext-v1.0.0`.
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
-powercontext setup codex --ref powercontext-v1.0.0rc2
+uv tool install --force "powercontext[cli,server]==1.0.0"
+powercontext setup codex --ref powercontext-v1.0.0
 ```
 
 Check the [capability matrix](../integrations/capabilities.md) for host support and maintenance status.
-Capabilities marked `experimental` remain experimental in this release candidate.
+Capabilities marked `experimental` remain experimental in this release.
 
 ## Install the application
 
@@ -41,13 +41,13 @@ You need Python 3.11 or newer, Git, and [`uv`](https://docs.astral.sh/uv/) on ma
 PowerContext from PyPI:
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server]==1.0.0"
 ```
 
 For a source installation of the same version:
 
 ```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@powercontext-v1.0.0rc2"
+uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@powercontext-v1.0.0"
 ```
 
 The Git command does not leave a repository checkout for you to manage. Git uses its normal credential configuration,
@@ -112,7 +112,7 @@ Embedded seekDB is available on Linux and macOS when a compatible `pylibseekdb` 
 support this embedded backend. Install or replace the tool with the optional seekDB extra:
 
 ```bash
-uv tool install --force "powercontext[cli,server,seekdb]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server,seekdb]==1.0.0"
 ```
 
 When switching from SQLite, remove `POWERCONTEXT_SERVER_DATABASE_URL` from the Server process environment. An explicit
@@ -160,10 +160,16 @@ For a long-running process, Docker, authentication, or remote access, continue w
 
 ## Update or replace an installation
 
-To upgrade to 1.0.0 RC2:
+Before upgrading an existing deployment, back up its database and configuration. Version 1.0.0 adds persistent
+processing state and Dream evidence fields during Server startup. Upgrade the Server, clients, and Agent integrations
+together. The Dashboard must be explicitly enabled with static Bearer authentication; see
+[Deploy the Server](../operate/deploy-server.md). Remote plaintext HTTP connections require explicit client consent;
+see [Connect to a remote Server](../operate/connect-remote-server.md).
+
+To upgrade to 1.0.0:
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server]==1.0.0"
 ```
 
 To replace the installed tool with another Git ref:
@@ -181,7 +187,7 @@ changes.
 An application that imports the async Client SDK should add it to that application's environment:
 
 ```bash
-uv add "powercontext[client]==1.0.0rc2"
+uv add "powercontext[client]==1.0.0"
 ```
 
 Use `builtin` for in-process Python composition, `server` for the service, `client` for the Python SDK, or `cli` for

--- a/docs/en/docs/get-started/quickstart.md
+++ b/docs/en/docs/get-started/quickstart.md
@@ -6,8 +6,8 @@ description: Configure full memory, connect Codex, and verify Source capture, To
 # Quick Start
 
 Start with installation, discuss a project in Codex, watch its input become Source evidence and an evolving topic,
-then recover the decisions in a new session. These instructions use PowerContext 1.0.0 RC2 for pre-release testing,
-with the Agent plugin from the matching `powercontext-v1.0.0rc2` tag.
+then recover the decisions in a new session. These instructions use the stable PowerContext 1.0.0 release,
+with the Agent plugin from the matching `powercontext-v1.0.0` tag.
 
 You need macOS or Linux, Python 3.11+, Git, [uv](https://docs.astral.sh/uv/getting-started/installation/),
 and an installed Codex CLI. Full memory also needs working Generation and Embedding model APIs:
@@ -18,7 +18,7 @@ and recall; that does not enable automatic Topic Memory.
 ## 1. Install and open the wizard
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server]==1.0.0"
 mkdir -p ~/powercontext-demo
 cd ~/powercontext-demo
 powercontext config init --language en --output .env
@@ -38,8 +38,7 @@ The wizard writes:
 
 | File | Purpose |
 | --- | --- |
-| `.env` | Server settings, database, model credentials, and Server token |
-| `.env` | Server, client, Agent, and model settings used by this installation |
+| `.env` | Server, client, Agent, database, and model settings, including credentials and the Server token |
 | `.env.next-steps.md` | Startup, Scope creation, plugin connection, and checks for your choices |
 
 The final screen shows the Dashboard URL, a newly generated token, and the SSH command when selected. Later, look up
@@ -94,7 +93,7 @@ Reload the client settings and install the matching plugin:
 set -a
 . ./.env
 set +a
-powercontext setup codex --ref powercontext-v1.0.0rc2
+powercontext setup codex --ref powercontext-v1.0.0
 powercontext doctor codex
 codex
 ```

--- a/docs/zh/docs/get-started/install-and-run.md
+++ b/docs/zh/docs/get-started/install-and-run.md
@@ -1,6 +1,6 @@
 ---
 title: 安装和运行
-description: 安装 PowerContext 1.0.0 RC2，并运行本地 Server。
+description: 安装 PowerContext 1.0.0，并运行本地 Server。
 ---
 
 # 安装和运行
@@ -22,16 +22,16 @@ Windows 的 CLI、Server 和个人服务支持为试验性；各 Agent Host 仍�
 
 ## 选择版本
 
-本页使用 PowerContext 1.0.0 RC2 预发布版本，供测试使用。包与 Agent 集成保持版本一致：
-Python 包版本为 `1.0.0rc2`，对应 Git tag 为 `powercontext-v1.0.0rc2`。
+本页使用 PowerContext 1.0.0 正式版本。包与 Agent 集成保持版本一致：
+Python 包版本为 `1.0.0`，对应 Git tag 为 `powercontext-v1.0.0`。
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
-powercontext setup codex --ref powercontext-v1.0.0rc2
+uv tool install --force "powercontext[cli,server]==1.0.0"
+powercontext setup codex --ref powercontext-v1.0.0
 ```
 
 宿主支持范围和维护状态见[能力矩阵](../integrations/capabilities.md)。
-标为 `experimental` 的能力在这个候选版本中仍属于试验性能力。
+标为 `experimental` 的能力在此正式版本中仍属于试验性能力。
 
 ## 安装应用
 
@@ -39,13 +39,13 @@ powercontext setup codex --ref powercontext-v1.0.0rc2
 [`uv`](https://docs.astral.sh/uv/)，然后从 PyPI 安装 PowerContext：
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server]==1.0.0"
 ```
 
 如需从源码安装同一版本：
 
 ```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@powercontext-v1.0.0rc2"
+uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@powercontext-v1.0.0"
 ```
 
 Git 安装命令不会留下需要自行管理的仓库工作副本。Git 会沿用本机的凭据配置，包括 credential helper 和 SSH 设置。
@@ -105,7 +105,7 @@ powercontext server run --env-file /path/to/powercontext.env
 后端。安装或替换工具时加入可选的 seekDB extra：
 
 ```bash
-uv tool install --force "powercontext[cli,server,seekdb]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server,seekdb]==1.0.0"
 ```
 
 从 SQLite 切换时，需要从 Server 进程环境中删除 `POWERCONTEXT_SERVER_DATABASE_URL`；seekDB 不接受显式的
@@ -150,10 +150,15 @@ Agent 诊断见[各自的集成文档](../integrations/index.md)；Server 状态
 
 ## 更新或替换安装
 
-升级到 1.0.0 RC2：
+升级已有部署前，先备份数据库和配置。1.0.0 会在 Server 启动时增加持久化处理状态和 Dream 证据字段。
+Server、客户端和 Agent 集成需一起升级。Dashboard 需要显式启用并配置静态 Bearer 认证，
+见[部署 Server](../operate/deploy-server.md)；远程明文 HTTP 连接需要客户端明确同意，
+见[连接远程 Server](../operate/connect-remote-server.md)。
+
+升级到 1.0.0：
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server]==1.0.0"
 ```
 
 使用其他 Git ref 替换现有工具：
@@ -170,7 +175,7 @@ uv tool install --force "powercontext[cli,server] @ git+https://github.com/ocean
 如果应用需要导入异步 Client SDK，应把它加入该应用自己的环境：
 
 ```bash
-uv add "powercontext[client]==1.0.0rc2"
+uv add "powercontext[client]==1.0.0"
 ```
 
 进程内 Python 组合使用 `builtin`，服务使用 `server`，Python SDK 使用 `client`，基于 Server 的命令行使用

--- a/docs/zh/docs/get-started/quickstart.md
+++ b/docs/zh/docs/get-started/quickstart.md
@@ -6,8 +6,8 @@ description: 通过配置向导安装完整记忆能力，接入 Codex，并验�
 # 快速开始
 
 本页从安装开始，带你完成一次真实的记忆体验：在 Codex 中讨论项目，看到原始输入进入 Source、主题记忆生成并演进，
-再在新会话中找回决策。以下命令使用 PowerContext 1.0.0 RC2 预发布版本，Agent 插件使用对应的
-`powercontext-v1.0.0rc2` tag，供测试使用。
+再在新会话中找回决策。以下命令使用 PowerContext 1.0.0 正式版本，Agent 插件使用对应的
+`powercontext-v1.0.0` tag。
 
 需要 macOS 或 Linux、Python 3.11+、Git、[uv](https://docs.astral.sh/uv/getting-started/installation/) 和已安装的 Codex CLI。
 完整记忆还需要可用的 Generation 和 Embedding 模型 API；准备好各自的地址、模型名和 API key。
@@ -17,7 +17,7 @@ Codex 或 Claude 的订阅登录不会自动为 PowerContext Server 提供这些
 ## 1. 安装并进入配置向导
 
 ```bash
-uv tool install --force "powercontext[cli,server]==1.0.0rc2"
+uv tool install --force "powercontext[cli,server]==1.0.0"
 mkdir -p ~/powercontext-demo
 cd ~/powercontext-demo
 powercontext config init --language zh --output .env
@@ -37,8 +37,7 @@ powercontext config init --language zh --output .env
 
 | 文件 | 用途 |
 | --- | --- |
-| `.env` | Server 配置，包括数据库、模型凭据和 Server Token |
-| `.env` | 本次安装使用的 Server、客户端、Agent 和模型配置 |
+| `.env` | 本次安装使用的 Server、客户端、Agent、数据库和模型配置，包括凭据与 Server Token |
 | `.env.next-steps.md` | 与本次选择对应的启动、Scope 创建、插件连接和验收说明 |
 
 向导会打印 Dashboard 地址、新生成的 Token，以及所选 SSH 转发命令。以后可在 `.env` 中查看
@@ -92,7 +91,7 @@ POWERCONTEXT_CODEX_SCOPE_ID=替换为返回的scope_id
 set -a
 . ./.env
 set +a
-powercontext setup codex --ref powercontext-v1.0.0rc2
+powercontext setup codex --ref powercontext-v1.0.0
 powercontext doctor codex
 codex
 ```

--- a/integrations/dsh/plugins/powercontext/README.md
+++ b/integrations/dsh/plugins/powercontext/README.md
@@ -5,8 +5,8 @@ This plugin is a thin DeepSeek Harness integration for a running PowerContext Se
 Install the released Server and plugin together:
 
 ```bash
-uv tool install --force "powercontext[cli,server]==0.2.0"
-powercontext setup dsh --source oceanbase/powercontext --ref powercontext-v0.2.0
+uv tool install --force "powercontext[cli,server]==1.0.0"
+powercontext setup dsh --source oceanbase/powercontext --ref powercontext-v1.0.0
 ```
 
 `setup dsh` calls `dsh plugin --profile web add`. The plugin talks HTTP only. It does not use MCP.
@@ -23,8 +23,7 @@ reuses the cached checkout without fetching; update a local checkout and reinsta
 Use [the DSH setup guide](../../../../docs/en/docs/integrations/dsh.md) for generation/processing configuration.
 Run `powercontext server run --env-file powercontext.env` in one terminal, then set
 `POWERCONTEXT_DSH_BASE_URL` in another terminal and run `dsh web`. Restart DSH after changing installation or environment.
-Release 0.2.0 includes direct-operation Scope failure handling; the layered Doctor and snapshot behavior below
-require the current development checkout.
+Release 1.0.0 includes direct-operation Scope failure handling and the layered Doctor and snapshot behavior below.
 
 Before each model step it:
 

--- a/openapi/powercontext.yaml
+++ b/openapi/powercontext.yaml
@@ -16,7 +16,7 @@ openapi: 3.0.3
 info:
   title: PowerContext API
   description: Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.
-  version: 1.0.0rc2
+  version: 1.0.0
 security:
   - BearerAuth: []
   - {}

--- a/src/powercontext/http/_generated/operations.py
+++ b/src/powercontext/http/_generated/operations.py
@@ -175,7 +175,7 @@ from powercontext.http._generated.models import (
 OPENAPI_VERSION = "3.0.3"
 API_TITLE = "PowerContext API"
 API_DESCRIPTION = "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities."
-API_VERSION = "1.0.0rc2"
+API_VERSION = "1.0.0"
 
 RequestT = TypeVar("RequestT")
 ResponseT = TypeVar("ResponseT")

--- a/src/powercontext/http/_generated/schema.py
+++ b/src/powercontext/http/_generated/schema.py
@@ -7,7 +7,7 @@ OPENAPI_SCHEMA: dict[str, JsonValue] = {
     "info": {
         "title": "PowerContext API",
         "description": "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.",
-        "version": "1.0.0rc2",
+        "version": "1.0.0",
     },
     "paths": {
         "/v1/scopes/{scope_id}/subject-sources": {

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -63,7 +63,7 @@ def test_init_creates_a_model_free_deployment_and_explains_capability_limits(tmp
     assert shown.exit_code == 0
 
 
-@pytest.mark.parametrize("installed", ["0.2.0", "1.0.0rc1", "1.0.0rc2", "0.2.1.dev1+g1234567"])
+@pytest.mark.parametrize("installed", ["0.2.0", "1.0.0rc1", "1.0.0rc2", "1.0.0", "0.2.1.dev1+g1234567"])
 def test_init_matches_dsh_setup_to_installed_server(installed: str, tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(config_cli, "version", lambda _name: installed)
     monkeypatch.setattr(config_cli, "collect_configuration", lambda **_kwargs: _configuration())
@@ -72,7 +72,7 @@ def test_init_matches_dsh_setup_to_installed_server(installed: str, tmp_path: Pa
     )
     assert result.exit_code == 0
     command = next(line.strip() for line in result.output.splitlines() if "powercontext setup dsh" in line)
-    if installed in {"0.2.0", "1.0.0rc1", "1.0.0rc2"}:
+    if installed in {"0.2.0", "1.0.0rc1", "1.0.0rc2", "1.0.0"}:
         assert command.endswith(f"--ref powercontext-v{installed}")
     else:
         assert "--source /path/to/matching-powercontext-checkout" in command

--- a/website/src/lib/releases.ts
+++ b/website/src/lib/releases.ts
@@ -29,6 +29,44 @@ export interface Release {
 // Only stable releases belong here; publish pre-release notes on GitHub Releases.
 export const releases: Release[] = [
   {
+    version: 'v1.0.0',
+    date: '2026-09-10',
+    title: {
+      en: 'Guided setup, Topic Memory, and reviewed learning',
+      zh: '交互式配置、Topic Memory 与审核式经验沉淀',
+    },
+    summary: {
+      en: 'PowerContext 1.0.0 connects guided onboarding with evolving Topic Memory, scoped Profiles, and a reviewed path from Memory to Experience and Skill, while preserving cross-session Memory and Handoff workflows.',
+      zh: 'PowerContext 1.0.0 将交互式配置、持续演进的 Topic Memory、按 Scope 管理的 Profile，以及经过审核的 Memory → Experience → Skill 工作流串联起来，延续跨会话记忆与工作交接。',
+    },
+    changes: {
+      en: [
+        'Configure storage, model APIs, Server access, background processing, and Agent connections through an English or Chinese wizard. Persist Agent authorization and generate matching setup commands and next steps.',
+        'Turn captured Sources into evolving Topic Memory with evidence and revision history; inspect Sources, topics, and processing state in the personal Dashboard. Automatic processing requires configured model APIs.',
+        'Maintain scoped Profiles and subject-attributed Sources, customize processing Prompts by Scope, and select how Profiles and Memory are assembled into prepared context.',
+        'Organize Artifacts and Memory entries with tags, manage versioned Prompt Artifacts, and discover Scopes and Sources through the public API.',
+        'Run durable background processing for Memory, Topic Memory, and Profiles. Use Dream to propose Experience from exact Memory citations and Skill from approved Experiences; inspect and approve Candidates before they become Artifacts. Approval does not install or execute a Skill.',
+        'Connect MiniMax through its native plugin, send Claude Code MCP authorization correctly, and inspect effective DSH configuration and recalled-context snapshots through layered diagnostics.',
+        'Start with explicit Memory operations without model credentials; use bilingual documentation search, the installation walkthrough, and guided Jupyter tutorials for further workflows.',
+        'Strengthen evidence access checks, enforce revoked Scope contributions, validate raw Skill archive paths, and support weak or multiple If-None-Match validators on Artifact reads.',
+        'Upgrade the Server, clients, and Agent integrations together and back up existing databases before startup schema changes. The Dashboard is now an opt-in personal viewer requiring static Bearer authentication; Dream and Candidate review use CLI, Client, or HTTP APIs. Server startup loads a local .env unless disabled, and remote plaintext HTTP requires explicit client consent. Windows remains experimental.',
+      ],
+      zh: [
+        '通过交互式向导配置存储、模型 API、Server 访问、后台处理与 Agent 连接，持久化 Agent 授权，并生成匹配版本的安装命令和后续操作步骤。',
+        '将采集到的 Source 整理为持续演进的 Topic Memory，保留证据和修订历史；在个人 Dashboard 中查看 Source、主题与处理状态。自动处理需要配置模型 API。',
+        '按 Scope 维护 Profile 和带主体归属的 Source，自定义处理 Prompt，并选择 Profile 与 Memory 在准备好的上下文中的组织方式。',
+        '使用标签组织 Artifact 与 Memory 条目，管理带版本的 Prompt Artifact，并通过公开 API 发现 Scope 和 Source。',
+        '通过持久化后台任务处理 Memory、Topic Memory 和 Profile；使用 Dream 从精确 Memory 引用提炼 Experience，再从已批准的 Experience 生成 Skill。检查并批准 Candidate 后才会写入 Artifact；批准不会安装或执行 Skill。',
+        '支持原生插件接入 MiniMax，修复 Claude Code 的 MCP 授权传递，并通过分层诊断检查 DSH 实际生效的配置与召回上下文快照。',
+        '无需模型凭据即可使用显式 Memory 操作；通过中英文文档搜索、安装教程和 Jupyter 示例继续学习其他工作流。',
+        '增强生成过程中的证据访问检查，执行撤销后的 Scope 写入权限，校验 Skill 压缩包原始路径，并支持 Artifact 读取中的弱 ETag 和多个 If-None-Match 值。',
+        'Server、客户端和 Agent 集成需一起升级，并在启动时的数据库结构变更前备份数据。Dashboard 改为显式启用、使用静态 Bearer 认证的个人内容查看器；Dream 与 Candidate 审核通过 CLI、Client 或 HTTP API 操作。Server 启动默认读取本地 .env，远程明文 HTTP 连接需要客户端明确同意。Windows 仍为试验性支持。',
+      ],
+    },
+    installCommand: 'uv tool install --force "powercontext[cli,server]==1.0.0"',
+    githubUrl: 'https://github.com/oceanbase/powercontext/releases/tag/powercontext-v1.0.0',
+  },
+  {
     version: 'v0.2.0',
     date: '2026-09-07',
     title: {


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Related: #1555. No issue or RFC is closed.

# Rationale for this change

Prepare the stable PowerContext 1.0.0 release. Installation instructions and API metadata now use version `1.0.0`, with Agent integrations pinned to `powercontext-v1.0.0`.

# What changes are included in this PR?

- Update the English, Chinese, and Japanese READMEs, bilingual installation guides, and DSH plugin installation example.
- Set the canonical OpenAPI version to `1.0.0` and regenerate the Python API metadata.
- Add bilingual 1.0.0 release notes covering guided setup, Topic Memory, Profiles, reviewed Dream workflows, integrations, and upgrade considerations.
- Update release workflow examples and cover stable-version matching in the configuration wizard test. Package versioning continues to derive from Git tags.

# Are there any user-facing changes?

The documentation installs the stable release and matching plugins. Upgrade guidance covers database backups, coordinated Server/client/integration upgrades, Dashboard authentication, and explicit consent for remote plaintext HTTP. Windows remains experimental. This PR changes release metadata and documentation; it does not introduce runtime or database schema changes.

# How was this change tested?

- `make api-generate` and `make contract-test`: generated artifacts verified; 47 contract tests passed.
- `make check`: integration manifest checks, lock consistency, all pre-commit hooks, and type checks passed.
- `make docs-test` with Node 24.14.1: lint, build, and export validation passed for 792 public pages; both 1.0.0 release pages contain the expected install command and release link.
- Configuration CLI and release-verification tests: 63 passed. Fresh-database release smoke: 1 passed after rerunning outside the socket-restricted sandbox.
- Built wheel and sdist from a disposable repository tagged `powercontext-v1.0.0`; both passed `twine check`.
- Installed the wheel in a fresh virtual environment and verified CLI, Server, MCP, and SQLite Memory search. Installed package and API versions both equal `1.0.0`.

# AI usage statement

Prepared with OpenAI Codex (GPT-6), including release documentation, API metadata generation, and validation.
