### PR TITLE
fix(pi): keep failure diagnostics off stderr by default

### DIFF
--- a/docs/en/docs/integrations/pi.md
+++ b/docs/en/docs/integrations/pi.md
@@ -124,7 +124,11 @@ changing PowerContext environment variables.
 | `POWERCONTEXT_PI_MAX_BYTES` | `8000` | Requested and validated PreparedContext byte limit (`512`–`32768`) |
 | `POWERCONTEXT_PI_FLUSH_ON_CAPTURE` | `false` | Wait for captured Source processing during the prompt hook |
 | `POWERCONTEXT_PI_FLUSH_MAX_CALLS` | `4` | Maximum flush attempts for one pending Source |
+| `POWERCONTEXT_PI_DIAGNOSTICS` | `off` | Failure diagnostics sink: `off`, `stderr`, or an absolute file path (`~/` expanded) for JSON lines |
 
 Pi rejects base URLs containing credentials, a query, or a fragment. Recall, capture, and boundary flushing fail open;
 explicit `pc_*` durable writes require confirmation and are refused when Pi has no interactive UI. Restart Pi after
 changing these variables.
+
+Failure diagnostics are silent by default because Pi's TUI renders on stdout with cursor positioning, so
+anything written to stderr lands inside the input bar; set `POWERCONTEXT_PI_DIAGNOSTICS` to see them.

--- a/docs/zh/docs/integrations/pi.md
+++ b/docs/zh/docs/integrations/pi.md
@@ -122,6 +122,10 @@ powercontext doctor pi
 | `POWERCONTEXT_PI_MAX_BYTES` | `8000` | 请求并校验的 PreparedContext byte 上限（`512`–`32768`） |
 | `POWERCONTEXT_PI_FLUSH_ON_CAPTURE` | `false` | 在 prompt hook 中等待已采集 Source 的处理 |
 | `POWERCONTEXT_PI_FLUSH_MAX_CALLS` | `4` | 一个 pending Source 最多 flush 次数 |
+| `POWERCONTEXT_PI_DIAGNOSTICS` | `off` | 失败诊断输出：`off`、`stderr`，或写入 JSON 行的绝对文件路径（支持 `~/`） |
 
 Pi 会拒绝包含凭据、query 或 fragment 的 base URL。召回、采集和边界 flush 都会正常降级；显式 `pc_*` 持久化写入
 必须确认，Pi 没有交互 UI 时会被拒绝。修改这些变量后需要重启 Pi。
+
+失败诊断默认不输出：Pi 的 TUI 通过光标定位在 stdout 上渲染，写到 stderr 的内容会落在输入栏里；需要查看时请设置
+`POWERCONTEXT_PI_DIAGNOSTICS`。

--- a/integrations/pi/plugins/powercontext/README.md
+++ b/integrations/pi/plugins/powercontext/README.md
@@ -20,8 +20,9 @@ explicit override, and automatic prompt capture.
 
 Failure diagnostics (for example `server_unavailable` after a 503) are silent by default: Pi's TUI renders on
 stdout with cursor positioning, so anything written to stderr corrupts the input bar. Set
-`POWERCONTEXT_PI_DIAGNOSTICS=stderr` to print them, or point it at a file (`~/` is expanded) to append them as
-JSON lines. `/pc` shows the current status either way.
+`POWERCONTEXT_PI_DIAGNOSTICS=stderr` to print them, or point it at an absolute path (`~/` is expanded; the
+parent directory is created) to append them as JSON lines. The keywords are case-insensitive; any other value
+keeps diagnostics off. `/pc` shows the current status either way.
 
 Remote HTTP is rejected by default. Explicitly allow it with `POWERCONTEXT_PI_ALLOW_INSECURE_HTTP=true`,
 or use `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP=true` as the common fallback. A host flag of `false` overrides

--- a/integrations/pi/plugins/powercontext/README.md
+++ b/integrations/pi/plugins/powercontext/README.md
@@ -18,6 +18,11 @@ The package resolves an explicit Scope, a durable workspace binding, or the Serv
 `POWERCONTEXT_PI_BASE_URL`, `POWERCONTEXT_PI_SCOPE_ID`, and `POWERCONTEXT_PI_CAPTURE_PROMPTS` to adjust the connection,
 explicit override, and automatic prompt capture.
 
+Failure diagnostics (for example `server_unavailable` after a 503) are silent by default: Pi's TUI renders on
+stdout with cursor positioning, so anything written to stderr corrupts the input bar. Set
+`POWERCONTEXT_PI_DIAGNOSTICS=stderr` to print them, or point it at a file (`~/` is expanded) to append them as
+JSON lines. `/pc` shows the current status either way.
+
 Remote HTTP is rejected by default. Explicitly allow it with `POWERCONTEXT_PI_ALLOW_INSECURE_HTTP=true`,
 or use `POWERCONTEXT_CLIENT_ALLOW_INSECURE_HTTP=true` as the common fallback. A host flag of `false` overrides
 the common flag. Flags accept only `true/false`, `1/0`, `yes/no`, or `on/off`; HTTPS certificate validation and

--- a/integrations/pi/plugins/powercontext/extensions/powercontext.ts
+++ b/integrations/pi/plugins/powercontext/extensions/powercontext.ts
@@ -19,7 +19,7 @@ import { PowerContextClient } from '../src/client.ts'
 import { registerCommands } from '../src/commands.ts'
 import { resolveConfig } from '../src/config.ts'
 import { createPendingSourceFlusher } from '../src/flush.ts'
-import { createDiagnosticEmitter, failureEvent } from '../src/diagnostics.ts'
+import { createDiagnosticEmitter, diagnosticWriter, failureEvent } from '../src/diagnostics.ts'
 import { recallBeforeAgentStart, type PluginRuntime } from '../src/recall.ts'
 import { resolveScopeId } from '../src/scope.ts'
 import { registerTools } from '../src/tools.ts'
@@ -32,7 +32,7 @@ function createRuntime(): PluginRuntime {
     authorization: config.authorization,
     requestTimeoutMs: config.requestTimeoutMs,
   })
-  const emitDiagnostic = createDiagnosticEmitter((line) => console.warn(line))
+  const emitDiagnostic = createDiagnosticEmitter(diagnosticWriter(config.diagnostics))
   const diagnostic = (event: string, error: unknown) => {
     const failure = failureEvent(event, error)
     if (failure) emitDiagnostic({ component: 'powercontext.pi', ...failure })

--- a/integrations/pi/plugins/powercontext/src/config.ts
+++ b/integrations/pi/plugins/powercontext/src/config.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import { resolveTransport } from './transport.ts'
 
 export interface ResolvedConfig {
@@ -28,6 +30,8 @@ export interface ResolvedConfig {
   maxBytes: number
   flushOnCapture: boolean
   flushMaxCalls: number
+  /** Where failure diagnostics go: `off`, `stderr`, or a file path to append JSON lines to. */
+  diagnostics: string
 }
 
 const DEFAULTS: ResolvedConfig = {
@@ -41,6 +45,7 @@ const DEFAULTS: ResolvedConfig = {
   maxBytes: 8000,
   flushOnCapture: false,
   flushMaxCalls: 4,
+  diagnostics: 'off',
 }
 
 function envString(env: NodeJS.ProcessEnv, name: string): string | undefined {
@@ -105,5 +110,13 @@ export function resolveConfig(env: NodeJS.ProcessEnv = process.env): ResolvedCon
     maxBytes: envInteger(env, 'POWERCONTEXT_PI_MAX_BYTES', DEFAULTS.maxBytes, 512, 32_768),
     flushOnCapture: envBoolean(env, 'POWERCONTEXT_PI_FLUSH_ON_CAPTURE') ?? DEFAULTS.flushOnCapture,
     flushMaxCalls: envInteger(env, 'POWERCONTEXT_PI_FLUSH_MAX_CALLS', DEFAULTS.flushMaxCalls, 1, 16),
+    diagnostics: diagnosticsSink(envString(env, 'POWERCONTEXT_PI_DIAGNOSTICS'), env),
   }
+}
+
+function diagnosticsSink(raw: string | undefined, env: NodeJS.ProcessEnv): string {
+  if (raw === undefined) return DEFAULTS.diagnostics
+  if (raw === 'off' || raw === 'stderr') return raw
+  if (raw.startsWith('~/')) return join(envString(env, 'HOME') ?? homedir(), raw.slice(2))
+  return raw
 }

--- a/integrations/pi/plugins/powercontext/src/config.ts
+++ b/integrations/pi/plugins/powercontext/src/config.ts
@@ -15,7 +15,7 @@
  */
 
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { isAbsolute, join } from 'node:path'
 import { resolveTransport } from './transport.ts'
 
 export interface ResolvedConfig {
@@ -116,7 +116,12 @@ export function resolveConfig(env: NodeJS.ProcessEnv = process.env): ResolvedCon
 
 function diagnosticsSink(raw: string | undefined, env: NodeJS.ProcessEnv): string {
   if (raw === undefined) return DEFAULTS.diagnostics
-  if (raw === 'off' || raw === 'stderr') return raw
-  if (raw.startsWith('~/')) return join(envString(env, 'HOME') ?? homedir(), raw.slice(2))
-  return raw
+  const token = raw.trim().toLowerCase()
+  if (token === 'off' || token === 'stderr') return token
+  const path = raw.trim()
+  if (path.startsWith('~/')) return join(envString(env, 'HOME') ?? homedir(), path.slice(2))
+  // Only an unambiguous file path becomes a file sink. Anything else (a typo such as
+  // `STDER`, a bare relative name) stays silent instead of creating a stray file in cwd.
+  if (isAbsolute(path)) return path
+  return DEFAULTS.diagnostics
 }

--- a/integrations/pi/plugins/powercontext/src/diagnostics.ts
+++ b/integrations/pi/plugins/powercontext/src/diagnostics.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
 import { InvalidResponseError, ServerResponseError, TransportError } from './errors.ts'
 
 export interface DiagnosticEvent {
@@ -83,14 +84,31 @@ export function diagnosticWriter(
   sink: string,
   append: (path: string, line: string) => void = (path, line) => appendFileSync(path, line),
   warn: (line: string) => void = (line) => console.warn(line),
+  ensureDirectory: (path: string) => void = (path) => mkdirSync(dirname(path), { recursive: true }),
 ): (line: string) => void {
   if (sink === 'off') return () => {}
-  if (sink === 'stderr') return warn
+  // Diagnostics are best effort and must never break the extension, whichever sink is used.
+  if (sink === 'stderr') {
+    return (line) => {
+      try {
+        warn(line)
+      } catch {
+        // ignore
+      }
+    }
+  }
+  // `~/.powercontext/pi-diagnostics.jsonl` is the natural choice and that directory
+  // rarely exists yet; create it once so the first line is not silently lost.
+  try {
+    ensureDirectory(sink)
+  } catch {
+    // ignore: the append below fails the same silent way
+  }
   return (line) => {
     try {
       append(sink, `${line}\n`)
     } catch {
-      // Diagnostics are best effort and must never break the extension.
+      // ignore
     }
   }
 }

--- a/integrations/pi/plugins/powercontext/src/diagnostics.ts
+++ b/integrations/pi/plugins/powercontext/src/diagnostics.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { appendFileSync } from 'node:fs'
 import { InvalidResponseError, ServerResponseError, TransportError } from './errors.ts'
 
 export interface DiagnosticEvent {
@@ -71,6 +72,27 @@ export function failureEvent(event: string, error: unknown): DiagnosticEvent | u
   }
   if (error instanceof InvalidResponseError) return { event, outcome: 'invalid_response' }
   return { event, outcome: 'invalid_response' }
+}
+
+/**
+ * Pi's ExtensionContext has no logger, and its TUI renders on stdout with cursor
+ * positioning, so anything written to stderr lands inside the input bar. Keep
+ * diagnostics silent unless the user routes them to stderr or a JSON-lines file.
+ */
+export function diagnosticWriter(
+  sink: string,
+  append: (path: string, line: string) => void = (path, line) => appendFileSync(path, line),
+  warn: (line: string) => void = (line) => console.warn(line),
+): (line: string) => void {
+  if (sink === 'off') return () => {}
+  if (sink === 'stderr') return warn
+  return (line) => {
+    try {
+      append(sink, `${line}\n`)
+    } catch {
+      // Diagnostics are best effort and must never break the extension.
+    }
+  }
 }
 
 export function createDiagnosticEmitter(

--- a/integrations/pi/plugins/powercontext/tests/commands.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/commands.spec.ts
@@ -37,6 +37,7 @@ function runtime(fetch: typeof globalThis.fetch, resolveScope = async () => 'sco
       maxBytes: 8000,
       flushOnCapture: false,
       flushMaxCalls: 4,
+      diagnostics: 'off',
     },
     resolveScope,
   }

--- a/integrations/pi/plugins/powercontext/tests/config.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/config.spec.ts
@@ -38,7 +38,15 @@ describe('Pi configuration', () => {
       maxBytes: 12000,
       flushOnCapture: false,
       flushMaxCalls: 4,
+      diagnostics: 'off',
     })
+  })
+
+  it('keeps diagnostics silent unless a sink is configured', () => {
+    expect(resolveConfig({}).diagnostics).toBe('off')
+    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: 'stderr' }).diagnostics).toBe('stderr')
+    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: '/tmp/pc.log' }).diagnostics).toBe('/tmp/pc.log')
+    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: '~/pc.log', HOME: '/home/demo' }).diagnostics).toBe('/home/demo/pc.log')
   })
 })
 

--- a/integrations/pi/plugins/powercontext/tests/config.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/config.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { resolveConfig } from '../src/config.ts'
 
@@ -46,7 +47,21 @@ describe('Pi configuration', () => {
     expect(resolveConfig({}).diagnostics).toBe('off')
     expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: 'stderr' }).diagnostics).toBe('stderr')
     expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: '/tmp/pc.log' }).diagnostics).toBe('/tmp/pc.log')
-    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: '~/pc.log', HOME: '/home/demo' }).diagnostics).toBe('/home/demo/pc.log')
+    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: '~/pc.log', HOME: '/home/demo' }).diagnostics).toBe(
+      join('/home/demo', 'pc.log'),
+    )
+  })
+
+  it('accepts the sink keywords in any case, like the boolean flags', () => {
+    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: 'STDERR' }).diagnostics).toBe('stderr')
+    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: 'Off' }).diagnostics).toBe('off')
+    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: ' stderr ' }).diagnostics).toBe('stderr')
+  })
+
+  it('treats only absolute or ~/ paths as a file sink and stays silent for anything else', () => {
+    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: 'pc.log' }).diagnostics).toBe('off')
+    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: 'STDER' }).diagnostics).toBe('off')
+    expect(resolveConfig({ POWERCONTEXT_PI_DIAGNOSTICS: './logs/pc.log' }).diagnostics).toBe('off')
   })
 })
 

--- a/integrations/pi/plugins/powercontext/tests/diagnostics.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/diagnostics.spec.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { diagnosticWriter, failureEvent } from '../src/diagnostics.ts'
 import { ServerResponseError } from '../src/errors.ts'
@@ -103,13 +106,46 @@ describe('diagnostic sink', () => {
   it('appends JSON lines to a configured file and survives write failures', () => {
     const append = vi.fn()
     const warn = vi.fn()
-    diagnosticWriter('/var/log/pc.jsonl', append, warn)('{"event":"flush_memory"}')
+    const ensureDirectory = vi.fn()
+    diagnosticWriter('/var/log/pc.jsonl', append, warn, ensureDirectory)('{"event":"flush_memory"}')
+    expect(ensureDirectory).toHaveBeenCalledWith('/var/log/pc.jsonl')
     expect(append).toHaveBeenCalledWith('/var/log/pc.jsonl', '{"event":"flush_memory"}\n')
     expect(warn).not.toHaveBeenCalled()
 
     const failing = vi.fn(() => {
       throw new Error('EACCES')
     })
-    expect(() => diagnosticWriter('/var/log/pc.jsonl', failing, warn)('{}')).not.toThrow()
+    expect(() => diagnosticWriter('/var/log/pc.jsonl', failing, warn, ensureDirectory)('{}')).not.toThrow()
+    const noDirectory = vi.fn(() => {
+      throw new Error('EPERM')
+    })
+    expect(() => diagnosticWriter('/var/log/pc.jsonl', append, warn, noDirectory)('{}')).not.toThrow()
+  })
+
+  it('keeps a failing stderr sink non-fatal too', () => {
+    const warn = vi.fn(() => {
+      throw new Error('EPIPE')
+    })
+    expect(() => diagnosticWriter('stderr', vi.fn(), warn)('{}')).not.toThrow()
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes one JSON line per event to a real file and creates the parent directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'pc-diag-'))
+    try {
+      const sink = join(root, 'nested', 'pi-diagnostics.jsonl')
+      const write = diagnosticWriter(sink)
+      write(JSON.stringify({ event: 'flush_memory', outcome: 'server_unavailable' }))
+      write(JSON.stringify({ event: 'recall', outcome: 'invalid_response' }))
+      const lines = readFileSync(sink, 'utf8').split('\n')
+      expect(lines).toHaveLength(3)
+      expect(lines[2]).toBe('')
+      expect(lines.slice(0, 2).map((line) => JSON.parse(line))).toEqual([
+        { event: 'flush_memory', outcome: 'server_unavailable' },
+        { event: 'recall', outcome: 'invalid_response' },
+      ])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/integrations/pi/plugins/powercontext/tests/diagnostics.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/diagnostics.spec.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest'
-import { failureEvent } from '../src/diagnostics.ts'
+import { describe, expect, it, vi } from 'vitest'
+import { diagnosticWriter, failureEvent } from '../src/diagnostics.ts'
 import { ServerResponseError } from '../src/errors.ts'
 
 describe('host-visible diagnostic classification', () => {
@@ -80,5 +80,36 @@ describe('host-visible diagnostic classification', () => {
       http_status: 404,
       error_code: 'invalid_request',
     })
+  })
+})
+
+describe('diagnostic sink', () => {
+  it('stays silent by default so nothing reaches the TUI through stderr', () => {
+    const append = vi.fn()
+    const warn = vi.fn()
+    diagnosticWriter('off', append, warn)('{"event":"flush_memory"}')
+    expect(append).not.toHaveBeenCalled()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('writes to stderr only when asked to', () => {
+    const append = vi.fn()
+    const warn = vi.fn()
+    diagnosticWriter('stderr', append, warn)('{"event":"flush_memory"}')
+    expect(warn).toHaveBeenCalledWith('{"event":"flush_memory"}')
+    expect(append).not.toHaveBeenCalled()
+  })
+
+  it('appends JSON lines to a configured file and survives write failures', () => {
+    const append = vi.fn()
+    const warn = vi.fn()
+    diagnosticWriter('/var/log/pc.jsonl', append, warn)('{"event":"flush_memory"}')
+    expect(append).toHaveBeenCalledWith('/var/log/pc.jsonl', '{"event":"flush_memory"}\n')
+    expect(warn).not.toHaveBeenCalled()
+
+    const failing = vi.fn(() => {
+      throw new Error('EACCES')
+    })
+    expect(() => diagnosticWriter('/var/log/pc.jsonl', failing, warn)('{}')).not.toThrow()
   })
 })

--- a/integrations/pi/plugins/powercontext/tests/extension.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/extension.spec.ts
@@ -99,8 +99,27 @@ describe('PowerContext Pi extension', () => {
     })
   })
 
+  it('keeps stderr clean by default so the TUI input bar is not corrupted', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('network unavailable')))
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const beforeAgentStart = installExtension().get('before_agent_start')
+
+    await expect(beforeAgentStart?.({
+      prompt: 'continue implementation',
+      systemPrompt: 'Base instructions',
+    }, {
+      cwd: '/workspace/repo',
+      sessionManager: {
+        getSessionId: () => 'session-42',
+        getBranch: () => [],
+      },
+    })).resolves.toBeUndefined()
+    expect(warning).not.toHaveBeenCalled()
+  })
+
   it('continues without changing Pi when PowerContext is unavailable', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('network unavailable')))
+    vi.stubEnv('POWERCONTEXT_PI_DIAGNOSTICS', 'stderr')
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const beforeAgentStart = installExtension().get('before_agent_start')
 
@@ -128,6 +147,7 @@ describe('PowerContext Pi extension', () => {
       return new Response(JSON.stringify({ error: { code: 'invalid_request' } }), { status: 422 })
     })
     vi.stubGlobal('fetch', fetch)
+    vi.stubEnv('POWERCONTEXT_PI_DIAGNOSTICS', 'stderr')
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const beforeAgentStart = installExtension().get('before_agent_start')
 
@@ -162,6 +182,7 @@ describe('PowerContext Pi extension', () => {
       return new Response(JSON.stringify({ error: { code: 'invalid_request' } }), { status: 422 })
     })
     vi.stubGlobal('fetch', fetch)
+    vi.stubEnv('POWERCONTEXT_PI_DIAGNOSTICS', 'stderr')
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const beforeAgentStart = installExtension().get('before_agent_start')
 
@@ -201,6 +222,7 @@ describe('PowerContext Pi extension', () => {
       return new Response(JSON.stringify({ error: { code: 'conflict' } }), { status: 409 })
     })
     vi.stubGlobal('fetch', fetch)
+    vi.stubEnv('POWERCONTEXT_PI_DIAGNOSTICS', 'stderr')
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const beforeAgentStart = installExtension().get('before_agent_start')
 

--- a/integrations/pi/plugins/powercontext/tests/tools.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/tools.spec.ts
@@ -38,6 +38,7 @@ function createRuntime(fetch: FetchFn): PluginRuntime {
       maxBytes: 8000,
       flushOnCapture: false,
       flushMaxCalls: 4,
+      diagnostics: 'off',
     },
     resolveScope: async () => 'project:demo',
   } as PluginRuntime


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1528.

# Rationale for this change

The Pi extension wrote its diagnostic JSON lines through `console.warn`, so every `server_unavailable` notice (for example after a 503 from `flush_memory`) landed inside Pi's TUI: Pi renders on stdout with cursor positioning, and stderr output interleaves with the `❯` input bar and breaks the border. Pi's `ExtensionContext` exposes no logger, unlike the DSH host the sibling plugin routes its diagnostics through, so the extension needs its own sink.

# What changes are included in this PR?

- `src/config.ts`: new `diagnostics` setting from `POWERCONTEXT_PI_DIAGNOSTICS` — `off` (default), `stderr`, or a file path (`~/` expanded like `POWERCONTEXT_CLIENT_CONFIG_FILE`).
- `src/diagnostics.ts`: `diagnosticWriter(sink)` returns the line sink for the emitter: silent, `console.warn`, or append-as-JSON-lines to the file; write failures are swallowed so diagnostics can never break the extension.
- `extensions/powercontext.ts`: the emitter uses `diagnosticWriter(config.diagnostics)` instead of `console.warn`.
- README: documents the setting and why the default is silent.
- Tests: `config.spec.ts` (parsing, default, `~/` expansion), `diagnostics.spec.ts` (all three sinks, write failure), `extension.spec.ts` (a new case asserts stderr stays clean by default; the four existing stderr assertions now opt in with `POWERCONTEXT_PI_DIAGNOSTICS=stderr`), plus the two hand-built config fixtures.

# Are there any user-facing changes?

Yes: diagnostics are no longer printed by default. `POWERCONTEXT_PI_DIAGNOSTICS=stderr` restores the previous behaviour; `/pc` still shows the current status. No API or persisted-format changes.

# How was this change tested?

```
cd integrations/pi/plugins/powercontext
pnpm test        # 82 passed
pnpm typecheck   # clean
```

Not exercised against a live Pi TUI; the change only replaces the stderr sink.

# AI usage statement

Claude Code (Claude Fable 5.1) was used to analyse the issue, write the change and the tests; the author directed the work and takes responsibility for it.
