### PR TITLE
docs: align English deployment and tracing guides

### DIFF
--- a/docs/en/docs/get-started/configure-models.md
+++ b/docs/en/docs/get-started/configure-models.md
@@ -29,6 +29,16 @@ Choose the interface your model service actually offers. OpenAI-compatible can a
 it does not require a particular Agent subscription. The wizard does not test credentials, billing limits, model
 availability, or remote connectivity. Readiness and actual processing after startup check those conditions.
 
+For example, with the OpenAI provider, the model identifier combines the provider prefix and model name:
+
+```dotenv
+OPENAI_API_KEY=<provide this through a protected environment or secret manager>
+POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=openai:gpt-4.1-mini
+```
+
+The available model still depends on the provider account and region. Other providers use the same
+`provider:model-name` form; use a model name supported by that provider instead of copying the OpenAI example.
+
 Embedding can share an endpoint and credentials with Generation, but usually uses a different model.
 Its dimension must match an output size the selected model supports. The Embedding Profile ID names that combination
 of model, dimension, and vector conventions; it is not another API key. For a new database, you can use the suggested ID.

--- a/docs/en/docs/operate/deploy-server.md
+++ b/docs/en/docs/operate/deploy-server.md
@@ -79,9 +79,6 @@ For access from another machine:
 
 The built-in command serves HTTP and has no TLS options. Terminate HTTPS outside PowerContext.
 
-Configure the Agent on the client machine using [Connect to a remote Server](connect-remote-server.md).
-Its `--allow-insecure-http` option is client-side and does not change the Server listener or authentication.
-
 ## Run from an installed tool
 
 Install PowerContext as described in [Install and run](../get-started/install-and-run.md), then choose a persistent data directory:

--- a/docs/en/docs/operate/deploy-server.md
+++ b/docs/en/docs/operate/deploy-server.md
@@ -26,6 +26,11 @@ option for a non-interactive choice.
 
 Linux uses `systemd --user` and writes logs to the user journal. macOS uses a per-user LaunchAgent, and Windows uses a current-user Task Scheduler task; both write stdout and stderr below the PowerContext user data directory. `service status` reports the exact log selector or path.
 
+Personal services support loopback addresses only. Even with authentication enabled, setting
+`POWERCONTEXT_SERVER_HTTP_HOST` to a non-loopback address makes `service install` reject the installation. To allow
+access from another machine, use a container or an administrator-owned service manager, or put a same-host reverse proxy
+in front of the loopback Server.
+
 For an explicit Server configuration, protect the environment file before installing:
 
 ```bash
@@ -39,6 +44,9 @@ On Windows, remove inherited access and grant the file only to the current user,
 ```powershell
 icacls $env:USERPROFILE\powercontext.env /inheritance:r /grant:r "${env:USERNAME}:(F)" "SYSTEM:(F)" "Administrators:(F)"
 ```
+
+This `icacls` command changes ACLs only; it does not change the file owner. If the owner is not the current user, fix the
+owner first.
 
 The native definition stores only the absolute file path and non-content file identity metadata. On Windows this
 includes the current user's owner SID, which is revalidated whenever the launcher starts. It does not copy
@@ -94,7 +102,8 @@ disabled by default, so no token is generated automatically.
 The file may contain provider credentials or a bearer token, so restrict it to the Server operator. For `server run`,
 process environment variables override same-named file values. `config init` creates a model-free base configuration; see
 [Enable extraction and vector search](../get-started/configure-models.md)
-when you need to add inference models and enable the full capability set.
+when you need to add inference models and enable the full capability set. See [Configuration](configuration.md) for all
+configuration parameters and their defaults.
 
 Whether the Server runs in the foreground, in Docker, or as a personal service, startup or installation output warns
 that missing models may affect some artifact features and links to the
@@ -180,7 +189,14 @@ curl --fail http://127.0.0.1:8000/health/ready
 ```
 
 Readiness returns HTTP 503 when a required runtime or database binding is unavailable. An optional inference provider
-can make the response `degraded` with HTTP 200 while database-backed operations remain available.
+can make the response `degraded` with HTTP 200 while database-backed operations remain available. Therefore,
+`curl --fail` checks only the HTTP status and does not treat `degraded` as a failure. If the deployment depends on
+inference, also require the response `status` to be `ready`:
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:8000/health/ready \
+  | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["status"]); sys.exit(data["status"] != "ready")'
+```
 
 After enabling authentication, verify a protected endpoint as well:
 

--- a/docs/en/docs/operate/deploy-server.md
+++ b/docs/en/docs/operate/deploy-server.md
@@ -5,6 +5,10 @@ description: Run PowerContext with persistent data, health checks, authenticatio
 
 # Deploy the Server
 
+For client address configuration and the `--allow-insecure-http` confirmation, see
+[Connect to a remote Server](connect-remote-server.md). This is a client option; it does not change the Server listener
+or authentication configuration.
+
 Windows support is `experimental`.
 
 `powercontext server run` is a foreground process. On a personal macOS, Linux, or Windows workstation, PowerContext can register
@@ -20,16 +24,16 @@ powercontext service install
 powercontext service status
 ```
 
-On Windows, the command asks whether to enable startup at the current user's next login when neither
-`--start-on-login` nor `--no-start-on-login` is supplied; pressing Enter keeps login auto-start disabled. Use either
-option for a non-interactive choice.
-
 Linux uses `systemd --user` and writes logs to the user journal. macOS uses a per-user LaunchAgent, and Windows uses a current-user Task Scheduler task; both write stdout and stderr below the PowerContext user data directory. `service status` reports the exact log selector or path.
 
 Personal services support loopback addresses only. Even with authentication enabled, setting
 `POWERCONTEXT_SERVER_HTTP_HOST` to a non-loopback address makes `service install` reject the installation. To allow
 access from another machine, use a container or an administrator-owned service manager, or put a same-host reverse proxy
 in front of the loopback Server.
+
+On Windows, the command asks whether to enable startup at the current user's next login when neither
+`--start-on-login` nor `--no-start-on-login` is supplied; pressing Enter keeps login auto-start disabled. Use either
+option for a non-interactive choice.
 
 For an explicit Server configuration, protect the environment file before installing:
 
@@ -38,6 +42,10 @@ chmod 600 /path/to/powercontext.env
 powercontext config validate --env-file /path/to/powercontext.env
 powercontext service install --env-file /path/to/powercontext.env
 ```
+
+The successful installation summary prints the environment file actually used. If Bearer authentication is enabled,
+read `POWERCONTEXT_SERVER_AUTH_TOKEN` from that file; the command never prints the token value. Authentication is
+disabled by default, so no token is generated automatically.
 
 On Windows, remove inherited access and grant the file only to the current user, `SYSTEM`, and local `Administrators` before validation, for example:
 
@@ -94,10 +102,6 @@ the working directory:
 powercontext config validate --env-file /etc/powercontext/powercontext.env
 powercontext server run --env-file /etc/powercontext/powercontext.env
 ```
-
-The successful installation summary prints the environment file actually used. If Bearer authentication is enabled,
-read `POWERCONTEXT_SERVER_AUTH_TOKEN` from that file; the command never prints the token value. Authentication is
-disabled by default, so no token is generated automatically.
 
 The file may contain provider credentials or a bearer token, so restrict it to the Server operator. For `server run`,
 process environment variables override same-named file values. `config init` creates a model-free base configuration; see

--- a/docs/en/docs/operate/observability.md
+++ b/docs/en/docs/operate/observability.md
@@ -20,8 +20,24 @@ explain content-free recall and capture diagnostics; a missing context result ca
 
 ## Metrics and readiness
 
-Metrics are enabled by default at `/metrics`. In enforced mode, authenticate the metrics request as an authorized
-Principal. Liveness at `/health/live` and readiness at `/health/ready` remain public.
+Metrics are enabled by default at `/metrics`. In `enforced` mode, `/metrics` and `capabilities` require a Principal with
+the `server.observe` permission. See [Troubleshoot](troubleshoot.md) for authentication and permission configuration.
+Liveness at `/health/live` and readiness at `/health/ready` remain public.
+
+`/metrics` exposes Prometheus-format metrics. Common metrics include:
+
+| Metric | Use |
+| --- | --- |
+| `powercontext_server_transport_requests_total` | Count requests by transport, operation, and outcome |
+| `powercontext_server_transport_request_duration_seconds` | Observe request duration |
+| `powercontext_server_application_operations_total` | Observe successful and failed application operations |
+| `powercontext_server_runtime_ready` | Determine whether the Runtime can accept operations |
+
+`powercontext_server_runtime_ready=1` means only that the Runtime can accept operations. It may still be `1` while the
+Server is `degraded`, so it does not prove that model capabilities are fully available. Combine it with the `status` from
+`/health/ready` and `powercontext capabilities`.
+
+To disable `/metrics`, set `POWERCONTEXT_SERVER_METRICS_ENABLED=false`; see [Configuration](configuration.md).
 
 Use `powercontext ready` and `powercontext capabilities` to distinguish an unavailable database from a degraded
 optional model provider. See [Troubleshoot](troubleshoot.md) for status definitions and recovery steps.

--- a/docs/en/docs/operate/trace-with-langfuse.md
+++ b/docs/en/docs/operate/trace-with-langfuse.md
@@ -13,6 +13,23 @@ This guide sends those spans to [Langfuse](https://langfuse.com) through its OTL
 code change and no Langfuse SDK: the standard OpenTelemetry variables from [Trace with Phoenix](trace-with-phoenix.md)
 point the exporter at Langfuse instead.
 
+## Prerequisites
+
+This guide assumes a Linux or macOS development machine with:
+
+- Git;
+- Docker Engine and Docker Compose, or Docker Desktop;
+- `uv`, Bash, `curl`, and `python3`;
+- ports `3000` and `8000` available locally.
+
+Check the tool versions before starting:
+
+```bash
+docker info
+docker compose version
+uv --version
+```
+
 ## Start Langfuse
 
 Langfuse self-hosting runs several services (web, worker, PostgreSQL, ClickHouse, Redis, and MinIO) with Docker
@@ -23,6 +40,10 @@ git clone https://github.com/langfuse/langfuse.git
 cd langfuse
 docker compose up -d
 ```
+
+The default Compose configuration is suitable for local evaluation only. It uses development credentials and local
+storage; do not expose it directly to an untrusted network. Run `docker compose ps` and inspect the service logs if
+the UI does not open.
 
 Open <http://localhost:3000>, create a user, an organization, and a project, then create an API key pair in the project
 settings. Keep the public key (`pk-lf-...`) and the secret key (`sk-lf-...`) at hand; they authenticate the exporter
@@ -35,18 +56,37 @@ URL of your region, such as `https://cloud.langfuse.com` or `https://us.cloud.la
 
 ## Install the export dependency
 
-Recording and export require the `tracing-otlp` extra:
+Recording and export require the `tracing-otlp` extra. The following command installs the latest code from the
+repository's `master` branch:
 
 ```bash
 uv tool install --force "powercontext[cli,server,tracing-otlp] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
-Without this extra, enabling tracing fails at startup with an explicit error instead of silently dropping spans.
+Without this extra, enabling tracing fails at startup with an explicit error instead of silently dropping spans. The
+command below is intended for a new local deployment. Because `--force` replaces the existing `uv` tool environment,
+do not use it blindly for a Server that is already serving traffic.
+
+If an existing Server should gain tracing, install the extra into the Python environment that actually runs that
+Server, then restart the Server. For example, with a `uv`-managed environment:
+
+```bash
+command -v powercontext
+uv tool install --force "powercontext[cli,server,tracing-otlp] @ git+https://github.com/oceanbase/powercontext.git@master"
+command -v powercontext
+powercontext server run --env-file /path/to/powercontext.env
+```
+
+For a systemd, Supervisor, container, or other managed deployment, update that deployment's image or environment
+instead and restart the existing Server through its process manager. The important requirement is that the restarted
+process imports the environment containing `tracing-otlp`; installing a separate CLI copy does not change a running
+process.
 
 ## Configure and start the Server
 
 Langfuse authenticates OTLP requests with HTTP Basic authentication built from the project keys. Enable tracing, point
-the exporter at Langfuse, and configure a generation model so inference spans have something to record:
+the exporter at Langfuse, and configure a supported generation model so inference spans have something to record.
+`provider:model-name` is only a placeholder and will not work as-is. For example, an OpenAI deployment can use:
 
 ```bash
 export LANGFUSE_PUBLIC_KEY=pk-lf-replace-me
@@ -55,11 +95,16 @@ LANGFUSE_AUTH=$(printf '%s:%s' "$LANGFUSE_PUBLIC_KEY" "$LANGFUSE_SECRET_KEY" | b
 
 export POWERCONTEXT_SERVER_TRACING_ENABLED=true
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3000/api/public/otel
-export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${LANGFUSE_AUTH},x-langfuse-ingestion-version=4"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $LANGFUSE_AUTH,x-langfuse-ingestion-version=4"
 export OTEL_SERVICE_NAME=powercontext-server
-export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=provider:model-name
+export OPENAI_API_KEY=replace-with-your-key
+export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=openai:gpt-4.1-mini
 powercontext server run
 ```
+
+Run the Server command in Terminal A and keep it running. If the Server is already running, apply the same
+environment variables to its actual service definition and restart it; setting them in another terminal does not
+change the existing process.
 
 The OpenTelemetry SDK appends `/v1/traces` to `OTEL_EXPORTER_OTLP_ENDPOINT`, so the spans arrive at
 `http://localhost:3000/api/public/otel/v1/traces`, the traces endpoint Langfuse expects. Langfuse accepts OTLP over
@@ -68,21 +113,84 @@ HTTP only, which is the protocol of the exporter installed by the `tracing-otlp`
 that ingestion can lag by up to ten minutes. Set the provider credentials your generation model needs; PowerContext
 records neither them nor the exporter headers.
 
-## Trigger one inference request
-
-Set `POWERCONTEXT_SCOPE_ID` to an existing ID returned by `create_scope`, capture a Source, then convert it into
-Memory:
+Create a Scope and run the client-side checks in Terminal B:
 
 ```bash
-curl -X POST http://localhost:8000/v1/sources/content \
+export POWERCONTEXT_BASE_URL=http://localhost:8000
+export POWERCONTEXT_AUTH_TOKEN=replace-with-server-token
+export POWERCONTEXT_SCOPE_NAME=tracing-example
+export POWERCONTEXT_AUTH_HEADER="Authorization: Bearer $POWERCONTEXT_AUTH_TOKEN"
+
+POWERCONTEXT_SCOPE_ID=$(curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/scopes" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
   -H 'content-type: application/json' \
-  -d "{\"scope_id\":\"${POWERCONTEXT_SCOPE_ID}\",\"source_id\":\"task-1\",\"content\":\"I always book aisle seats.\"}"
+  -d "$POWERCONTEXT_SCOPE_NAME" \
+  | python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])')
+export POWERCONTEXT_SCOPE_ID
 ```
 
+The exact authentication setup depends on the Server configuration. Keep `POWERCONTEXT_AUTH_TOKEN` empty for an
+unauthenticated local Server and remove the `Authorization` header in the examples, or set a token with the
+permission required by the endpoint. For an authenticated Server, the token must be allowed to create Scopes and
+call the traced endpoints; the management endpoints also enforce the configured `server.observe` permission where
+applicable.
+
+Check readiness, capabilities, and a real trace-producing request in order:
+
 ```bash
-curl -X POST http://localhost:8000/v1/memory/flush \
+curl --fail-with-body -sS "$POWERCONTEXT_BASE_URL/health/ready" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
+  | python3 -c 'import json, sys; data=json.load(sys.stdin); assert data.get("status") == "ready", data; print(data["status"])'
+
+curl --fail-with-body -sS "$POWERCONTEXT_BASE_URL/v1/capabilities" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
+  | python3 -m json.tool
+
+curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/memory/flush" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
   -H 'content-type: application/json' \
-  -d "{\"scope_id\":\"${POWERCONTEXT_SCOPE_ID}\"}"
+  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'"}' \
+  | python3 -m json.tool
+```
+
+`curl --fail-with-body` only checks the HTTP status code. The readiness example also parses the JSON body and fails
+when the response is HTTP 200 with a `degraded` status. The capabilities response should report tracing as enabled.
+The flush request is the final end-to-end check; it needs the configured model credentials and may take a few seconds.
+
+## Trigger one inference request
+
+The following full API flow creates a fresh Scope, captures a Source, and converts it into Memory. It also avoids
+silently continuing after a failed request:
+
+```bash
+set -euo pipefail
+
+POWERCONTEXT_BASE_URL=${POWERCONTEXT_BASE_URL:-http://localhost:8000}
+POWERCONTEXT_IDEMPOTENCY_KEY="tracing-example-$(date +%s)-$"
+POWERCONTEXT_SCOPE_NAME=tracing-example
+POWERCONTEXT_SOURCE_ID="tracing-source-$(date +%s)"
+POWERCONTEXT_AUTH_HEADER="Authorization: Bearer $POWERCONTEXT_AUTH_TOKEN"
+
+POWERCONTEXT_SCOPE_ID=$(curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/scopes" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
+  -H 'content-type: application/json' \
+  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
+  -d "$POWERCONTEXT_SCOPE_NAME" \
+  | python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])')
+
+curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/sources/content" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
+  -H 'content-type: application/json' \
+  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
+  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'","source_id":"'"$POWERCONTEXT_SOURCE_ID"'","content":"I always book aisle seats."}' \
+  | python3 -m json.tool
+
+curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/memory/flush" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
+  -H 'content-type: application/json' \
+  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
+  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'"}' \
+  | python3 -m json.tool
 ```
 
 Memory extraction runs during the flush, not during capture.
@@ -118,7 +226,7 @@ recognize show usage but no cost until you add a definition under the project's 
 can then be aggregated in the Langfuse dashboards and Metrics API.
 
 Spans are exported in batches, so allow a few seconds before refreshing. Scheduled background activations arrive as
-their own traces, as described in the "Scheduled background spans" section of
+their own traces, as described in the "Background Worker spans" section of
 [Trace with Phoenix](trace-with-phoenix.md).
 
 ## What is not exported
@@ -135,7 +243,8 @@ and traces are located through metadata instead.
 docker compose down
 ```
 
-Add `-v` to delete the stored traces as well.
+This stops the containers while preserving named volumes. Add `-v` only when you also want to delete the stored
+traces and other local Langfuse data.
 
 Span names and attributes follow the Pydantic AI GenAI semantic conventions and can change when that dependency is
 upgraded across a major version. Do not treat them as a stable contract.

--- a/docs/en/docs/operate/trace-with-langfuse.md
+++ b/docs/en/docs/operate/trace-with-langfuse.md
@@ -25,6 +25,7 @@ This guide assumes a Linux or macOS development machine with:
 Check the tool versions before starting:
 
 ```bash
+git --version
 docker info
 docker compose version
 uv --version
@@ -33,17 +34,16 @@ uv --version
 ## Start Langfuse
 
 Langfuse self-hosting runs several services (web, worker, PostgreSQL, ClickHouse, Redis, and MinIO) with Docker
-Compose:
+Compose. The Compose file in the Langfuse repository contains default database, Redis, MinIO, and application
+secrets. The command below uses those defaults and is suitable only for temporary single-machine evaluation. If the
+host may be accessed by others or the deployment will run for a long time, replace the values marked `CHANGEME` in
+the Compose file first:
 
 ```bash
 git clone https://github.com/langfuse/langfuse.git
 cd langfuse
 docker compose up -d
 ```
-
-The default Compose configuration is suitable for local evaluation only. It uses development credentials and local
-storage; do not expose it directly to an untrusted network. Run `docker compose ps` and inspect the service logs if
-the UI does not open.
 
 Open <http://localhost:3000>, create a user, an organization, and a project, then create an API key pair in the project
 settings. Keep the public key (`pk-lf-...`) and the secret key (`sk-lf-...`) at hand; they authenticate the exporter
@@ -56,37 +56,41 @@ URL of your region, such as `https://cloud.langfuse.com` or `https://us.cloud.la
 
 ## Install the export dependency
 
-Recording and export require the `tracing-otlp` extra. The following command installs the latest code from the
-repository's `master` branch:
+Recording and export require the `tracing-otlp` extra:
 
 ```bash
 uv tool install --force "powercontext[cli,server,tracing-otlp] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
-Without this extra, enabling tracing fails at startup with an explicit error instead of silently dropping spans. The
-command below is intended for a new local deployment. Because `--force` replaces the existing `uv` tool environment,
-do not use it blindly for a Server that is already serving traffic.
+Without this extra, enabling tracing fails at startup with an explicit error instead of silently dropping spans. This
+command is intended for a new deployment. It force-rebuilds the existing `uv tool` environment and replaces the
+PowerContext installed in it, so confirm the existing Server's installation method and configuration path first. It
+installs the current code from `master`, so the result changes as the repository is updated.
 
 If an existing Server should gain tracing, install the extra into the Python environment that actually runs that
-Server, then restart the Server. For example, with a `uv`-managed environment:
+Server, then restart the old process. For a foreground Server installed with `uv tool`, press `Ctrl+C` in the old
+Server terminal first, then run:
 
 ```bash
 command -v powercontext
 uv tool install --force "powercontext[cli,server,tracing-otlp] @ git+https://github.com/oceanbase/powercontext.git@master"
-command -v powercontext
 powercontext server run --env-file /path/to/powercontext.env
 ```
 
-For a systemd, Supervisor, container, or other managed deployment, update that deployment's image or environment
-instead and restart the existing Server through its process manager. The important requirement is that the restarted
-process imports the environment containing `tracing-otlp`; installing a separate CLI copy does not change a running
-process.
+Replace the example path with the existing Server's actual configuration path. If the Server is started by systemd,
+Supervisor, or another process manager, confirm that the service points to the updated `powercontext` executable and
+restart it through that manager. Installing the exporter in another environment does not give the running Server
+tracing capability.
 
 ## Configure and start the Server
 
-Langfuse authenticates OTLP requests with HTTP Basic authentication built from the project keys. Enable tracing, point
-the exporter at Langfuse, and configure a supported generation model so inference spans have something to record.
-`provider:model-name` is only a placeholder and will not work as-is. For example, an OpenAI deployment can use:
+`provider:model-name` is only a placeholder and will not work as-is. First configure a supported generation model and
+provider credentials as described in [Configure models and full memory](../get-started/configure-models.md). If you use
+only a proxy or custom endpoint, also set its base URL. The example below uses `openai:gpt-4.1-mini`; the available
+model still depends on the provider account and region.
+
+Langfuse authenticates OTLP requests with HTTP Basic authentication built from the project keys. In Terminal A, enable
+tracing, point the exporter at Langfuse, and configure a generation model so `flush_memory` produces a model-call span:
 
 ```bash
 export LANGFUSE_PUBLIC_KEY=pk-lf-replace-me
@@ -102,9 +106,7 @@ export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=openai:gpt-4.1-mini
 powercontext server run
 ```
 
-Run the Server command in Terminal A and keep it running. If the Server is already running, apply the same
-environment variables to its actual service definition and restart it; setting them in another terminal does not
-change the existing process.
+`powercontext server run` stays in the foreground. Keep Terminal A open and run the checks and requests in Terminal B.
 
 The OpenTelemetry SDK appends `/v1/traces` to `OTEL_EXPORTER_OTLP_ENDPOINT`, so the spans arrive at
 `http://localhost:3000/api/public/otel/v1/traces`, the traces endpoint Langfuse expects. Langfuse accepts OTLP over
@@ -113,84 +115,76 @@ HTTP only, which is the protocol of the exporter installed by the `tracing-otlp`
 that ingestion can lag by up to ten minutes. Set the provider credentials your generation model needs; PowerContext
 records neither them nor the exporter headers.
 
-Create a Scope and run the client-side checks in Terminal B:
+In Terminal B, first set the connection address. Replace the default address if the Server uses another port. If
+authentication is enabled, provide a valid `POWERCONTEXT_CLIENT_API_TOKEN`; do not put the token in this document or
+the repository. The capabilities check also requires `server.observe`:
 
 ```bash
-export POWERCONTEXT_BASE_URL=http://localhost:8000
-export POWERCONTEXT_AUTH_TOKEN=replace-with-server-token
-export POWERCONTEXT_SCOPE_NAME=tracing-example
-export POWERCONTEXT_AUTH_HEADER="Authorization: Bearer $POWERCONTEXT_AUTH_TOKEN"
-
-POWERCONTEXT_SCOPE_ID=$(curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/scopes" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
-  -H 'content-type: application/json' \
-  -d "$POWERCONTEXT_SCOPE_NAME" \
-  | python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])')
-export POWERCONTEXT_SCOPE_ID
+export POWERCONTEXT_BASE_URL="${POWERCONTEXT_BASE_URL:-http://127.0.0.1:8000}"
+export POWERCONTEXT_CLIENT_SERVER_URL="$POWERCONTEXT_BASE_URL"
 ```
 
-The exact authentication setup depends on the Server configuration. Keep `POWERCONTEXT_AUTH_TOKEN` empty for an
-unauthenticated local Server and remove the `Authorization` header in the examples, or set a token with the
-permission required by the endpoint. For an authenticated Server, the token must be allowed to create Scopes and
-call the traced endpoints; the management endpoints also enforce the configured `server.observe` permission where
-applicable.
+Then follow the checks below in order:
 
-Check readiness, capabilities, and a real trace-producing request in order:
+1. Use `powercontext --json ready` or read `/health/ready` directly, checking `status` and `checks`. Automation must
+   confirm that `status` is `ready` instead of checking only the command exit code.
+2. Use `powercontext capabilities` and confirm that the output contains `Memory extraction: enabled`.
+3. Run the `flush_memory` request below and confirm in Langfuse's **Traces** view that the trace contains a
+   `chat <model>` observation.
 
-```bash
-curl --fail-with-body -sS "$POWERCONTEXT_BASE_URL/health/ready" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
-  | python3 -c 'import json, sys; data=json.load(sys.stdin); assert data.get("status") == "ready", data; print(data["status"])'
-
-curl --fail-with-body -sS "$POWERCONTEXT_BASE_URL/v1/capabilities" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
-  | python3 -m json.tool
-
-curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/memory/flush" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
-  -H 'content-type: application/json' \
-  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'"}' \
-  | python3 -m json.tool
-```
-
-`curl --fail-with-body` only checks the HTTP status code. The readiness example also parses the JSON body and fails
-when the response is HTTP 200 with a `degraded` status. The capabilities response should report tracing as enabled.
-The flush request is the final end-to-end check; it needs the configured model credentials and may take a few seconds.
+Only the third step proves that the inference and tracing path works. Starting the Server or receiving a successful
+`/health/ready` response does not prove that Memory extraction is available.
 
 ## Trigger one inference request
 
 The following full API flow creates a fresh Scope, captures a Source, and converts it into Memory. It also avoids
 silently continuing after a failed request:
 
+This Bash API example uses an unauthenticated local instance by default. If the Server uses authentication, provide
+the client token first; the requests below add an `Authorization: Bearer` header consistently. Creating a Scope requires
+`server.admin`. Writing a Source and flushing Memory require `scope.contribute` for the Scope.
+
 ```bash
-set -euo pipefail
+export POWERCONTEXT_BASE_URL="${POWERCONTEXT_BASE_URL:-http://127.0.0.1:8000}"
+export POWERCONTEXT_IDEMPOTENCY_KEY="tracing-example-$(date +%s)-$"
 
-POWERCONTEXT_BASE_URL=${POWERCONTEXT_BASE_URL:-http://localhost:8000}
-POWERCONTEXT_IDEMPOTENCY_KEY="tracing-example-$(date +%s)-$"
-POWERCONTEXT_SCOPE_NAME=tracing-example
-POWERCONTEXT_SOURCE_ID="tracing-source-$(date +%s)"
-POWERCONTEXT_AUTH_HEADER="Authorization: Bearer $POWERCONTEXT_AUTH_TOKEN"
+if [[ -n "${POWERCONTEXT_CLIENT_API_TOKEN:-}" ]]; then
+  POWERCONTEXT_AUTH_ARGS=(--header "Authorization: Bearer ${POWERCONTEXT_CLIENT_API_TOKEN}")
+else
+  POWERCONTEXT_AUTH_ARGS=()
+fi
 
-POWERCONTEXT_SCOPE_ID=$(curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/scopes" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
+POWERCONTEXT_SCOPE_ID="$(
+  set -o pipefail
+  curl --fail --silent --show-error \
+    "${POWERCONTEXT_AUTH_ARGS[@]}" \
+    --header 'content-type: application/json' \
+    --data "{\"title\":\"Langfuse tracing example\",\"summary\":\"Scope for tracing verification\",\"idempotency_key\":\"${POWERCONTEXT_IDEMPOTENCY_KEY}\"}" \
+    "${POWERCONTEXT_BASE_URL}/v1/scopes" \
+  | python3 -c 'import json, sys; print(json.load(sys.stdin)["scope_id"])'
+)"
+: "${POWERCONTEXT_SCOPE_ID:?Scope creation failed; check the response and authentication, then retry}"
+export POWERCONTEXT_SCOPE_ID
+```
+
+The command stores the `scope_id` returned by `create_scope` in `POWERCONTEXT_SCOPE_ID`. To inspect the creation
+request's HTTP status and `X-PowerContext-Request-ID`, rerun it separately with `curl -i`. Then capture a Source and
+convert it into Memory:
+
+```bash
+export POWERCONTEXT_SOURCE_ID="tracing-example-$(date +%s)-$"
+
+curl --fail --show-error -i -X POST "${POWERCONTEXT_BASE_URL}/v1/sources/content" \
+  "${POWERCONTEXT_AUTH_ARGS[@]}" \
   -H 'content-type: application/json' \
-  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
-  -d "$POWERCONTEXT_SCOPE_NAME" \
-  | python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])')
+  -d "{\"scope_id\":\"${POWERCONTEXT_SCOPE_ID}\",\"source_id\":\"${POWERCONTEXT_SOURCE_ID}\",\"content\":\"I always book aisle seats.\"}"
+```
 
-curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/sources/content" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
+```bash
+curl --fail --show-error -i -X POST "${POWERCONTEXT_BASE_URL}/v1/memory/flush" \
+  "${POWERCONTEXT_AUTH_ARGS[@]}" \
   -H 'content-type: application/json' \
-  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
-  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'","source_id":"'"$POWERCONTEXT_SOURCE_ID"'","content":"I always book aisle seats."}' \
-  | python3 -m json.tool
-
-curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/memory/flush" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
-  -H 'content-type: application/json' \
-  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
-  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'"}' \
-  | python3 -m json.tool
+  -d "{\"scope_id\":\"${POWERCONTEXT_SCOPE_ID}\"}"
 ```
 
 Memory extraction runs during the flush, not during capture.
@@ -243,8 +237,7 @@ and traces are located through metadata instead.
 docker compose down
 ```
 
-This stops the containers while preserving named volumes. Add `-v` only when you also want to delete the stored
-traces and other local Langfuse data.
+Add `-v` to delete the stored traces as well.
 
 Span names and attributes follow the Pydantic AI GenAI semantic conventions and can change when that dependency is
 upgraded across a major version. Do not treat them as a stable contract.

--- a/docs/en/docs/operate/trace-with-langfuse.md
+++ b/docs/en/docs/operate/trace-with-langfuse.md
@@ -85,8 +85,8 @@ tracing capability.
 ## Configure and start the Server
 
 `provider:model-name` is only a placeholder and will not work as-is. First configure a supported generation model and
-provider credentials as described in [Configure models and full memory](../get-started/configure-models.md). If you use
-only a proxy or custom endpoint, also set its base URL. The example below uses `openai:gpt-4.1-mini`; the available
+provider credentials as described in [Configure models and full memory](../get-started/configure-models.md). Set a custom
+base URL only if you use a proxy or custom endpoint. The example below uses `openai:gpt-4.1-mini`; the available
 model still depends on the provider account and region.
 
 Langfuse authenticates OTLP requests with HTTP Basic authentication built from the project keys. In Terminal A, enable
@@ -101,7 +101,6 @@ export POWERCONTEXT_SERVER_TRACING_ENABLED=true
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3000/api/public/otel
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $LANGFUSE_AUTH,x-langfuse-ingestion-version=4"
 export OTEL_SERVICE_NAME=powercontext-server
-export OPENAI_API_KEY=replace-with-your-key
 export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=openai:gpt-4.1-mini
 powercontext server run
 ```
@@ -137,8 +136,7 @@ Only the third step proves that the inference and tracing path works. Starting t
 
 ## Trigger one inference request
 
-The following full API flow creates a fresh Scope, captures a Source, and converts it into Memory. It also avoids
-silently continuing after a failed request:
+The following API flow creates a fresh Scope, captures a Source, and converts it into Memory.
 
 This Bash API example uses an unauthenticated local instance by default. If the Server uses authentication, provide
 the client token first; the requests below add an `Authorization: Bearer` header consistently. Creating a Scope requires

--- a/docs/en/docs/operate/trace-with-phoenix.md
+++ b/docs/en/docs/operate/trace-with-phoenix.md
@@ -91,8 +91,8 @@ tracing capability.
 ## Configure and start the Server
 
 `provider:model-name` is only a placeholder and will not work as-is. First configure a supported generation model and
-provider credentials as described in [Configure models and full memory](../get-started/configure-models.md). If you use
-only a proxy or custom endpoint, also set its base URL. The example below uses `openai:gpt-4.1-mini`; the available
+provider credentials as described in [Configure models and full memory](../get-started/configure-models.md). Set a custom
+base URL only if you use a proxy or custom endpoint. The example below uses `openai:gpt-4.1-mini`; the available
 model still depends on the provider account and region.
 
 In Terminal A, enable tracing, point the exporter at Phoenix, and configure a generation model so `flush_memory`
@@ -102,7 +102,6 @@ produces a model-call span:
 export POWERCONTEXT_SERVER_TRACING_ENABLED=true
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:6006
 export OTEL_SERVICE_NAME=powercontext-server
-export OPENAI_API_KEY=replace-with-your-key
 export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=openai:gpt-4.1-mini
 powercontext server run
 ```
@@ -142,8 +141,7 @@ Only the third step proves that the inference and tracing path works. Starting t
 
 ## Trigger one inference request
 
-The following full API flow creates a fresh Scope, captures a Source, and converts it into Memory. It also avoids
-silently continuing after a failed request:
+The following API flow creates a fresh Scope, captures a Source, and converts it into Memory.
 
 This Bash API example uses an unauthenticated local instance by default. If the Server uses authentication, provide
 the client token first; the requests below add an `Authorization: Bearer` header consistently. Creating a Scope requires
@@ -258,7 +256,7 @@ PowerContext configures inference instrumentation to exclude content. Spans carr
 durations, and error categories. Prompts, model responses, Memory content, and vectors are excluded, and message
 attributes record only the shape of each message rather than its text.
 
-## Stop Phoenix
+## Stop and remove Phoenix
 
 Stop the temporary container without removing it:
 
@@ -272,7 +270,8 @@ Start it again later with:
 docker start powercontext-phoenix
 ```
 
-If the container is no longer needed, remove it:
+If the container is no longer needed, remove it. Without a persistent volume, this also deletes the SQLite trace data
+stored inside the container:
 
 ```bash
 docker rm -f powercontext-phoenix

--- a/docs/en/docs/operate/trace-with-phoenix.md
+++ b/docs/en/docs/operate/trace-with-phoenix.md
@@ -15,7 +15,7 @@ This guide sends those spans to [Phoenix](https://github.com/Arize-ai/phoenix) r
 
 This guide assumes a Linux or macOS development machine with:
 
-- Docker Engine and Docker Compose, or Docker Desktop;
+- Docker Engine; use Docker Desktop on macOS;
 - `uv`, Bash, `curl`, and `python3`;
 - ports `6006` and `8000` available locally.
 
@@ -23,7 +23,6 @@ Check the tool versions before starting:
 
 ```bash
 docker info
-docker compose version
 uv --version
 ```
 
@@ -35,59 +34,69 @@ The simplest command uses a temporary container:
 docker run -d --name powercontext-phoenix -p 6006:6006 arizephoenix/phoenix:20.1.0
 ```
 
-For a local setup that retains SQLite trace data across container recreation, set a working directory and mount a
-named volume:
+Choose either the temporary container or the persistent-volume command below; do not run both commands with the same
+container name. To retain traces after removing the container, use the persistent-volume command on the first launch.
+If a temporary container already exists, back up any data you need and remove the old container before switching.
 
 ```bash
-export PHOENIX_WORKING_DIR=/mnt/data
 docker volume create powercontext-phoenix-data
 docker run -d --name powercontext-phoenix \
   -p 6006:6006 \
-  -e PHOENIX_WORKING_DIR="$PHOENIX_WORKING_DIR" \
-  -v powercontext-phoenix-data:"$PHOENIX_WORKING_DIR" \
+  -e PHOENIX_WORKING_DIR=/mnt/data \
+  -v powercontext-phoenix-data:/mnt/data \
   arizephoenix/phoenix:20.1.0
 ```
 
 Phoenix serves both its UI and its OTLP HTTP receiver on port `6006`. Open <http://localhost:6006> to confirm it is
-running. Pin an explicit tag so the endpoint and UI layout match this guide. The OTLP HTTP route is
-`http://localhost:6006/v1/traces`; port `4317` is only relevant when using an OTLP gRPC receiver.
+running. The OTLP HTTP route is `http://localhost:6006/v1/traces`; port `4317` is only relevant when using an OTLP
+gRPC receiver. Opening the UI confirms only that the UI and Phoenix process are running. Even a successful
+`GET /v1/traces` response confirms only that the HTTP route is reachable; it does not prove that OTLP spans are received,
+stored, and queryable. Pin an explicit image tag so the endpoint and UI layout match this guide.
 
-The first command uses the container's writable layer. Without the named volume, removing the container also removes
-the SQLite trace data. Use the volume variant when you need to stop and recreate Phoenix without losing traces.
+Phoenix uses SQLite by default; the official recommendation is to point `PHOENIX_WORKING_DIR` at a persistent volume.
+See the [Phoenix storage configuration](https://arize.com/docs/phoenix/self-hosting/deployment-options/docker) documentation
+for other storage options.
+
+This guide uses an OTLP/HTTP exporter, so port `4317` is not a required check. Verify it only when using an OTLP/gRPC
+exporter.
 
 ## Install the export dependency
 
-Recording and export require the `tracing-otlp` extra. The following command installs the latest code from the
-repository's `master` branch:
+Recording and export require the `tracing-otlp` extra:
 
 ```bash
 uv tool install --force "powercontext[cli,server,tracing-otlp] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
-Without this extra, enabling tracing fails at startup with an explicit error instead of silently dropping spans. The
-command below is intended for a new local deployment. Because `--force` replaces the existing `uv` tool environment,
-do not use it blindly for a Server that is already serving traffic.
+Without this extra, enabling tracing fails at startup with an explicit error instead of silently dropping spans. This
+command is intended for a new deployment. It force-rebuilds the existing `uv tool` environment and replaces the
+PowerContext installed in it, so confirm the existing Server's installation method and configuration path first. It
+installs the current code from `master`, so the result changes as the repository is updated.
 
 If an existing Server should gain tracing, install the extra into the Python environment that actually runs that
-Server, then restart the Server. For example, with a `uv`-managed environment:
+Server, then restart the old process. For a foreground Server installed with `uv tool`, press `Ctrl+C` in the old
+Server terminal first, then run:
 
 ```bash
 command -v powercontext
 uv tool install --force "powercontext[cli,server,tracing-otlp] @ git+https://github.com/oceanbase/powercontext.git@master"
-command -v powercontext
 powercontext server run --env-file /path/to/powercontext.env
 ```
 
-For a systemd, Supervisor, container, or other managed deployment, update that deployment's image or environment
-instead and restart the existing Server through its process manager. The important requirement is that the restarted
-process imports the environment containing `tracing-otlp`; installing a separate CLI copy does not change a running
-process.
+Replace the example path with the existing Server's actual configuration path. If the Server is started by systemd,
+Supervisor, or another process manager, confirm that the service points to the updated `powercontext` executable and
+restart it through that manager. Installing the exporter in another environment does not give the running Server
+tracing capability.
 
 ## Configure and start the Server
 
-Enable tracing, point the exporter at Phoenix, and configure a supported generation model so inference spans have
-something to record. `provider:model-name` is only a placeholder and will not work as-is. For example, an OpenAI
-deployment can use:
+`provider:model-name` is only a placeholder and will not work as-is. First configure a supported generation model and
+provider credentials as described in [Configure models and full memory](../get-started/configure-models.md). If you use
+only a proxy or custom endpoint, also set its base URL. The example below uses `openai:gpt-4.1-mini`; the available
+model still depends on the provider account and region.
+
+In Terminal A, enable tracing, point the exporter at Phoenix, and configure a generation model so `flush_memory`
+produces a model-call span:
 
 ```bash
 export POWERCONTEXT_SERVER_TRACING_ENABLED=true
@@ -98,91 +107,89 @@ export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=openai:gpt-4.1-mini
 powercontext server run
 ```
 
-Run the Server command in Terminal A and keep it running. If the Server is already running, apply the same
-environment variables to its actual service definition and restart it; setting them in another terminal does not
-change the existing process.
+`powercontext server run` stays in the foreground. Keep Terminal A open and run the checks and requests in Terminal B.
 
 The OpenTelemetry SDK appends `/v1/traces` to `OTEL_EXPORTER_OTLP_ENDPOINT`, so the spans arrive at
 `http://localhost:6006/v1/traces`. Use `OTEL_EXPORTER_OTLP_HEADERS` for a Phoenix deployment that requires
 authentication. Set the provider credentials your generation model needs; PowerContext never records them.
 
-Create a Scope and run the client-side checks in Terminal B:
+The acceptance flow has three levels:
+
+| Check | What it proves |
+| --- | --- |
+| Open <http://localhost:6006> or check that the HTTP route is reachable | Phoenix UI and HTTP service have started; it does not prove spans are received. |
+| Send a real operation after starting the Server and find its span in Phoenix | The OTLP/HTTP exporter sent a valid span and Phoenix received, stored, and queried it. |
+| A successful `flush_memory` with a `chat <model>` generation span in the trace | The PowerContext inference tracing path works. |
+
+In Terminal B, first set the connection address. Replace the default address if the Server uses another port. If
+authentication is enabled, provide a valid `POWERCONTEXT_CLIENT_API_TOKEN`; do not put the token in this document or
+the repository. The capabilities check also requires `server.observe`:
 
 ```bash
-export POWERCONTEXT_BASE_URL=http://localhost:8000
-export POWERCONTEXT_AUTH_TOKEN=replace-with-server-token
-export POWERCONTEXT_SCOPE_NAME=tracing-example
-export POWERCONTEXT_AUTH_HEADER="Authorization: Bearer $POWERCONTEXT_AUTH_TOKEN"
-
-POWERCONTEXT_SCOPE_ID=$(curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/scopes" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
-  -H 'content-type: application/json' \
-  -d "$POWERCONTEXT_SCOPE_NAME" \
-  | python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])')
-export POWERCONTEXT_SCOPE_ID
+export POWERCONTEXT_BASE_URL="${POWERCONTEXT_BASE_URL:-http://127.0.0.1:8000}"
+export POWERCONTEXT_CLIENT_SERVER_URL="$POWERCONTEXT_BASE_URL"
 ```
 
-The exact authentication setup depends on the Server configuration. Keep `POWERCONTEXT_AUTH_TOKEN` empty for an
-unauthenticated local Server and remove the `Authorization` header in the examples, or set a token with the
-permission required by the endpoint. For an authenticated Server, the token must be allowed to create Scopes and
-call the traced endpoints.
+Then follow the checks below in order:
 
-Check readiness, capabilities, and a real trace-producing request in order:
+1. Use `powercontext --json ready` or read `/health/ready` directly, checking `status` and `checks`. Automation must
+   confirm that `status` is `ready` instead of checking only the command exit code.
+2. Use `powercontext capabilities` and confirm that the output contains `Memory extraction: enabled`.
+3. Run the `flush_memory` request below and confirm in Phoenix that the trace contains a `chat <model>` span.
 
-```bash
-curl --fail-with-body -sS "$POWERCONTEXT_BASE_URL/health/ready" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
-  | python3 -c 'import json, sys; data=json.load(sys.stdin); assert data.get("status") == "ready", data; print(data["status"])'
-
-curl --fail-with-body -sS "$POWERCONTEXT_BASE_URL/v1/capabilities" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
-  | python3 -m json.tool
-
-curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/memory/flush" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
-  -H 'content-type: application/json' \
-  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'"}' \
-  | python3 -m json.tool
-```
-
-`curl --fail-with-body` only checks the HTTP status code. The readiness example also parses the JSON body and fails
-when the response is HTTP 200 with a `degraded` status. The capabilities response should report tracing as enabled.
-The flush request is the final end-to-end check; it needs the configured model credentials and may take a few seconds.
+Only the third step proves that the inference and tracing path works. Starting the Server or receiving a successful
+`/health/ready` response does not prove that Memory extraction is available.
 
 ## Trigger one inference request
 
 The following full API flow creates a fresh Scope, captures a Source, and converts it into Memory. It also avoids
 silently continuing after a failed request:
 
+This Bash API example uses an unauthenticated local instance by default. If the Server uses authentication, provide
+the client token first; the requests below add an `Authorization: Bearer` header consistently. Creating a Scope requires
+`server.admin`. Writing a Source and flushing Memory require `scope.contribute` for the Scope.
+
 ```bash
-set -euo pipefail
+export POWERCONTEXT_BASE_URL="${POWERCONTEXT_BASE_URL:-http://127.0.0.1:8000}"
+export POWERCONTEXT_IDEMPOTENCY_KEY="tracing-example-$(date +%s)-$"
 
-POWERCONTEXT_BASE_URL=${POWERCONTEXT_BASE_URL:-http://localhost:8000}
-POWERCONTEXT_IDEMPOTENCY_KEY="tracing-example-$(date +%s)-$"
-POWERCONTEXT_SCOPE_NAME=tracing-example
-POWERCONTEXT_SOURCE_ID="tracing-source-$(date +%s)"
-POWERCONTEXT_AUTH_HEADER="Authorization: Bearer $POWERCONTEXT_AUTH_TOKEN"
+if [[ -n "${POWERCONTEXT_CLIENT_API_TOKEN:-}" ]]; then
+  POWERCONTEXT_AUTH_ARGS=(--header "Authorization: Bearer ${POWERCONTEXT_CLIENT_API_TOKEN}")
+else
+  POWERCONTEXT_AUTH_ARGS=()
+fi
 
-POWERCONTEXT_SCOPE_ID=$(curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/scopes" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
+POWERCONTEXT_SCOPE_ID="$(
+  set -o pipefail
+  curl --fail --silent --show-error \
+    "${POWERCONTEXT_AUTH_ARGS[@]}" \
+    --header 'content-type: application/json' \
+    --data "{\"title\":\"Phoenix tracing example\",\"summary\":\"Scope for tracing verification\",\"idempotency_key\":\"${POWERCONTEXT_IDEMPOTENCY_KEY}\"}" \
+    "${POWERCONTEXT_BASE_URL}/v1/scopes" \
+  | python3 -c 'import json, sys; print(json.load(sys.stdin)["scope_id"])'
+)"
+: "${POWERCONTEXT_SCOPE_ID:?Scope creation failed; check the response and authentication, then retry}"
+export POWERCONTEXT_SCOPE_ID
+```
+
+The command stores the `scope_id` returned by `create_scope` in `POWERCONTEXT_SCOPE_ID`. To inspect the creation
+request's HTTP status and `X-PowerContext-Request-ID`, rerun it separately with `curl -i`. Then capture a Source and
+convert it into Memory:
+
+```bash
+export POWERCONTEXT_SOURCE_ID="tracing-example-$(date +%s)-$"
+
+curl --fail --show-error -i -X POST "${POWERCONTEXT_BASE_URL}/v1/sources/content" \
+  "${POWERCONTEXT_AUTH_ARGS[@]}" \
   -H 'content-type: application/json' \
-  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
-  -d "$POWERCONTEXT_SCOPE_NAME" \
-  | python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])')
+  -d "{\"scope_id\":\"${POWERCONTEXT_SCOPE_ID}\",\"source_id\":\"${POWERCONTEXT_SOURCE_ID}\",\"content\":\"I always book aisle seats.\"}"
+```
 
-curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/sources/content" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
+```bash
+curl --fail --show-error -i -X POST "${POWERCONTEXT_BASE_URL}/v1/memory/flush" \
+  "${POWERCONTEXT_AUTH_ARGS[@]}" \
   -H 'content-type: application/json' \
-  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
-  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'","source_id":"'"$POWERCONTEXT_SOURCE_ID"'","content":"I always book aisle seats."}' \
-  | python3 -m json.tool
-
-curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/memory/flush" \
-  -H "$POWERCONTEXT_AUTH_HEADER" \
-  -H 'content-type: application/json' \
-  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
-  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'"}' \
-  | python3 -m json.tool
+  -d "{\"scope_id\":\"${POWERCONTEXT_SCOPE_ID}\"}"
 ```
 
 Memory extraction runs during the flush, not during capture.

--- a/docs/en/docs/operate/trace-with-phoenix.md
+++ b/docs/en/docs/operate/trace-with-phoenix.md
@@ -11,57 +11,178 @@ Memory operation, and the model calls underneath it.
 
 This guide sends those spans to [Phoenix](https://github.com/Arize-ai/phoenix) running locally.
 
+## Prerequisites
+
+This guide assumes a Linux or macOS development machine with:
+
+- Docker Engine and Docker Compose, or Docker Desktop;
+- `uv`, Bash, `curl`, and `python3`;
+- ports `6006` and `8000` available locally.
+
+Check the tool versions before starting:
+
+```bash
+docker info
+docker compose version
+uv --version
+```
+
 ## Start Phoenix
+
+The simplest command uses a temporary container:
 
 ```bash
 docker run -d --name powercontext-phoenix -p 6006:6006 arizephoenix/phoenix:20.1.0
 ```
 
+For a local setup that retains SQLite trace data across container recreation, set a working directory and mount a
+named volume:
+
+```bash
+export PHOENIX_WORKING_DIR=/mnt/data
+docker volume create powercontext-phoenix-data
+docker run -d --name powercontext-phoenix \
+  -p 6006:6006 \
+  -e PHOENIX_WORKING_DIR="$PHOENIX_WORKING_DIR" \
+  -v powercontext-phoenix-data:"$PHOENIX_WORKING_DIR" \
+  arizephoenix/phoenix:20.1.0
+```
+
 Phoenix serves both its UI and its OTLP HTTP receiver on port `6006`. Open <http://localhost:6006> to confirm it is
-running. Pin an explicit tag so the endpoint and UI layout match this guide.
+running. Pin an explicit tag so the endpoint and UI layout match this guide. The OTLP HTTP route is
+`http://localhost:6006/v1/traces`; port `4317` is only relevant when using an OTLP gRPC receiver.
+
+The first command uses the container's writable layer. Without the named volume, removing the container also removes
+the SQLite trace data. Use the volume variant when you need to stop and recreate Phoenix without losing traces.
 
 ## Install the export dependency
 
-Recording and export require the `tracing-otlp` extra:
+Recording and export require the `tracing-otlp` extra. The following command installs the latest code from the
+repository's `master` branch:
 
 ```bash
 uv tool install --force "powercontext[cli,server,tracing-otlp] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
-Without this extra, enabling tracing fails at startup with an explicit error instead of silently dropping spans.
+Without this extra, enabling tracing fails at startup with an explicit error instead of silently dropping spans. The
+command below is intended for a new local deployment. Because `--force` replaces the existing `uv` tool environment,
+do not use it blindly for a Server that is already serving traffic.
+
+If an existing Server should gain tracing, install the extra into the Python environment that actually runs that
+Server, then restart the Server. For example, with a `uv`-managed environment:
+
+```bash
+command -v powercontext
+uv tool install --force "powercontext[cli,server,tracing-otlp] @ git+https://github.com/oceanbase/powercontext.git@master"
+command -v powercontext
+powercontext server run --env-file /path/to/powercontext.env
+```
+
+For a systemd, Supervisor, container, or other managed deployment, update that deployment's image or environment
+instead and restart the existing Server through its process manager. The important requirement is that the restarted
+process imports the environment containing `tracing-otlp`; installing a separate CLI copy does not change a running
+process.
 
 ## Configure and start the Server
 
-Enable tracing, point the exporter at Phoenix, and configure a generation model so inference spans have something to
-record:
+Enable tracing, point the exporter at Phoenix, and configure a supported generation model so inference spans have
+something to record. `provider:model-name` is only a placeholder and will not work as-is. For example, an OpenAI
+deployment can use:
 
 ```bash
 export POWERCONTEXT_SERVER_TRACING_ENABLED=true
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:6006
 export OTEL_SERVICE_NAME=powercontext-server
-export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=provider:model-name
+export OPENAI_API_KEY=replace-with-your-key
+export POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL=openai:gpt-4.1-mini
 powercontext server run
 ```
+
+Run the Server command in Terminal A and keep it running. If the Server is already running, apply the same
+environment variables to its actual service definition and restart it; setting them in another terminal does not
+change the existing process.
 
 The OpenTelemetry SDK appends `/v1/traces` to `OTEL_EXPORTER_OTLP_ENDPOINT`, so the spans arrive at
 `http://localhost:6006/v1/traces`. Use `OTEL_EXPORTER_OTLP_HEADERS` for a Phoenix deployment that requires
 authentication. Set the provider credentials your generation model needs; PowerContext never records them.
 
-## Trigger one inference request
-
-Set `POWERCONTEXT_SCOPE_ID` to an existing ID returned by `create_scope`, capture a Source, then convert it into
-Memory:
+Create a Scope and run the client-side checks in Terminal B:
 
 ```bash
-curl -X POST http://localhost:8000/v1/sources/content \
+export POWERCONTEXT_BASE_URL=http://localhost:8000
+export POWERCONTEXT_AUTH_TOKEN=replace-with-server-token
+export POWERCONTEXT_SCOPE_NAME=tracing-example
+export POWERCONTEXT_AUTH_HEADER="Authorization: Bearer $POWERCONTEXT_AUTH_TOKEN"
+
+POWERCONTEXT_SCOPE_ID=$(curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/scopes" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
   -H 'content-type: application/json' \
-  -d "{\"scope_id\":\"${POWERCONTEXT_SCOPE_ID}\",\"source_id\":\"task-1\",\"content\":\"I always book aisle seats.\"}"
+  -d "$POWERCONTEXT_SCOPE_NAME" \
+  | python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])')
+export POWERCONTEXT_SCOPE_ID
 ```
 
+The exact authentication setup depends on the Server configuration. Keep `POWERCONTEXT_AUTH_TOKEN` empty for an
+unauthenticated local Server and remove the `Authorization` header in the examples, or set a token with the
+permission required by the endpoint. For an authenticated Server, the token must be allowed to create Scopes and
+call the traced endpoints.
+
+Check readiness, capabilities, and a real trace-producing request in order:
+
 ```bash
-curl -X POST http://localhost:8000/v1/memory/flush \
+curl --fail-with-body -sS "$POWERCONTEXT_BASE_URL/health/ready" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
+  | python3 -c 'import json, sys; data=json.load(sys.stdin); assert data.get("status") == "ready", data; print(data["status"])'
+
+curl --fail-with-body -sS "$POWERCONTEXT_BASE_URL/v1/capabilities" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
+  | python3 -m json.tool
+
+curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/memory/flush" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
   -H 'content-type: application/json' \
-  -d "{\"scope_id\":\"${POWERCONTEXT_SCOPE_ID}\"}"
+  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'"}' \
+  | python3 -m json.tool
+```
+
+`curl --fail-with-body` only checks the HTTP status code. The readiness example also parses the JSON body and fails
+when the response is HTTP 200 with a `degraded` status. The capabilities response should report tracing as enabled.
+The flush request is the final end-to-end check; it needs the configured model credentials and may take a few seconds.
+
+## Trigger one inference request
+
+The following full API flow creates a fresh Scope, captures a Source, and converts it into Memory. It also avoids
+silently continuing after a failed request:
+
+```bash
+set -euo pipefail
+
+POWERCONTEXT_BASE_URL=${POWERCONTEXT_BASE_URL:-http://localhost:8000}
+POWERCONTEXT_IDEMPOTENCY_KEY="tracing-example-$(date +%s)-$"
+POWERCONTEXT_SCOPE_NAME=tracing-example
+POWERCONTEXT_SOURCE_ID="tracing-source-$(date +%s)"
+POWERCONTEXT_AUTH_HEADER="Authorization: Bearer $POWERCONTEXT_AUTH_TOKEN"
+
+POWERCONTEXT_SCOPE_ID=$(curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/scopes" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
+  -H 'content-type: application/json' \
+  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
+  -d "$POWERCONTEXT_SCOPE_NAME" \
+  | python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])')
+
+curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/sources/content" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
+  -H 'content-type: application/json' \
+  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
+  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'","source_id":"'"$POWERCONTEXT_SOURCE_ID"'","content":"I always book aisle seats."}' \
+  | python3 -m json.tool
+
+curl --fail-with-body -sS -X POST "$POWERCONTEXT_BASE_URL/v1/memory/flush" \
+  -H "$POWERCONTEXT_AUTH_HEADER" \
+  -H 'content-type: application/json' \
+  -H "Idempotency-Key: $POWERCONTEXT_IDEMPOTENCY_KEY" \
+  -d '{"scope_id":"'"$POWERCONTEXT_SCOPE_ID"'"}' \
+  | python3 -m json.tool
 ```
 
 Memory extraction runs during the flush, not during capture.
@@ -132,8 +253,29 @@ attributes record only the shape of each message rather than its text.
 
 ## Stop Phoenix
 
+Stop the temporary container without removing it:
+
+```bash
+docker stop powercontext-phoenix
+```
+
+Start it again later with:
+
+```bash
+docker start powercontext-phoenix
+```
+
+If the container is no longer needed, remove it:
+
 ```bash
 docker rm -f powercontext-phoenix
+```
+
+When the named-volume variant was used, the volume remains after removing the container. Delete it only when the
+stored SQLite traces are no longer needed:
+
+```bash
+docker volume rm powercontext-phoenix-data
 ```
 
 Span names and attributes follow the Pydantic AI GenAI semantic conventions and can change when that dependency is

--- a/docs/en/docs/operate/troubleshoot.md
+++ b/docs/en/docs/operate/troubleshoot.md
@@ -188,7 +188,15 @@ versions, a personal Dashboard requires `ACCESS_MODE=enforced` and a valid `AUTH
 the Dashboard in the isolated local test instance.
 
 When an existing Server already uses static Bearer authentication, keep its authentication configuration while adding
-tracing. Do not clear authentication variables to bypass a startup error.
+tracing. If you also enable the Dashboard, use the same static Bearer configuration:
+
+```dotenv
+POWERCONTEXT_SERVER_DASHBOARD_ENABLED=true
+POWERCONTEXT_SERVER_ACCESS_MODE=enforced
+POWERCONTEXT_SERVER_AUTH_TOKEN=<valid-token>
+```
+
+Do not clear authentication variables to bypass a startup error.
 
 If you need an isolated unauthenticated test instance, use a separate environment configuration such as:
 

--- a/docs/en/docs/operate/troubleshoot.md
+++ b/docs/en/docs/operate/troubleshoot.md
@@ -139,6 +139,68 @@ cannot answer health requests, so readiness is not checked. `not_ready` with HTT
 `degraded` with HTTP 200 means a configured inference capability failed while database-backed operations remain
 available. Human and JSON output retain the Server's individual check statuses.
 
+Automation should not check only the exit code of `powercontext ready`: when the Server returns HTTP 200 with
+`degraded`, the `ready` command can still exit 0. Check the top-level JSON `status` instead:
+
+```bash
+powercontext --json ready | jq -e '.status == "ready"' >/dev/null
+```
+
+The command exits nonzero when `status` is `degraded`. To have PowerContext itself fail on a degraded result, use
+`powercontext doctor --json`; it exits nonzero unless the complete diagnostic result is `ok`.
+
+### Permissions for metrics and capabilities
+
+In `enforced` mode, the Authentication Provider builds a Principal from the request credentials. A valid Bearer token
+only authenticates the request; it does not automatically grant every permission.
+
+Both `/metrics` and `/v1/capabilities` require the Server-level `server.observe` permission. Requests therefore return:
+
+- HTTP 401 when no valid authentication credentials are supplied;
+- HTTP 403 when the Principal is authenticated but lacks `server.observe`.
+
+With the built-in static Bearer token, check metrics with:
+
+```bash
+export POWERCONTEXT_DEPLOYMENT_TOKEN="your-token"
+
+curl --fail \
+  --header "Authorization: Bearer ${POWERCONTEXT_DEPLOYMENT_TOKEN}" \
+  http://127.0.0.1:8000/metrics
+```
+
+You can check the Server's advertised capabilities in the same way:
+
+```bash
+curl --fail \
+  --header "Authorization: Bearer ${POWERCONTEXT_DEPLOYMENT_TOKEN}" \
+  http://127.0.0.1:8000/v1/capabilities
+```
+
+See [Server authentication and permissions](configuration.md#server) for Principal, access-control, and Bearer token configuration.
+
+## Local tracing examples and existing Server configuration
+
+The local Phoenix and Langfuse tracing examples are written for an isolated test instance and default to loopback
+addresses. Whether the Dashboard is enabled depends on the installed version and effective configuration. In newer
+versions, a personal Dashboard requires `ACCESS_MODE=enforced` and a valid `AUTH_TOKEN`; if startup reports
+`DASHBOARD_ENABLED requires ACCESS_MODE=enforced and AUTH_TOKEN`, complete the authentication configuration or disable
+the Dashboard in the isolated local test instance.
+
+When an existing Server already uses static Bearer authentication, keep its authentication configuration while adding
+tracing. Do not clear authentication variables to bypass a startup error.
+
+If you need an isolated unauthenticated test instance, use a separate environment configuration such as:
+
+```dotenv
+POWERCONTEXT_SERVER_DASHBOARD_ENABLED=false
+POWERCONTEXT_SERVER_ACCESS_MODE=disabled
+POWERCONTEXT_SERVER_HTTP_HOST=127.0.0.1
+```
+
+Unauthenticated mode is suitable only for a local test environment bound to loopback. Configure a remote or existing
+Server according to [Deploy the Server](deploy-server.md).
+
 ## The Server cannot open its database
 
 The database is created when the Server starts, not when the tool is installed. Inspect the Server startup error before


### PR DESCRIPTION
## Summary

- Align the English deployment and operations guides with the corresponding Chinese updates.
- Document prerequisites, loopback limits, readiness status parsing, capabilities and metrics permissions, and existing Server tracing restart requirements.
- Expand Phoenix and Langfuse setup, model configuration, Scope creation, end-to-end checks, persistence, and stop/delete guidance.

## Validation

- `git diff --check`
- Markdown parsing, Bash syntax checks, internal-link checks, and table validation: passed for 6 English documents.
- `pnpm check:links`: not completed because the environment could not download npm dependencies from the registry.

## User-facing changes

Documentation only. No runtime code or API behavior changes.

## AI usage

This PR was prepared with assistance from OpenAI Codex. The changes were reviewed against the corresponding Chinese documentation and validated with local documentation checks.