### PR TITLE
docs: migrate website links to official domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PowerContext keeps context with the work across conversations. When you return, 
 
 ![You and agents hand work off and continue with stored context](docs/assets/readme-workflow.svg)
 
-[Website](https://frf12.github.io/powercontext/) · [Installation walkthrough](https://frf12.github.io/powercontext/en/docs/get-started/quickstart/)
+[Website](https://powercontext.oceanbase.io/) · [Installation walkthrough](https://powercontext.oceanbase.io/en/docs/get-started/quickstart/)
 
 PowerContext 1.0.0 includes the guided setup. The commands below install the stable release and connect
 the matching Agent integration.
@@ -39,7 +39,7 @@ cd powercontext-config
 powercontext config init --language en --output .env
 ```
 
-If Python dependency downloads are slow or fail, follow the [mirror retry instructions](https://frf12.github.io/powercontext/en/docs/get-started/install-and-run/#retry-dependency-downloads-with-a-mirror).
+If Python dependency downloads are slow or fail, follow the [mirror retry instructions](https://powercontext.oceanbase.io/en/docs/get-started/install-and-run/#retry-dependency-downloads-with-a-mirror).
 
 The wizard asks about storage, local or remote access, memory capabilities, Dashboard, model APIs, and Agent
 connections. Choose **Full memory capabilities** to test automatic Memory and Topic Memory; this requires separate
@@ -66,7 +66,7 @@ powercontext capabilities
 ```
 
 Continue with `.env.next-steps.md` to create and bind the selected Scopes, install the matching plugins, and launch
-a new Agent session. The [complete walkthrough](https://frf12.github.io/powercontext/en/docs/get-started/quickstart/)
+a new Agent session. The [complete walkthrough](https://powercontext.oceanbase.io/en/docs/get-started/quickstart/)
 covers Codex and Claude Code, Dashboard login, SSH forwarding, HTTPS prerequisites, and observable acceptance checks.
 For example, the matching Codex installation is:
 
@@ -84,7 +84,7 @@ flags or environment variables and asks for explicit consent; automated setup us
 
 Codex is `official`; other hosts and Python Agent frameworks are `community`; Bub is `evaluation` only.
 These tags describe PowerContext integration maintenance and use. See the
-[capability matrix](https://frf12.github.io/powercontext/en/docs/integrations/capabilities/) for supported features and availability.
+[capability matrix](https://powercontext.oceanbase.io/en/docs/integrations/capabilities/) for supported features and availability.
 
 <table>
 <tr>
@@ -105,7 +105,7 @@ These tags describe PowerContext integration maintenance and use. See the
 </tr>
 </table>
 
-Applications can use PowerContext through the async Python client, HTTP API, MCP, or the in-process Core SDK. See the [interface reference](https://frf12.github.io/powercontext/en/docs/develop/interfaces/) to choose an entry point.
+Applications can use PowerContext through the async Python client, HTTP API, MCP, or the in-process Core SDK. See the [interface reference](https://powercontext.oceanbase.io/en/docs/develop/interfaces/) to choose an entry point.
 
 Explore the [22 Chinese Jupyter tutorials and a complete team workflow](examples/jupyter/README.md) to run Memory, context preparation, Handoff, Experience, Skill, and a real Agent step by step. The first seven tutorials need no model or API key.
 
@@ -113,7 +113,7 @@ Explore the [22 Chinese Jupyter tutorials and a complete team workflow](examples
 
 ![Compact comparison of PowerContext results on LoCoMo and SWE-bench Pro](docs/assets/readme-benchmark-summary.svg)
 
-See the [methods, full results, and limitations](https://frf12.github.io/powercontext/en/benchmarks/) behind these comparisons.
+See the [methods, full results, and limitations](https://powercontext.oceanbase.io/en/benchmarks/) behind these comparisons.
 
 ## Build PowerContext
 
@@ -127,11 +127,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the complete development workflow.
 
 ## Learn more
 
-- [Get started](https://frf12.github.io/powercontext/en/docs/get-started/quickstart/)
-- [Connect Agents](https://frf12.github.io/powercontext/en/docs/integrations/)
-- [Manage context](https://frf12.github.io/powercontext/en/docs/workflows/)
-- [Deploy and operate](https://frf12.github.io/powercontext/en/docs/operate/)
-- [Develop with APIs](https://frf12.github.io/powercontext/en/docs/develop/)
+- [Get started](https://powercontext.oceanbase.io/en/docs/get-started/quickstart/)
+- [Connect Agents](https://powercontext.oceanbase.io/en/docs/integrations/)
+- [Manage context](https://powercontext.oceanbase.io/en/docs/workflows/)
+- [Deploy and operate](https://powercontext.oceanbase.io/en/docs/operate/)
+- [Develop with APIs](https://powercontext.oceanbase.io/en/docs/develop/)
 
 PowerContext is the successor to [PowerMem](https://www.powermem.ai/).
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -14,7 +14,7 @@ PowerContext 让上下文跟随工作，跨越不同的对话。你回来时，�
 
 ![你和 Agent 交接工作，并基于已存储的上下文继续推进](docs/assets/readme-workflow.svg)
 
-[网站](https://frf12.github.io/powercontext/zh/) · [完整安装流程](https://frf12.github.io/powercontext/zh/docs/get-started/quickstart/)
+[网站](https://powercontext.oceanbase.io/zh/) · [完整安装流程](https://powercontext.oceanbase.io/zh/docs/get-started/quickstart/)
 
 PowerContext 1.0.0 包含交互式配置向导。下面的命令安装这一正式版本，并接入相同版本的 Agent 集成。
 
@@ -38,7 +38,7 @@ cd powercontext-config
 powercontext config init --language zh --output .env
 ```
 
-Python 依赖下载缓慢或失败时，可按[镜像重试步骤](https://frf12.github.io/powercontext/zh/docs/get-started/install-and-run/#使用镜像重试依赖下载)重新安装。
+Python 依赖下载缓慢或失败时，可按[镜像重试步骤](https://powercontext.oceanbase.io/zh/docs/get-started/install-and-run/#使用镜像重试依赖下载)重新安装。
 
 向导会依次询问存储、使用场景、记忆能力、Dashboard、模型 API 和 Agent 连接。
 要体验自动 Memory 提取和 Topic Memory，请选择**完整记忆能力**并准备独立的 Generation、Embedding API 凭据；
@@ -62,7 +62,7 @@ powercontext capabilities
 ```
 
 接着按 `.env.next-steps.md` 创建并绑定 Scope、安装相同版本的插件，再打开新 Agent 会话。
-[完整安装流程](https://frf12.github.io/powercontext/zh/docs/get-started/quickstart/)包含 Codex、Claude Code、Dashboard 登录、
+[完整安装流程](https://powercontext.oceanbase.io/zh/docs/get-started/quickstart/)包含 Codex、Claude Code、Dashboard 登录、
 SSH 隧道、HTTPS 前提及逐项验收。例如，匹配本版本的 Codex 安装命令是：
 
 ```bash
@@ -75,7 +75,7 @@ powercontext doctor codex
 
 Codex 标为 `official`，其他宿主及 Python Agent 框架标为 `community`，Bub 标为 `evaluation`，仅用于评测。
 这些标签表示 PowerContext 集成的维护归属和用途，具体功能及可用状态见
-[能力矩阵](https://frf12.github.io/powercontext/zh/docs/integrations/capabilities/)。
+[能力矩阵](https://powercontext.oceanbase.io/zh/docs/integrations/capabilities/)。
 
 <table>
 <tr>
@@ -96,7 +96,7 @@ Codex 标为 `official`，其他宿主及 Python Agent 框架标为 `community`�
 </tr>
 </table>
 
-应用还可以通过异步 Python Client、HTTP API、MCP 或进程内 Core SDK 使用 PowerContext。请参考[接口说明](https://frf12.github.io/powercontext/zh/docs/develop/interfaces/)选择入口。
+应用还可以通过异步 Python Client、HTTP API、MCP 或进程内 Core SDK 使用 PowerContext。请参考[接口说明](https://powercontext.oceanbase.io/zh/docs/develop/interfaces/)选择入口。
 
 想用 Python 逐步体验？从 [22 篇 Jupyter 教程与完整团队工作流](examples/jupyter/README.md)开始，亲手运行 Memory、上下文、交接、Experience、Skill 和真实 Agent。前七篇不需要模型或 API Key。
 
@@ -104,7 +104,7 @@ Codex 标为 `official`，其他宿主及 Python Agent 框架标为 `community`�
 
 ![PowerContext 在 LoCoMo 和 SWE-bench Pro 上的紧凑对比图](docs/assets/readme-benchmark-summary.svg)
 
-这些对比的评测方法、完整结果和适用边界请见[官网评测页](https://frf12.github.io/powercontext/zh/benchmarks/)。
+这些对比的评测方法、完整结果和适用边界请见[官网评测页](https://powercontext.oceanbase.io/zh/benchmarks/)。
 
 ## 参与构建 PowerContext
 
@@ -118,11 +118,11 @@ make test
 
 ## 进一步了解
 
-- [开始使用](https://frf12.github.io/powercontext/zh/docs/get-started/quickstart/)
-- [接入 Agent](https://frf12.github.io/powercontext/zh/docs/integrations/)
-- [管理上下文](https://frf12.github.io/powercontext/zh/docs/workflows/)
-- [部署与运维](https://frf12.github.io/powercontext/zh/docs/operate/)
-- [开发与 API](https://frf12.github.io/powercontext/zh/docs/develop/)
+- [开始使用](https://powercontext.oceanbase.io/zh/docs/get-started/quickstart/)
+- [接入 Agent](https://powercontext.oceanbase.io/zh/docs/integrations/)
+- [管理上下文](https://powercontext.oceanbase.io/zh/docs/workflows/)
+- [部署与运维](https://powercontext.oceanbase.io/zh/docs/operate/)
+- [开发与 API](https://powercontext.oceanbase.io/zh/docs/develop/)
 
 PowerContext 是 [PowerMem](https://www.powermem.ai/) 的后续项目。
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -14,7 +14,7 @@ PowerContext は、会話をまたいでもコンテキストを作業ととも�
 
 ![あなたと Agent が作業を引き継ぎ、保存されたコンテキストから継続する流れ](docs/assets/readme-workflow.svg)
 
-[Web サイト](https://frf12.github.io/powercontext/en/) · [インストール手順](https://frf12.github.io/powercontext/en/docs/get-started/quickstart/)
+[Web サイト](https://powercontext.oceanbase.io/en/) · [インストール手順](https://powercontext.oceanbase.io/en/docs/get-started/quickstart/)
 
 PowerContext 1.0.0 には対話式セットアップが含まれています。
 以下のコマンドで正式リリースと同じバージョンの Agent 連携をインストールします。
@@ -55,13 +55,13 @@ powercontext doctor codex
 ```
 
 PowerContext ツールと Agent 連携には、常に同じ Git ref を使用してください。
-[Quick Start](https://frf12.github.io/powercontext/en/docs/get-started/quickstart/) で Dashboard、SSH、HTTPS、
+[Quick Start](https://powercontext.oceanbase.io/en/docs/get-started/quickstart/) で Dashboard、SSH、HTTPS、
 Source から Topic 生成・更新、新しいセッションでの検索まで確認できます。
 Python 3.11+ が必要です。macOS と Linux をサポートし、Windows のサポートは `experimental` です。
 
 Codex は `official`、他のホストと Python Agent フレームワークは `community`、Bub は評価専用の `evaluation` です。
 これらは PowerContext 連携のメンテナンス主体と用途を示すタグです。対応機能と利用可能なバージョンは
-[機能一覧](https://frf12.github.io/powercontext/en/docs/integrations/capabilities/)を参照してください。
+[機能一覧](https://powercontext.oceanbase.io/en/docs/integrations/capabilities/)を参照してください。
 
 <table>
 <tr>
@@ -82,7 +82,7 @@ Codex は `official`、他のホストと Python Agent フレームワークは 
 </tr>
 </table>
 
-アプリケーションは、非同期 Python クライアント、HTTP API、MCP、または同一プロセス内の Core SDK から PowerContext を利用できます。入口を選ぶには[インターフェースリファレンス](https://frf12.github.io/powercontext/en/docs/develop/interfaces/)を参照してください。
+アプリケーションは、非同期 Python クライアント、HTTP API、MCP、または同一プロセス内の Core SDK から PowerContext を利用できます。入口を選ぶには[インターフェースリファレンス](https://powercontext.oceanbase.io/en/docs/develop/interfaces/)を参照してください。
 
 Python で段階的に試すには、チーム作業の一連の流れも学べる [22 本の Jupyter チュートリアル（中国語）](examples/jupyter/README.md)をご覧ください。Memory、コンテキストの準備、Handoff、Experience、Skill、実際の Agent を動かしながら学べます。最初の 7 本はモデルや API キーなしで実行できます。
 
@@ -90,7 +90,7 @@ Python で段階的に試すには、チーム作業の一連の流れも学べ�
 
 ![LoCoMo と SWE-bench Pro における PowerContext の結果をまとめた比較図](docs/assets/readme-benchmark-summary.svg)
 
-比較に用いた評価方法、詳細な結果、適用範囲は[公式ベンチマークページ](https://frf12.github.io/powercontext/en/benchmarks/)を参照してください。
+比較に用いた評価方法、詳細な結果、適用範囲は[公式ベンチマークページ](https://powercontext.oceanbase.io/en/benchmarks/)を参照してください。
 
 ## PowerContext を開発する
 
@@ -104,11 +104,11 @@ make test
 
 ## さらに詳しく
 
-- [はじめる](https://frf12.github.io/powercontext/en/docs/get-started/quickstart/)
-- [Agent と接続する](https://frf12.github.io/powercontext/en/docs/integrations/)
-- [コンテキストの管理](https://frf12.github.io/powercontext/en/docs/workflows/)
-- [デプロイと運用](https://frf12.github.io/powercontext/en/docs/operate/)
-- [開発と API](https://frf12.github.io/powercontext/en/docs/develop/)
+- [はじめる](https://powercontext.oceanbase.io/en/docs/get-started/quickstart/)
+- [Agent と接続する](https://powercontext.oceanbase.io/en/docs/integrations/)
+- [コンテキストの管理](https://powercontext.oceanbase.io/en/docs/workflows/)
+- [デプロイと運用](https://powercontext.oceanbase.io/en/docs/operate/)
+- [開発と API](https://powercontext.oceanbase.io/en/docs/develop/)
 
 PowerContext は [PowerMem](https://www.powermem.ai/) の後継プロジェクトです。
 

--- a/website/README.md
+++ b/website/README.md
@@ -29,9 +29,19 @@ pnpm build
 
 静态产物输出到 `website/out`。
 
-## 发布到子路径
+## 发布到 GitHub Pages
 
-GitHub Pages 验收站使用以下构建参数：
+正式仓库 `oceanbase/powercontext` 使用根路径构建：
+
+```bash
+NEXT_PUBLIC_SITE_URL=https://powercontext.oceanbase.io \
+NEXT_PUBLIC_REPOSITORY_URL=https://github.com/oceanbase/powercontext \
+pnpm build
+```
+
+把 `out` 的内容部署到 `https://powercontext.oceanbase.io/`。这些参数在构建时写入页面和资源路径。
+
+调试仓库 `frf12/powercontext` 使用 GitHub Pages 子路径：
 
 ```bash
 NEXT_PUBLIC_BASE_PATH=/powercontext \
@@ -40,8 +50,7 @@ NEXT_PUBLIC_REPOSITORY_URL=https://github.com/frf12/powercontext/tree/codex/guid
 pnpm build
 ```
 
-把 `out` 的内容部署到 `https://frf12.github.io/powercontext/`。这些参数在构建时写入页面和资源路径；
-省略参数时仍使用根路径及上游官网地址。修改部署路径后需要重新构建。
+把 `out` 的内容部署到 `https://frf12.github.io/powercontext/`。修改部署路径后需要重新构建。
 
 `pnpm verify:export` 应使用与构建相同的环境变量；它会检查页面链接、静态资源、跳转页和双语首页的规范地址。
 


### PR DESCRIPTION
## Which issue or RFC does this PR close?

No linked issue or RFC was provided for this documentation-only migration.

## Rationale for this change

The official documentation site is now served from `https://powercontext.oceanbase.io`. Public documentation links should point to the official domain, while the `frf12/powercontext` GitHub Pages deployment remains available for temporary debugging.

## What changes are included in this PR?

- Update English, Chinese, and Japanese README links to the official documentation domain.
- Document both deployment modes in `website/README.md`:
  - official `oceanbase/powercontext` at the root of `https://powercontext.oceanbase.io`;
  - debugging `frf12/powercontext` at `https://frf12.github.io/powercontext/`.
- Preserve the existing workflow branch trigger and repository-specific `NEXT_PUBLIC_SITE_URL` / `NEXT_PUBLIC_BASE_PATH` behavior.

## Are there any user-facing changes?

Yes. Public README links now lead to the official documentation domain. The debugging GitHub Pages deployment remains supported.

## How was this change tested?

- `CI=true pnpm lint`
- Official build with `NEXT_PUBLIC_SITE_URL=https://powercontext.oceanbase.io`
- Debug build with `NEXT_PUBLIC_BASE_PATH=/powercontext` and `NEXT_PUBLIC_SITE_URL=https://frf12.github.io`
- Both builds passed link validation and static export verification for 794 pages.
- `git diff --check`

## AI usage statement

This PR was prepared with OpenAI Codex using GPT-5. The changes were reviewed against the repository PR template and verified with the commands listed above.