### PR TITLE
chore: clean outdated links

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,14 +2,6 @@ name: Deploy website
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - codex/guided-config
-    paths:
-      - website/**
-      - docs/**
-      - src/**
-      - .github/workflows/deploy-docs.yml
 
 permissions:
   contents: read
@@ -23,16 +15,15 @@ concurrency:
 jobs:
   deploy-website:
     if: >-
-      github.ref == 'refs/heads/master' ||
-      (github.repository == 'frf12/powercontext' && github.ref == 'refs/heads/codex/guided-config')
+      github.repository == 'oceanbase/powercontext' && github.ref == 'refs/heads/master'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     env:
-      NEXT_PUBLIC_BASE_PATH: ${{ github.repository == 'frf12/powercontext' && '/powercontext' || '' }}
-      NEXT_PUBLIC_SITE_URL: ${{ github.repository == 'frf12/powercontext' && 'https://frf12.github.io' || 'https://powercontext.oceanbase.io' }}
-      NEXT_PUBLIC_REPOSITORY_URL: ${{ github.repository == 'frf12/powercontext' && 'https://github.com/frf12/powercontext/tree/codex/guided-config' || 'https://github.com/oceanbase/powercontext' }}
+      NEXT_PUBLIC_BASE_PATH: ''
+      NEXT_PUBLIC_SITE_URL: https://powercontext.oceanbase.io
+      NEXT_PUBLIC_REPOSITORY_URL: https://github.com/oceanbase/powercontext
     steps:
       - name: Check out
         uses: actions/checkout@v7

--- a/src/powercontext/builtin/persistence/oceanbase/profile.py
+++ b/src/powercontext/builtin/persistence/oceanbase/profile.py
@@ -44,8 +44,7 @@ WHERE TABLE_SCHEMA = DATABASE()
   AND DATA_TYPE = 'varchar'
 """
 _SCHEMA_RECREATION_GUIDE = (
-    "https://oceanbase.github.io/powercontext/en/docs/operate/troubleshoot/"
-    "#oceanbase-startup-rejects-an-incompatible-schema"
+    "https://powercontext.oceanbase.io/en/docs/operate/troubleshoot/#oceanbase-startup-rejects-an-incompatible-schema"
 )
 
 

--- a/website/README.md
+++ b/website/README.md
@@ -31,26 +31,17 @@ pnpm build
 
 ## 发布到 GitHub Pages
 
-正式仓库 `oceanbase/powercontext` 使用根路径构建：
+在正式仓库 `oceanbase/powercontext` 的 `master` 分支上手动运行 `Deploy website` 工作流，发布官网。
+本地验证时使用相同的根路径构建参数：
 
 ```bash
+NEXT_PUBLIC_BASE_PATH= \
 NEXT_PUBLIC_SITE_URL=https://powercontext.oceanbase.io \
 NEXT_PUBLIC_REPOSITORY_URL=https://github.com/oceanbase/powercontext \
 pnpm build
 ```
 
 把 `out` 的内容部署到 `https://powercontext.oceanbase.io/`。这些参数在构建时写入页面和资源路径。
-
-调试仓库 `frf12/powercontext` 使用 GitHub Pages 子路径：
-
-```bash
-NEXT_PUBLIC_BASE_PATH=/powercontext \
-NEXT_PUBLIC_SITE_URL=https://frf12.github.io \
-NEXT_PUBLIC_REPOSITORY_URL=https://github.com/frf12/powercontext/tree/codex/guided-config \
-pnpm build
-```
-
-把 `out` 的内容部署到 `https://frf12.github.io/powercontext/`。修改部署路径后需要重新构建。
 
 `pnpm verify:export` 应使用与构建相同的环境变量；它会检查页面链接、静态资源、跳转页和双语首页的规范地址。
 


### PR DESCRIPTION
## Related PR

Follow-up to #1568.

## Rationale

Remove outdated deployment links and consistently point users to the official website.

## Changes

- Remove personal Pages deployment links and configuration.
- Keep manual deployment from the official repository’s master branch.
- Update the OceanBase troubleshooting link to the official domain.

## User-facing changes

Documentation and error messages link to the official website. No API changes.

## Validation

- `uv run --locked prek run -a`
- `make docs-test`: 798 pages verified.
- OceanBase profile tests: 15 passed, 2 skipped.
- Confirmed outdated addresses are absent from tracked files and static output.

## AI usage

Implemented and verified with OpenAI Codex.
