### PR TITLE
test(native): report the service's state at the moment it fails to start

### DIFF
--- a/tests/native/test_personal_service_lifecycle.py
+++ b/tests/native/test_personal_service_lifecycle.py
@@ -122,11 +122,15 @@ def test_failure_diagnostics_reports_an_absent_service(tmp_path: Path) -> None:
     assert "server.stdout.log: not created" in report
     assert "server.stderr.log: not created" in report
     # The platform's own service manager was asked, and its answer is quoted.
-    expected_manager = {
+    # Annotated: without it the key type is inferred as the union of the three
+    # concrete classes, which `type(adapter)` (a `type[NativeServiceAdapter]`)
+    # cannot index.
+    expected_managers: dict[type[NativeServiceAdapter], str] = {
         LaunchdUserAdapter: "launchctl",
         SystemdUserAdapter: "systemctl",
         WindowsTaskSchedulerAdapter: "schtasks",
-    }[type(adapter)]
+    }
+    expected_manager = expected_managers[type(adapter)]
     assert expected_manager in report
 
 

--- a/tests/native/test_personal_service_lifecycle.py
+++ b/tests/native/test_personal_service_lifecycle.py
@@ -68,9 +68,9 @@ def test_native_personal_service_lifecycle(tmp_path: Path) -> None:
         try:
             installed = controller.install(env_file=environment)
         except ServiceError as error:
-            pytest.fail(f"{error}\n{_server_error_tail(tmp_path)}")
+            pytest.fail(f"{error}\n\n{_failure_diagnostics(adapter, tmp_path)}")
 
-        assert installed.ok
+        assert installed.ok, f"{installed}\n\n{_failure_diagnostics(adapter, tmp_path)}"
         assert installed.manager_ownership is ManagerOwnershipState.OWNED
         loaded = adapter.loaded_registration()
         assert loaded.state is ManagerOwnershipState.OWNED
@@ -86,7 +86,7 @@ def test_native_personal_service_lifecycle(tmp_path: Path) -> None:
 
         adapter.start(reload_definition=False)
         restarted = _wait_for_status(controller)
-        assert restarted.ok, f"{restarted}\n{_server_error_tail(tmp_path)}"
+        assert restarted.ok, f"{restarted}\n\n{_failure_diagnostics(adapter, tmp_path)}"
 
         removed = controller.uninstall()
 
@@ -95,6 +95,39 @@ def test_native_personal_service_lifecycle(tmp_path: Path) -> None:
         assert not adapter.artifact_path.exists()
     finally:
         _cleanup(adapter)
+
+
+def test_failure_diagnostics_reports_an_absent_service(tmp_path: Path) -> None:
+    """The report must survive the state it exists to describe: nothing there.
+
+    It runs on the failure path, so every probe is read-only and independent.
+    If one of them raises, the report replaces the failure it was meant to
+    explain and the run says nothing about either (#1571).
+    """
+    adapter = _native_adapter(suffix="diagnostics")
+    environment = _environment_file(tmp_path)
+    port = _service_port(tmp_path)
+    assert port is not None, f"the environment file records no port: {environment.read_text()}"
+
+    report = _failure_diagnostics(adapter, tmp_path)
+
+    assert adapter.identifier in report
+    assert "loaded_registration:" in report
+    assert "manager_state:" in report
+    assert "inspect:" in report
+    assert f"artifact {adapter.artifact_path}: exists=False" in report
+    assert f"port {port}: reachable=False" in report
+    # The logs never existed, and saying so is the point: the issue's failure
+    # reported an empty stderr tail with no way to tell absent from silent.
+    assert "server.stdout.log: not created" in report
+    assert "server.stderr.log: not created" in report
+    # The platform's own service manager was asked, and its answer is quoted.
+    expected_manager = {
+        LaunchdUserAdapter: "launchctl",
+        SystemdUserAdapter: "systemctl",
+        WindowsTaskSchedulerAdapter: "schtasks",
+    }[type(adapter)]
+    assert expected_manager in report
 
 
 def test_native_service_definition_matches_running_process(tmp_path: Path) -> None:
@@ -309,13 +342,128 @@ def _unused_loopback_port() -> int:
         return int(listener.getsockname()[1])
 
 
-def _server_error_tail(tmp_path: Path) -> str:
-    path = tmp_path / "data" / "logs" / "server.stderr.log"
+def _log_tail(tmp_path: Path, name: str, limit: int = 4000) -> str:
+    path = tmp_path / "data" / "logs" / name
     try:
         content = path.read_text(encoding="utf-8", errors="replace")
     except FileNotFoundError:
-        return "server.stderr.log was not created"
-    return f"server.stderr.log tail:\n{content[-8000:]}"
+        return f"{name}: not created"
+    if not content.strip():
+        return f"{name}: empty ({path.stat().st_size} bytes)"
+    return f"{name} tail:\n{content[-limit:]}"
+
+
+def _command_output(argv: list[str], *, timeout: float = 10) -> str:
+    """Run a read-only diagnostic command and render whatever it said."""
+    try:
+        completed = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return f"$ {' '.join(argv)}\n(command not available)"
+    except subprocess.TimeoutExpired:
+        return f"$ {' '.join(argv)}\n(timed out after {timeout}s)"
+    except OSError as error:  # pragma: no cover - platform dependent
+        return f"$ {' '.join(argv)}\n(failed: {error})"
+    body = (completed.stdout + completed.stderr).strip() or "(no output)"
+    return f"$ {' '.join(argv)} -> exit {completed.returncode}\n{body[-4000:]}"
+
+
+def _service_port(tmp_path: Path) -> int | None:
+    environment = tmp_path / "powercontext.env"
+    try:
+        lines = environment.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        key, _, value = line.partition("=")
+        if key.strip() == "POWERCONTEXT_SERVER_HTTP_PORT":
+            with suppress(ValueError):
+                return int(value.strip().strip('"'))
+    return None
+
+
+def _platform_diagnostics(adapter: NativeServiceAdapter) -> list[str]:
+    """Ask the platform's own service manager what it thinks the state is."""
+    identifier = adapter.identifier
+    if isinstance(adapter, LaunchdUserAdapter):
+        uid = os.getuid() if hasattr(os, "getuid") else 0
+        return [
+            _command_output(["launchctl", "print", f"gui/{uid}/{identifier}"]),
+            _command_output(["launchctl", "list", identifier]),
+        ]
+    if isinstance(adapter, SystemdUserAdapter):
+        return [
+            _command_output(["systemctl", "--user", "status", identifier, "--no-pager"]),
+            _command_output(["journalctl", "--user", "--unit", identifier, "--no-pager", "-n", "50"]),
+        ]
+    if isinstance(adapter, WindowsTaskSchedulerAdapter):
+        return [_command_output(["schtasks.exe", "/Query", "/TN", identifier, "/V", "/FO", "LIST"])]
+    return ["(no platform diagnostics for this adapter)"]
+
+
+def _failure_diagnostics(adapter: NativeServiceAdapter, tmp_path: Path) -> str:
+    """Everything about a failed start, collected BEFORE the test cleans up.
+
+    The `finally` block stops, disables and removes the registration, so a CI
+    step that inspects the service afterwards finds nothing and reports "could
+    not be found" whatever the failure was (#1571). Each probe is independent
+    and swallows its own errors: a report that raises replaces the failure it
+    was meant to explain.
+
+    Every probe is read-only and scoped to this service: its own label, its own
+    port, its own entry point. Nothing here dumps a global process table or a
+    log this test did not create, because the report lands in a public CI log.
+    """
+    sections: list[str] = [f"identifier: {adapter.identifier}"]
+
+    for label, probe in (
+        ("loaded_registration", adapter.loaded_registration),
+        ("manager_state", adapter.manager_state),
+        ("inspect", adapter.inspect),
+    ):
+        try:
+            sections.append(f"{label}: {probe()}")
+        except Exception as error:
+            sections.append(f"{label}: probe failed: {error!r}")
+
+    try:
+        artifact = adapter.artifact_path
+        sections.append(
+            f"artifact {artifact}: exists={artifact.exists()}"
+            + (f" size={artifact.stat().st_size}" if artifact.exists() else "")
+        )
+    except Exception as error:
+        sections.append(f"artifact: probe failed: {error!r}")
+
+    port = _service_port(tmp_path)
+    if port is None:
+        sections.append("port: not recorded in the environment file")
+    else:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe_socket:
+            probe_socket.settimeout(2)
+            reachable = probe_socket.connect_ex(("127.0.0.1", port)) == 0
+        sections.append(f"port {port}: reachable={reachable}")
+        if sys.platform != "win32":
+            sections.append(_command_output(["lsof", "-nP", f"-iTCP:{port}"]))
+
+    # Matched on the service's own entry point rather than dumped whole: a CI
+    # log is public, and a full process table carries other people's command
+    # lines, tokens and paths with it.
+    if sys.platform == "win32":
+        sections.append(_command_output(["tasklist.exe", "/FI", "IMAGENAME eq pythonw.exe", "/FO", "LIST"]))
+    else:
+        sections.append(_command_output(["pgrep", "-fl", "powercontext_service_bootstrap"]))
+
+    sections.extend(_platform_diagnostics(adapter))
+    sections.append(_log_tail(tmp_path, "server.stdout.log"))
+    sections.append(_log_tail(tmp_path, "server.stderr.log", limit=8000))
+
+    return "\n\n".join(sections)
 
 
 def _cleanup(adapter: NativeServiceAdapter) -> None:


### PR DESCRIPTION
## What

`test_native_personal_service_lifecycle` fails intermittently on the `macos-launchagent` job with "the personal service was registered but did not become live", and the run says nothing else: the only evidence printed is the tail of `server.stderr.log`, which was empty on the reported failure. The `finally` block then stops, disables and removes the registration, so the launchd diagnostic step that follows reports the service as not found whatever the failure was.

This adds the evidence the issue asks for first, at the moment of failure, before the cleanup. It does not fix the flake, and does not claim to.

Refs #1571.

## The report

Collected by `_failure_diagnostics(adapter, tmp_path)` and attached to the install failure, the `installed.ok` assertion and the post-restart status assertion:

| probe | answers |
|---|---|
| `loaded_registration`, `manager_state`, `inspect` | what the adapter itself believes, from its three independent views |
| artifact path | whether the plist / unit / task file exists, and its size |
| port | whether `127.0.0.1:<port>` accepts a connection, plus `lsof -nP -iTCP:<port>` for who holds it |
| entry point | `pgrep -fl powercontext_service_bootstrap`, or the `pythonw.exe` filter on Windows |
| platform manager | `launchctl print gui/<uid>/<label>` and `launchctl list <label>`; `systemctl --user status` plus 50 journal lines; `schtasks /Query /V` |
| logs | tails of `server.stdout.log` **and** `server.stderr.log`, distinguishing "not created" from "empty" |

Two properties worth calling out:

- **Nothing in the report can replace the failure.** Every probe swallows its own errors and records that it failed, so a diagnostic bug cannot turn "service did not start" into a `FileNotFoundError` from `pgrep`.
- **Nothing is dumped wholesale.** Each probe is scoped to this service's own label, port and entry point. The first version used `ps -Ao pid,etime,command`, and its output on my machine carried unrelated command lines, tokens and paths; a CI log is public, so the process probe matches the service's entry point instead.

The previously stderr-only helper is gone, replaced by `_log_tail`, which is what makes the absent-versus-silent distinction the reported failure lacked.

## Evidence

`test_failure_diagnostics_reports_an_absent_service` drives the report against a service that was never installed, which is the state it has to survive, and asserts every section including the platform manager's own answer. It installs nothing: all probes are read-only.

```
POWERCONTEXT_RUN_NATIVE_SERVICE_TESTS=1 pytest tests/native/test_personal_service_lifecycle.py -k failure_diagnostics
# 1 passed
```

Sample output on macOS 26 for a label that was never registered, 1.2 KB whole:

```
loaded_registration: ManagerRegistration(state=<ManagerOwnershipState.NOT_LOADED: 'not_loaded'>, definition=None, detail=None)
manager_state: inactive
inspect: NativeRegistration(state=<RegistrationState.NOT_INSTALLED: 'not_installed'>, ...)
artifact /Users/…/Library/LaunchAgents/com.oceanbase.powercontext.native.<uuid>.preview.plist: exists=False
port 55782: reachable=False
$ lsof -nP -iTCP:55782 -> exit 1
(no output)
$ pgrep -fl powercontext_service_bootstrap -> exit 1
(no output)
$ launchctl print gui/501/com.oceanbase.powercontext.native.<uuid>.preview -> exit 113
Could not find service "…" in domain for user gui: 501
server.stdout.log: not created
server.stderr.log: not created
```

Negative controls: dropping the log section or the platform section each fails the new test. `ruff check` and `ruff format --check` clean with the pinned 0.15.7.

The lifecycle tests themselves need a disposable runner (`POWERCONTEXT_RUN_NATIVE_SERVICE_TESTS=1` installs a real LaunchAgent), so I did not run them here; only the report is exercised locally.

## What this does not do

It does not change the 30-second startup window, the adapter, or the service. If the next failure is a slow start, the report will show a registration that exists with a port that is not yet accepting; if the agent never launched, it will show launchd's own refusal and no process. That is the distinction the issue needs before anything is tuned.
